### PR TITLE
fix: Handle symlinked README.md and CHANGELOG.md in GitHub scraper

### DIFF
--- a/src/skill_seekers/cli/github_scraper.py
+++ b/src/skill_seekers/cli/github_scraper.py
@@ -325,6 +325,58 @@ class GitHubScraper:
                 raise ValueError(f"Repository not found: {self.repo_name}")
             raise
 
+    def _get_file_content(self, file_path: str) -> Optional[str]:
+        """
+        Safely get file content, handling symlinks and encoding issues.
+
+        Args:
+            file_path: Path to file in repository
+
+        Returns:
+            File content as string, or None if file not found/error
+        """
+        try:
+            content = self.repo.get_contents(file_path)
+            if not content:
+                return None
+
+            # Handle symlinks - follow the target to get actual file
+            if hasattr(content, 'type') and content.type == 'symlink':
+                target = getattr(content, 'target', None)
+                if target:
+                    target = target.strip()
+                    logger.debug(f"File {file_path} is a symlink to {target}, following...")
+                    try:
+                        content = self.repo.get_contents(target)
+                    except GithubException as e:
+                        logger.warning(f"Failed to follow symlink {file_path} -> {target}: {e}")
+                        return None
+                else:
+                    logger.warning(f"Symlink {file_path} has no target")
+                    return None
+
+            # Handle regular files - decode content
+            try:
+                if isinstance(content.decoded_content, bytes):
+                    return content.decoded_content.decode('utf-8')
+                else:
+                    return str(content.decoded_content)
+            except (UnicodeDecodeError, AttributeError, LookupError, AssertionError) as e:
+                logger.warning(f"Encoding issue with {file_path}: {e}")
+                # Try alternative encoding
+                try:
+                    if isinstance(content.decoded_content, bytes):
+                        return content.decoded_content.decode('latin-1')
+                except Exception:
+                    return None
+                return None
+
+        except GithubException:
+            return None
+        except Exception as e:
+            logger.warning(f"Error reading {file_path}: {e}")
+            return None
+
     def _extract_readme(self):
         """C1.2: Extract README.md files."""
         logger.info("Extracting README...")
@@ -334,24 +386,21 @@ class GitHubScraper:
                        'docs/README.md', '.github/README.md']
 
         for readme_path in readme_files:
-            try:
-                content = self.repo.get_contents(readme_path)
-                if content:
-                    self.extracted_data['readme'] = content.decoded_content.decode('utf-8')
-                    logger.info(f"README found: {readme_path}")
+            readme_content = self._get_file_content(readme_path)
+            if readme_content:
+                self.extracted_data['readme'] = readme_content
+                logger.info(f"README found: {readme_path}")
 
-                    # Update description if not explicitly set in config
-                    if 'description' not in self.config:
-                        smart_description = extract_description_from_readme(
-                            self.extracted_data['readme'],
-                            self.repo_name
-                        )
-                        self.description = smart_description
-                        logger.debug(f"Generated description: {self.description}")
+                # Update description if not explicitly set in config
+                if 'description' not in self.config:
+                    smart_description = extract_description_from_readme(
+                        self.extracted_data['readme'],
+                        self.repo_name
+                    )
+                    self.description = smart_description
+                    logger.debug(f"Generated description: {self.description}")
 
-                    return
-            except GithubException:
-                continue
+                return
 
         logger.warning("No README found in repository")
 
@@ -666,35 +715,11 @@ class GitHubScraper:
                           'docs/CHANGELOG.md', '.github/CHANGELOG.md']
 
         for changelog_path in changelog_files:
-            try:
-                content = self.repo.get_contents(changelog_path)
-                if content:
-                    # decoded_content is already bytes, decode to string
-                    # Handle potential encoding issues gracefully
-                    try:
-                        if isinstance(content.decoded_content, bytes):
-                            changelog_text = content.decoded_content.decode('utf-8')
-                        else:
-                            # Already a string
-                            changelog_text = str(content.decoded_content)
-                    except (UnicodeDecodeError, AttributeError, LookupError) as e:
-                        # Try alternative encodings or skip this file
-                        logger.warning(f"Encoding issue with {changelog_path}: {e}, trying latin-1")
-                        try:
-                            changelog_text = content.decoded_content.decode('latin-1')
-                        except Exception:
-                            logger.warning(f"Could not decode {changelog_path}, skipping")
-                            continue
-
-                    self.extracted_data['changelog'] = changelog_text
-                    logger.info(f"CHANGELOG found: {changelog_path}")
-                    return
-            except GithubException:
-                continue
-            except Exception as e:
-                # Catch any other errors (like "unsupported encoding: none")
-                logger.warning(f"Error reading {changelog_path}: {e}")
-                continue
+            changelog_content = self._get_file_content(changelog_path)
+            if changelog_content:
+                self.extracted_data['changelog'] = changelog_content
+                logger.info(f"CHANGELOG found: {changelog_path}")
+                return
 
         logger.warning("No CHANGELOG found in repository")
 


### PR DESCRIPTION
## 🐛 Bug Fix: Symlink Support for README and CHANGELOG

Fixes #225

### Problem

When README.md or CHANGELOG.md are **symlinks** (like in `vercel/ai` repository), the GitHub scraper crashes with:
```
AssertionError: unsupported encoding: None
```

**Root Cause**: PyGithub's `ContentFile` for symlinks has `type='symlink'` and `encoding=None`. Direct access to `decoded_content` triggers an assertion error.

### Solution

Added `_get_file_content()` helper method that:
- ✅ Detects symlink files (`content.type == 'symlink'`)
- ✅ Follows symlink target path (`content.target`)
- ✅ Fetches actual file content from target
- ✅ Handles encoding gracefully (UTF-8 → latin-1 fallback)
- ✅ Handles edge cases (broken symlinks, missing targets)

### Changes

**Modified Files**:
- `src/skill_seekers/cli/github_scraper.py`:
  - Added `_get_file_content()` helper (52 lines)
  - Updated `_extract_readme()` to use helper
  - Updated `_extract_changelog()` to use helper
  
- `tests/test_github_scraper.py`:
  - Added `TestSymlinkHandling` test class
  - Added 7 comprehensive tests for symlink handling

### Testing

**All 29 tests pass** ✅

New tests added:
1. ✅ `test_get_file_content_regular_file` - Regular file handling
2. ✅ `test_get_file_content_symlink` - Symlink following
3. ✅ `test_get_file_content_broken_symlink` - Broken symlink handling
4. ✅ `test_get_file_content_symlink_no_target` - Missing target handling
5. ✅ `test_extract_readme_with_symlink` - README symlink integration test
6. ✅ `test_extract_changelog_with_symlink` - CHANGELOG symlink integration test
7. ✅ `test_get_file_content_encoding_error` - Encoding error handling

**Test Results**:
```bash
$ pytest tests/test_github_scraper.py -v
29 passed, 1 warning in 0.07s
```

### Verification

The fix will now work correctly with repositories like `vercel/ai`:

```bash
# This now works without AssertionError
skill-seekers github --repo vercel/ai --name ai
```

### Impact

- **Backward compatible** - Regular files still work exactly as before
- **Handles edge cases** - Graceful fallback for broken symlinks
- **Well tested** - 7 new tests covering all scenarios
- **No breaking changes** - Only adds new functionality

### Checklist

- [x] Fix implemented
- [x] Tests added (7 new tests)
- [x] All tests passing (29/29)
- [x] No breaking changes
- [x] Issue #225 linked
- [x] Ready for review

---

**Ready for review and merge!** 🚀