### PR TITLE
fix: Move logging configuration before code_analyzer import

### DIFF
--- a/src/skill_seekers/cli/github_scraper.py
+++ b/src/skill_seekers/cli/github_scraper.py
@@ -31,6 +31,13 @@ except ImportError:
     print("Error: PyGithub not installed. Run: pip install PyGithub")
     sys.exit(1)
 
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
 # Import code analyzer for deep code analysis
 try:
     from code_analyzer import CodeAnalyzer
@@ -38,13 +45,6 @@ try:
 except ImportError:
     CODE_ANALYZER_AVAILABLE = False
     logger.warning("Code analyzer not available - deep analysis disabled")
-
-# Configure logging
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(levelname)s - %(message)s'
-)
-logger = logging.getLogger(__name__)
 
 
 class GitHubScraper:


### PR DESCRIPTION
## Summary
- Fixes undefined logger error in github_scraper.py
- Moves logging configuration before code_analyzer import
- Prevents NameError when code_analyzer module is not available

## Details
The code_analyzer import block was referencing `logger.warning()` before the logger was configured. This change reorders the initialization so that logging is set up first, ensuring logger is available for the import error handling.

## Changes
- Moved `logging.basicConfig()` and `logger = logging.getLogger(__name__)` to execute before the code_analyzer import statement
- No functional changes to the logic, just reordering for proper initialization sequence

## Before
```python
try:
    from code_analyzer import CodeAnalyzer
    CODE_ANALYZER_AVAILABLE = True
except ImportError:
    CODE_ANALYZER_AVAILABLE = False
    logger.warning("Code analyzer not available")  # ❌ NameError - logger not defined yet

logging.basicConfig(...)
logger = logging.getLogger(__name__)
```

## After
```python
logging.basicConfig(...)
logger = logging.getLogger(__name__)

try:
    from code_analyzer import CodeAnalyzer
    CODE_ANALYZER_AVAILABLE = True
except ImportError:
    CODE_ANALYZER_AVAILABLE = False
    logger.warning("Code analyzer not available")  # ✅ Works correctly
```

## Test Plan
- [x] Code runs without NameError
- [x] logger.warning() works correctly when code_analyzer is missing
- [x] Existing functionality unchanged
- [x] No regression in import behavior

## Related Issues
Resolves import order bug discovered during codebase maintenance