### PR TITLE
fix: Add missing adaptors module to pyproject.toml packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,7 +132,7 @@ skill-seekers-install = "skill_seekers.cli.install_skill:main"
 skill-seekers-install-agent = "skill_seekers.cli.install_agent:main"
 
 [tool.setuptools]
-packages = ["skill_seekers", "skill_seekers.cli", "skill_seekers.mcp", "skill_seekers.mcp.tools"]
+packages = ["skill_seekers", "skill_seekers.cli", "skill_seekers.cli.adaptors", "skill_seekers.mcp", "skill_seekers.mcp.tools"]
 
 [tool.setuptools.package-dir]
 "" = "src"


### PR DESCRIPTION
  ---
  Description

  The skill_seekers.cli.adaptors module was missing from the packages list in pyproject.toml, causing ModuleNotFoundError: No module named 'skill_seekers.cli.adaptors' when using the package_skill command with PyPI-installed package (v2.5.0).

  This module provides multi-LLM platform support:
  - base.py - Base adaptor class
  - claude.py - Claude AI adaptor
  - gemini.py - Google Gemini adaptor
  - openai.py - OpenAI ChatGPT adaptor
  - markdown.py - Generic markdown export

  Type of Change

  - 🐛 Bug fix (non-breaking change which fixes an issue)

  How Has This Been Tested?

  # Install from local with fix
  uv pip install -e .

  # Verify module is accessible
  python -c "from skill_seekers.cli.adaptors import base; print('OK')"

  # Test package command
  skill-seekers package output/hono/
  # ✅ Successfully created hono.zip

  Test Configuration:
  - Python version: 3.13.5
  - OS: Ubuntu 22.04 (Linux 6.8.0-90-generic)
  - Install method: uv pip install -e .

  Checklist

  - My code follows the style guidelines of this project
  - I have performed a self-review of my own code
  - My changes generate no new warnings
  - New and existing unit tests pass locally with my changes

  🤖 Generated with https://claude.com/claude-code

  ---
  PR URL: https://github.com/yusufkaraaslan/Skill_Seekers/compare/development...MiaoDX-fork-and-pruning:Skill_Seekers:fix/add-adaptors-to-packages
