### PR TITLE
Strip anchors from urls so that the pages aren't duplicated

### DIFF
--- a/cli/doc_scraper.py
+++ b/cli/doc_scraper.py
@@ -196,7 +196,9 @@ class DocToSkillConverter:
         # Extract links
         for link in main.find_all('a', href=True):
             href = urljoin(url, link['href'])
-            if self.is_valid_url(href):
+            # Strip anchor fragments to avoid treating #anchors as separate pages
+            href = href.split('#')[0]
+            if self.is_valid_url(href) and href not in page['links']:
                 page['links'].append(href)
         
         return page


### PR DESCRIPTION
Noticed that the many of the pages crawled where the same just with different anchors when processing https://docs.axolotl.ai/.