### PR TITLE
fix: Update setup_mcp.sh for v2.0.0 src/ layout

### DIFF
--- a/setup_mcp.sh
+++ b/setup_mcp.sh
@@ -77,15 +77,9 @@ read -p "Continue? (y/n) " -n 1 -r
 echo ""
 
 if [[ $REPLY =~ ^[Yy]$ ]]; then
-    echo "Installing MCP server dependencies..."
-    $PIP_INSTALL_CMD -r skill_seeker_mcp/requirements.txt || {
-        echo -e "${RED}❌ Failed to install MCP dependencies${NC}"
-        exit 1
-    }
-
-    echo "Installing CLI tool dependencies..."
-    $PIP_INSTALL_CMD requests beautifulsoup4 || {
-        echo -e "${RED}❌ Failed to install CLI dependencies${NC}"
+    echo "Installing package in editable mode..."
+    $PIP_INSTALL_CMD -e . || {
+        echo -e "${RED}❌ Failed to install package${NC}"
         exit 1
     }
 
@@ -97,7 +91,7 @@ echo ""
 
 # Step 4: Test MCP server
 echo "Step 4: Testing MCP server..."
-timeout 3 python3 skill_seeker_mcp/server.py 2>/dev/null || {
+timeout 3 python3 src/skill_seekers/mcp/server.py 2>/dev/null || {
     if [ $? -eq 124 ]; then
         echo -e "${GREEN}✓${NC} MCP server starts correctly (timeout expected)"
     else
@@ -147,7 +141,7 @@ echo "  \"mcpServers\": {"
 echo "    \"skill-seeker\": {"
 echo "      \"command\": \"python3\","
 echo "      \"args\": ["
-echo "        \"$REPO_PATH/skill_seeker_mcp/server.py\""
+echo "        \"$REPO_PATH/src/skill_seekers/mcp/server.py\""
 echo "      ],"
 echo "      \"cwd\": \"$REPO_PATH\""
 echo "    }"
@@ -188,7 +182,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
     "skill-seeker": {
       "command": "python3",
       "args": [
-        "$REPO_PATH/skill_seeker_mcp/server.py"
+        "$REPO_PATH/src/skill_seekers/mcp/server.py"
       ],
       "cwd": "$REPO_PATH"
     }
@@ -203,10 +197,10 @@ EOF
     echo ""
 
     # Verify the path exists
-    if [ -f "$REPO_PATH/skill_seeker_mcp/server.py" ]; then
-        echo -e "${GREEN}✓${NC} Verified: MCP server file exists at $REPO_PATH/skill_seeker_mcp/server.py"
+    if [ -f "$REPO_PATH/src/skill_seekers/mcp/server.py" ]; then
+        echo -e "${GREEN}✓${NC} Verified: MCP server file exists at $REPO_PATH/src/skill_seekers/mcp/server.py"
     else
-        echo -e "${RED}❌ Warning: MCP server not found at $REPO_PATH/skill_seeker_mcp/server.py${NC}"
+        echo -e "${RED}❌ Warning: MCP server not found at $REPO_PATH/src/skill_seekers/mcp/server.py${NC}"
         echo "Please check the path!"
     fi
 else
@@ -266,7 +260,7 @@ echo "  • Full docs: ${YELLOW}README.md${NC}"
 echo ""
 echo "Troubleshooting:"
 echo "  • Check logs: ~/Library/Logs/Claude Code/ (macOS)"
-echo "  • Test server: python3 skill_seeker_mcp/server.py"
+echo "  • Test server: python3 src/skill_seekers/mcp/server.py"
 echo "  • Run tests: python3 -m pytest tests/test_mcp_server.py -v"
 echo ""
 echo "Happy skill creating! 🚀"


### PR DESCRIPTION
## Summary

Fixed `setup_mcp.sh` to work with the v2.0.0 src/ layout structure.

## Changes

- ✅ Fixed MCP server path: `skill_seeker_mcp/server.py` → `src/skill_seekers/mcp/server.py`
- ✅ Updated installation method: Use `pip install -e .` instead of separate requirements files
- ✅ Updated all path references throughout the script (4 locations)
- ✅ Aligned with v2.0.0 modern Python packaging structure

## Problem

After the v2.0.0 release, the MCP setup script was still pointing to the old `skill_seeker_mcp/` directory structure, causing setup failures:

```
❌ Warning: MCP server not found at /path/to/Skill_Seekers/skill_seeker_mcp/server.py
```

## Solution

Updated all references to use the new `src/skill_seekers/mcp/server.py` path and simplified the installation process to use `pip install -e .` which properly installs the package with all dependencies.

## Testing

- [x] Script paths updated correctly
- [x] Installation command simplified
- [x] Compatible with v2.0.0 package structure

## Related

- Fixes setup issues reported after v2.0.0 PyPI release
- Aligns with modern Python packaging best practices (PEP 621)

🤖 Generated with [Claude Code](https://claude.ai/code)