### PR TITLE
Fix: Migrate from deprecated `tool.uv` to standard `dependency-groups`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,13 +173,10 @@ exclude_lines = [
     "@abstractmethod",
 ]
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "pytest>=8.4.2",
     "pytest-asyncio>=0.24.0",
     "pytest-cov>=7.0.0",
     "coverage>=7.11.0",
 ]
-
-[tool.uv.sources]
-# Use PyPI for all dependencies


### PR DESCRIPTION
# Fix: Migrate from deprecated `tool.uv` to standard `dependency-groups`

## Problem

When opening a terminal in VS Code, users encountered two warnings:

1. **UV deprecation warning**: `The 'tool.uv.dev-dependencies' field (used in pyproject.toml) is deprecated and will be removed in a future release`
2. **Powerlevel10k instant prompt warning**: Triggered by console output during zsh initialization from the UV warning

## Solution

Updated `pyproject.toml` to use the modern PEP standard `[dependency-groups]` section instead of the deprecated `[tool.uv]` configuration.

## Changes Made

- ✅ Replaced `[tool.uv]` section with `[dependency-groups]`
- ✅ Changed `dev-dependencies` field to `dev` (standard naming)
- ✅ Removed obsolete `[tool.uv.sources]` section

```diff
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "pytest>=8.4.2",
     "pytest-asyncio>=0.24.0",
     "pytest-cov>=7.0.0",
     "coverage>=7.11.0",
 ]

-[tool.uv.sources]
-# Use PyPI for all dependencies
```

## Benefits

- 🎯 Eliminates UV deprecation warnings
- 🚀 Compatible with latest UV versions
- ✨ Cleaner terminal startup (no Powerlevel10k warnings)
- 📦 Follows modern Python packaging standards

## Testing

- [x] UV successfully resolves dependencies without warnings
- [x] Development dependencies install correctly
- [x] No breaking changes to existing workflows

## Impact

- **Breaking Changes**: None
- **Backward Compatibility**: Fully maintained
- **Migration Required**: None (automatic)
