### PR TITLE
fix: use getattr for max_pages in create command web routing

### DIFF
--- a/src/skill_seekers/cli/create_command.py
+++ b/src/skill_seekers/cli/create_command.py
@@ -152,7 +152,7 @@ class CreateCommand:
         self._add_common_args(argv)
 
         # Add web-specific arguments
-        if self.args.max_pages:
+        if getattr(self.args, "max_pages", None):
             argv.extend(["--max-pages", str(self.args.max_pages)])
         if getattr(self.args, "skip_scrape", False):
             argv.append("--skip-scrape")


### PR DESCRIPTION
## Summary
- Fix `AttributeError: 'Namespace' object has no attribute 'max_pages'` when running `skill-seekers create <url>`
- Changed direct `self.args.max_pages` access to `getattr(self.args, "max_pages", None)` to match all other source-specific attributes in the same method

## Test plan
- [x] Verified `getattr` returns `None` when `max_pages` is not in the default parser mode
- [x] Existing create command tests pass (75/75)

Closes #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)