### PR TITLE
fix: enable --browser flag in create command

### DIFF
--- a/src/skill_seekers/cli/parsers/create_parser.py
+++ b/src/skill_seekers/cli/parsers/create_parser.py
@@ -53,9 +53,9 @@ Presets: -p quick (1-2min) | -p standard (5-10min) | -p comprehensive (20-60min)
 
         Multi-mode help handled via custom flags detected in argument parsing.
         """
-        # Add all arguments in 'default' mode (universal only)
-        # This keeps help text clean and focused
-        add_create_arguments(parser, mode="default")
+        # Add all arguments in 'all' mode to support all source types
+        # Progressive help still works via --help-web, --help-github, etc.
+        add_create_arguments(parser, mode="all")
 
         # Add hidden help mode flags
         # These won't show in default help but can be used to get source-specific help


### PR DESCRIPTION
## Problem

The `--browser` flag was not recognized when using `skill-seekers create <url> --browser` for JavaScript SPA sites.

**Root cause:** The argument parser was built in `'default'` mode, which only includes `UNIVERSAL_ARGUMENTS`. The `--browser` flag lives in `WEB_ARGUMENTS`, which are only added when mode is `'web'` or `'all'`.

**User impact:** Cannot scrape JavaScript SPA sites (React, Vue, Angular docs) which require headless browser rendering.

## Solution

Changed `create_parser.py` line 58 from:
```python
add_create_arguments(parser, mode="default")
```

To:
```python
add_create_arguments(parser, mode="all")
```

This ensures all source-specific arguments (web, github, local, pdf, video, etc.) are available in the create command.

## Preserved Functionality

✅ **Progressive help still works** via `--help-web`, `--help-github`, `--help-local`, `--help-pdf`, `--help-advanced`, `--help-all`

✅ **No breaking changes** — all existing commands continue to work

✅ **Backward compatible** — only adds missing arguments, doesn't remove any

## Testing

Tested that:
- ✅ `--browser` flag is now recognized
- ✅ SPA scraping works with headless browser
- ✅ Progressive help flags still function

## Closes

Fixes #321

## Credit

Root cause identified by @skeith in issue comment (https://github.com/yusufkaraaslan/Skill_Seekers/issues/321#issuecomment-4178933555)