### PR TITLE
fix: Replace PaginatedList slicing with iterator in _extract_issues

### DIFF
--- a/src/skill_seekers/cli/github_scraper.py
+++ b/src/skill_seekers/cli/github_scraper.py
@@ -778,7 +778,12 @@ class GitHubScraper:
             issues = self.repo.get_issues(state="all", sort="updated", direction="desc")
 
             issue_list = []
-            for issue in issues[: self.max_issues]:
+            count = 0
+            for issue in issues:
+                # Stop if we've reached the limit
+                if count >= self.max_issues:
+                    break
+
                 # Skip pull requests (they appear in issues)
                 if issue.pull_request:
                     continue
@@ -796,6 +801,7 @@ class GitHubScraper:
                     "body": issue.body[:500] if issue.body else None,  # First 500 chars
                 }
                 issue_list.append(issue_data)
+                count += 1
 
             self.extracted_data["issues"] = issue_list
             logger.info(f"Extracted {len(issue_list)} issues")


### PR DESCRIPTION
## ?? Bug Fix

### Problem
The `_extract_issues` method uses list slicing on PyGithub's `PaginatedList` object, which causes a `list index out of range` error when repositories have no issues or when the API returns unexpected results.

**Error:**
```
ERROR - Unexpected error during scraping: list index out of range
```

**Location:** `src/skill_seekers/cli/github_scraper.py:781`

### Root Cause
PyGithub's `get_issues()` returns a `PaginatedList` object that doesn't support slicing operations like `issues[:max_issues]`.

### Solution
Replaced slicing with iterator + manual counter:
- Use `for issue in issues:` instead of `for issue in issues[:max_issues]:`
- Add counter to track number of issues processed
- Break loop when reaching `max_issues` limit

### Testing
? Tested with repository: `TullyMonster/exa-pool-mcp`
- Before: `list index out of range` error
- After: Successfully extracted 0 issues without errors

### Changes
- Modified: `src/skill_seekers/cli/github_scraper.py` (8 lines changed)
- Added counter variable and break condition
- Properly handles empty issue lists

---

?? Generated with [Claude Code](https://claude.com/claude-code)