### PR TITLE
fix: Update setuptools configuration to include adaptors module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,10 +132,12 @@ skill-seekers-install = "skill_seekers.cli.install_skill:main"
 skill-seekers-install-agent = "skill_seekers.cli.install_agent:main"
 
 [tool.setuptools]
-packages = ["skill_seekers", "skill_seekers.cli", "skill_seekers.cli.adaptors", "skill_seekers.mcp", "skill_seekers.mcp.tools"]
+package-dir = {"" = "src"}
 
-[tool.setuptools.package-dir]
-"" = "src"
+[tool.setuptools.packages.find]
+where = ["src"]
+include = ["skill_seekers*"]
+namespaces = false
 
 [tool.setuptools.package-data]
 skill_seekers = ["py.typed"]


### PR DESCRIPTION
## Summary
Fixes #226 by updating `pyproject.toml` to use automatic package discovery instead of manual package listing. This ensures all submodules including `adaptors/` are properly included in the PyPI distribution.

## Problem
The MCP server's `package_skill` tool was failing with:
```
ModuleNotFoundError: No module named 'skill_seekers.cli.adaptors'
```

The PyPI package (v2.5.0) was missing the `adaptors/` directory even though it exists in the GitHub repository at `src/skill_seekers/cli/adaptors/`.

## Root Cause
The `pyproject.toml` used manual package listing:
```toml
[tool.setuptools]
packages = ["skill_seekers", "skill_seekers.cli", "skill_seekers.cli.adaptors", ...]
```

This approach has limitations:
- Requires manual updates when adding new submodules
- Doesn't respect the `src/` layout properly
- May fail during build if directories don't exist at build time

## Solution
Changed to automatic package discovery:
```toml
[tool.setuptools]
package-dir = {"" = "src"}

[tool.setuptools.packages.find]
where = ["src"]
include = ["skill_seekers*"]
namespaces = false
```

### Benefits
- ✅ Auto-discovers all submodules under `skill_seekers/`
- ✅ Properly handles `src/` layout
- ✅ No manual updates needed when adding new modules
- ✅ Matches Python packaging best practices

## Changes
- Modified `pyproject.toml` to use `[tool.setuptools.packages.find]`
- Removed explicit `packages` list
- Configured `package-dir` for `src/` layout

## Testing
To verify this fix:
```bash
# Build the package
pip install build
python -m build

# Install locally
pip install dist/skill_seekers-2.5.1-py3-none-any.whl

# Test adaptors import
python -c "from skill_seekers.cli.adaptors import get_adaptor; print('Success!')"
```

## Impact
- Fixes broken MCP tools: `package_skill`, `upload_skill`, `enhance_skill`, `install_skill`
- No breaking changes to existing functionality
- Aligns with setuptools best practices for src layout

## Checklist
- [x] Code follows project style guidelines
- [x] Changes are tested locally
- [x] Documentation updated (N/A - configuration change only)
- [x] Linked to relevant issue: #226

---

**Note to maintainers**: After merging, please cut a new release (v2.5.2) to deploy the fixed package to PyPI.