### PR TITLE
docs: add best practices guide for high-quality skills (#206)

### DIFF
--- a/docs/BEST_PRACTICES.md
+++ b/docs/BEST_PRACTICES.md
@@ -289,7 +289,7 @@ skill-seekers quality output/myskill/
 
 **"No code examples found"**
 - Add code blocks to SKILL.md
-- Run enhancement: `python3 cli/enhance_skill_local.py output/myskill/`
+- Run enhancement: `skill-seekers enhance output/myskill/`
 
 **"Generic description"**
 - Rewrite "When to Use" section
@@ -436,9 +436,9 @@ That's it! Follow these practices and your skills will work better with Claude.
 
 ## See Also
 
-- [ENHANCEMENT.md](ENHANCEMENT.md) - AI-powered SKILL.md improvement
-- [UPLOAD_GUIDE.md](UPLOAD_GUIDE.md) - How to upload skills to Claude
-- [USAGE.md](USAGE.md) - Complete command reference
+- [Enhancement Guide](features/ENHANCEMENT.md) - AI-powered SKILL.md improvement
+- [Upload Guide](guides/UPLOAD_GUIDE.md) - How to upload skills to Claude
+- [CLI Reference](reference/CLI_REFERENCE.md) - Complete command reference
 
 ---
 


### PR DESCRIPTION
## Summary

Adds a comprehensive best practices guide for creating high-quality Claude skills (docs/BEST_PRACTICES.md, 449 lines). Addresses roadmap item I2.2.

Based on PR #206 by @jmagly from the AI Writing Guide project — rebased onto current development with fixes applied.

### Content covers
- Clear SKILL.md structure with When to Use triggers
- Code examples (why 5+ matter)
- Prerequisites documentation patterns
- Troubleshooting section templates
- Reference organization guidelines
- Quality workflow with grade targets
- Real-world before/after example (Grade F to Grade A)

### Fixes applied
1. Replaced outdated python3 cli/enhance_skill_local.py with skill-seekers enhance
2. Fixed broken See Also links (docs reorganized into features/, guides/, reference/)

Supersedes #206
Co-authored-by: jmagly <jmagly@users.noreply.github.com>