### PR TITLE
fix: MCP scraping hangs and collects only 1 page when using Claude Code CLI

### DIFF
--- a/skill_seeker_mcp/server.py
+++ b/skill_seeker_mcp/server.py
@@ -603,6 +603,10 @@ async def scrape_docs_tool(args: dict) -> list[TextContent]:
     if is_unified and merge_mode:
         cmd.extend(["--merge-mode", merge_mode])
 
+    # Add --fresh to avoid user input prompts when existing data found
+    if not skip_scrape:
+        cmd.append("--fresh")
+
     if enhance_local:
         cmd.append("--enhance-local")
     if skip_scrape:


### PR DESCRIPTION
## Environment
- macOS M3 Mac
- Claude Code CLI (claude.ai/code)
- Skill Seeker MCP integration
- Python 3.12.8

## Issue
When using Claude Code CLI with MCP tools to scrape documentation, the scraping process only collects 1 page instead of max_pages. The MCP tool returns "success" but the skill is unusable.

## Steps to Reproduce
1. Install Skill Seeker MCP server in Claude Code CLI
2. Ask Claude: "Use the MCP tool to scrape Tailwind CSS documentation"
3. Claude calls `mcp__skill-seeker__scrape_docs`
4. Tool completes with no visible errors
5. Check `output/tailwindcss_data/pages/` - only 1 page exists

## Root Causes

### 1. MCP subprocess hits EOFError on user input prompt
- `skill_seeker_mcp/server.py` spawns `doc_scraper.py` as subprocess
- When cached data exists, `doc_scraper.py` calls `input()`
- MCP subprocess has no stdin → EOFError
- Process terminates before scraping begins

### 2. --fresh flag doesn't prevent user prompt
- Flag only cleared checkpoints, didn't skip prompt
- MCP server didn't pass `--fresh` flag anyway

### 3. Link extraction searches only main content selector
- Only searched within main_content selector (e.g., `div.prose`)
- Many docs have navigation outside main content
- No links found → BFS queue empty → scraping stops

## Changes

**skill_seeker_mcp/server.py:**
- Add `--fresh` flag to subprocess command to prevent user prompts

**cli/doc_scraper.py:**
- Fix `--fresh` flag to actually skip user input prompt
- Change link extraction from main content only to entire page
- Allows discovery of navigation links outside main content area

## Testing Results

### Unit Tests
- ✅ **283 tests passed, 89 skipped** (PDF tests require optional dependencies)
- ✅ All MCP server tests pass (25 tests)
- ✅ All scraper feature tests pass (30 tests)
- ✅ All link extraction tests pass (4 tests)

### MCP Integration Testing
- ✅ **Tailwind CSS via MCP: Before 1 page → After 100 pages**
- ✅ No user prompts during MCP execution
- ✅ Link discovery working (found navigation links outside main content)
- ✅ Works end-to-end through Claude Code CLI

### Sample Output
```
Pages scraped: 100
Sample pages:
  - Get started with Tailwind CSS
  - Editor setup
  - Compatibility
  - Upgrade guide
  - Styling with utility classes
  - Hover, focus, and other states
  - Responsive design
  - Dark mode
  - Theme variables
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)