### PR TITLE
feat: add Manifest observability platform config

### DIFF
--- a/configs/manifest.json
+++ b/configs/manifest.json
@@ -1,0 +1,101 @@
+{
+  "name": "manifest",
+  "description": "Use this skill when working with Manifest, an AI agent observability platform. Manifest monitors costs, tokens, messages, and performance of your AI agents in real time via an OTLP-based telemetry plugin.",
+  "version": "1.0.0",
+  "base_url": "https://manifest.build/",
+  "sources": [
+    {
+      "type": "documentation",
+      "base_url": "https://manifest.build/",
+      "selectors": {
+        "main_content": "main, article, .content",
+        "title": "h1",
+        "code_blocks": "pre code"
+      }
+    },
+    {
+      "type": "github",
+      "repo": "mnfst/manifest",
+      "code_analysis_depth": "deep",
+      "enable_codebase_analysis": true,
+      "fetch_issues": true,
+      "fetch_changelog": true,
+      "fetch_releases": true,
+      "max_issues": 30
+    }
+  ],
+  "selectors": {
+    "main_content": "main, article, .content",
+    "title": "h1",
+    "code_blocks": "pre code"
+  },
+  "url_patterns": {
+    "include": [
+      "/"
+    ],
+    "exclude": [
+      "/register",
+      "/login",
+      "/app"
+    ]
+  },
+  "categories": {
+    "getting_started": [
+      "quickstart",
+      "install",
+      "getting-started",
+      "setup"
+    ],
+    "configuration": [
+      "config",
+      "env",
+      "environment",
+      "settings",
+      "api-key"
+    ],
+    "telemetry": [
+      "otlp",
+      "telemetry",
+      "observability",
+      "tracing",
+      "monitoring"
+    ],
+    "plugin": [
+      "plugin",
+      "gateway",
+      "openclaw-plugin",
+      "integration"
+    ],
+    "deployment": [
+      "self-hosted",
+      "docker",
+      "railway",
+      "production"
+    ],
+    "api_reference": [
+      "api",
+      "endpoints",
+      "authentication",
+      "rate-limit"
+    ]
+  },
+  "rate_limit": 0.5,
+  "max_pages": 50,
+  "metadata": {
+    "author": "mnfst",
+    "language": "TypeScript",
+    "framework_type": "Observability Platform",
+    "use_cases": [
+      "AI agent cost monitoring",
+      "Token usage tracking",
+      "Agent performance observability",
+      "OTLP telemetry collection",
+      "Self-hosted agent monitoring"
+    ],
+    "related_skills": [
+      "observability-engineer",
+      "prometheus",
+      "opentelemetry"
+    ]
+  }
+}


### PR DESCRIPTION
## Description

Adds a scraping configuration for [Manifest](https://manifest.build), an AI agent observability platform that monitors costs, tokens, messages, and performance in real time via OTLP telemetry.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Config details

- **Config:** `configs/manifest.json`
- **Sources:** Landing page (manifest.build) + GitHub repo (mnfst/manifest) with deep code analysis
- **Categories:** getting_started, configuration, telemetry, plugin, deployment, api_reference
- **Rate limit:** 0.5s
- **Max pages:** 50

## How Has This Been Tested?

Config validated manually against the JSON schema used by existing configs (claude-code.json, httpx_comprehensive.json).

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings