### PR TITLE
feat(utils): add retry utilities with exponential backoff

### DIFF
--- a/src/skill_seekers/cli/utils.py
+++ b/src/skill_seekers/cli/utils.py
@@ -7,8 +7,14 @@ import os
 import sys
 import subprocess
 import platform
+import time
+import logging
 from pathlib import Path
-from typing import Optional, Tuple, Dict, Union
+from typing import Optional, Tuple, Dict, Union, TypeVar, Callable
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar('T')
 
 
 def open_folder(folder_path: Union[str, Path]) -> bool:
@@ -222,3 +228,113 @@ def read_reference_files(skill_dir: Union[str, Path], max_chars: int = 100000, p
             break
 
     return references
+
+
+def retry_with_backoff(
+    operation: Callable[[], T],
+    max_attempts: int = 3,
+    base_delay: float = 1.0,
+    operation_name: str = "operation"
+) -> T:
+    """Retry an operation with exponential backoff.
+
+    Useful for network operations that may fail due to transient errors.
+    Waits progressively longer between retries (exponential backoff).
+
+    Args:
+        operation: Function to retry (takes no arguments, returns result)
+        max_attempts: Maximum number of attempts (default: 3)
+        base_delay: Base delay in seconds, doubles each retry (default: 1.0)
+        operation_name: Name for logging purposes (default: "operation")
+
+    Returns:
+        Result of successful operation
+
+    Raises:
+        Exception: Last exception if all retries fail
+
+    Example:
+        >>> def fetch_page():
+        ...     response = requests.get(url, timeout=30)
+        ...     response.raise_for_status()
+        ...     return response.text
+        >>> content = retry_with_backoff(fetch_page, max_attempts=3, operation_name=f"fetch {url}")
+    """
+    last_exception: Optional[Exception] = None
+
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return operation()
+        except Exception as e:
+            last_exception = e
+            if attempt < max_attempts:
+                delay = base_delay * (2 ** (attempt - 1))
+                logger.warning(
+                    "%s failed (attempt %d/%d), retrying in %.1fs: %s",
+                    operation_name, attempt, max_attempts, delay, e
+                )
+                time.sleep(delay)
+            else:
+                logger.error(
+                    "%s failed after %d attempts: %s",
+                    operation_name, max_attempts, e
+                )
+
+    # This should always have a value, but mypy doesn't know that
+    if last_exception is not None:
+        raise last_exception
+    raise RuntimeError(f"{operation_name} failed with no exception captured")
+
+
+async def retry_with_backoff_async(
+    operation: Callable[[], T],
+    max_attempts: int = 3,
+    base_delay: float = 1.0,
+    operation_name: str = "operation"
+) -> T:
+    """Async version of retry_with_backoff for async operations.
+
+    Args:
+        operation: Async function to retry (takes no arguments, returns awaitable)
+        max_attempts: Maximum number of attempts (default: 3)
+        base_delay: Base delay in seconds, doubles each retry (default: 1.0)
+        operation_name: Name for logging purposes (default: "operation")
+
+    Returns:
+        Result of successful operation
+
+    Raises:
+        Exception: Last exception if all retries fail
+
+    Example:
+        >>> async def fetch_page():
+        ...     response = await client.get(url, timeout=30.0)
+        ...     response.raise_for_status()
+        ...     return response.text
+        >>> content = await retry_with_backoff_async(fetch_page, operation_name=f"fetch {url}")
+    """
+    import asyncio
+
+    last_exception: Optional[Exception] = None
+
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return await operation()
+        except Exception as e:
+            last_exception = e
+            if attempt < max_attempts:
+                delay = base_delay * (2 ** (attempt - 1))
+                logger.warning(
+                    "%s failed (attempt %d/%d), retrying in %.1fs: %s",
+                    operation_name, attempt, max_attempts, delay, e
+                )
+                await asyncio.sleep(delay)
+            else:
+                logger.error(
+                    "%s failed after %d attempts: %s",
+                    operation_name, max_attempts, e
+                )
+
+    if last_exception is not None:
+        raise last_exception
+    raise RuntimeError(f"{operation_name} failed with no exception captured")


### PR DESCRIPTION
## Summary

This PR adds retry utilities to `utils.py`, addressing **E2.6** from the roadmap ("Add retry logic for network failures").

### What's Included

**Two new functions in `src/skill_seekers/cli/utils.py`:**

1. **`retry_with_backoff()`** - Sync version for `requests` operations
2. **`retry_with_backoff_async()`** - Async version for `httpx.AsyncClient` operations

### Features

- Configurable max attempts (default: 3)
- Exponential backoff with configurable base delay (doubles each retry)
- Operation name parameter for meaningful log messages
- Proper exception handling (re-raises last exception if all retries fail)

### Roadmap Alignment

- **E2.6**: Add retry logic for network failures ✅

### Usage Example

```python
from skill_seekers.cli.utils import retry_with_backoff

def fetch_page():
    response = requests.get(url, timeout=30)
    response.raise_for_status()
    return response.text

content = retry_with_backoff(
    fetch_page,
    max_attempts=3,
    base_delay=1.0,
    operation_name=f"fetch {url}"
)
```

Async version:
```python
from skill_seekers.cli.utils import retry_with_backoff_async

async def fetch_page():
    response = await client.get(url, timeout=30.0)
    response.raise_for_status()
    return response.text

content = await retry_with_backoff_async(
    fetch_page,
    operation_name=f"fetch {url}"
)
```

### Log Output Example

```
WARNING: fetch https://example.com failed (attempt 1/3), retrying in 1.0s: Connection refused
WARNING: fetch https://example.com failed (attempt 2/3), retrying in 2.0s: Connection refused
ERROR: fetch https://example.com failed after 3 attempts: Connection refused
```

### Tests Included

7 new unit tests in `TestRetryWithBackoff` and `TestRetryWithBackoffAsync`:
- `test_successful_operation_first_try`
- `test_successful_operation_after_retry`
- `test_all_retries_fail`
- `test_exponential_backoff_timing`
- `test_async_successful_operation`
- `test_async_retry_then_success`
- `test_async_all_retries_fail`

### Integration Note

This PR provides the utility functions but does not modify existing scrapers. Once merged, the doc_scraper can be updated to use these utilities:

```python
# In doc_scraper.py scrape_page():
def _fetch():
    response = requests.get(url, headers=headers, timeout=30)
    response.raise_for_status()
    return response

response = retry_with_backoff(_fetch, operation_name=f"fetch {url}")
```

This keeps the PR focused and reviewable. Integration can be done in a follow-up PR if desired.

---

Contributed by the [AI Writing Guide](https://github.com/jmagly/ai-writing-guide) project.