### PR TITLE
fix: replace glob('*.md') with rglob('*.md') in all adaptors

### DIFF
--- a/src/skill_seekers/cli/adaptors/claude.py
+++ b/src/skill_seekers/cli/adaptors/claude.py
@@ -422,8 +422,8 @@ version: {metadata.version}
         references = {}
         total_chars = 0
 
-        # Read all .md files
-        for ref_file in sorted(references_dir.glob("*.md")):
+        # Read all .md files recursively (including subdirectories)
+        for ref_file in sorted(references_dir.rglob("*.md")):
             if total_chars >= max_chars:
                 break
 

--- a/src/skill_seekers/cli/adaptors/gemini.py
+++ b/src/skill_seekers/cli/adaptors/gemini.py
@@ -237,7 +237,7 @@ See the references directory for complete documentation with examples and best p
                 refs_dir = temp_path / "references"
                 uploaded_refs = []
                 if refs_dir.exists():
-                    for ref_file in refs_dir.glob("*.md"):
+                    for ref_file in refs_dir.rglob("*.md"):
                         ref_uploaded = genai.upload_file(
                             path=str(ref_file), display_name=f"{package_path.stem}_{ref_file.stem}"
                         )
@@ -382,8 +382,8 @@ See the references directory for complete documentation with examples and best p
         references = {}
         total_chars = 0
 
-        # Read all .md files
-        for ref_file in sorted(references_dir.glob("*.md")):
+        # Read all .md files recursively (including subdirectories)
+        for ref_file in sorted(references_dir.rglob("*.md")):
             if total_chars >= max_chars:
                 break
 

--- a/src/skill_seekers/cli/adaptors/openai.py
+++ b/src/skill_seekers/cli/adaptors/openai.py
@@ -264,7 +264,7 @@ Always prioritize accuracy by consulting the attached documentation files before
                 file_ids = []
 
                 if vector_files_dir.exists():
-                    for ref_file in vector_files_dir.glob("*.md"):
+                    for ref_file in vector_files_dir.rglob("*.md"):
                         # Upload file
                         with open(ref_file, "rb") as f:
                             uploaded_file = client.files.create(file=f, purpose="assistants")
@@ -433,8 +433,8 @@ Always prioritize accuracy by consulting the attached documentation files before
         references = {}
         total_chars = 0
 
-        # Read all .md files
-        for ref_file in sorted(references_dir.glob("*.md")):
+        # Read all .md files recursively (including subdirectories)
+        for ref_file in sorted(references_dir.rglob("*.md")):
             if total_chars >= max_chars:
                 break
 


### PR DESCRIPTION
## Summary

Fixes #348

`_read_reference_files()` in `GeminiAdaptor`, `ClaudeAdaptor` and `OpenAIAdaptor` were using `glob('*.md')` which only searches the **root** of the `references/` directory, silently ignoring any `.md` files located in subdirectories.

`OpenAIAdaptor.upload()` had the same issue when iterating `vector_store_files/` before sending files to the OpenAI Assistants API.

## Changes

| File | Method | Before | After |
|---|---|---|---|
| `gemini.py` | `upload()` | `refs_dir.glob("*.md")` | `refs_dir.rglob("*.md")` |
| `gemini.py` | `_read_reference_files()` | `references_dir.glob("*.md")` | `references_dir.rglob("*.md")` |
| `claude.py` | `_read_reference_files()` | `references_dir.glob("*.md")` | `references_dir.rglob("*.md")` |
| `openai.py` | `_read_reference_files()` | `references_dir.glob("*.md")` | `references_dir.rglob("*.md")` |
| `openai.py` | `upload()` | `vector_files_dir.glob("*.md")` | `vector_files_dir.rglob("*.md")` |

Note: `package()` already correctly used `rglob` in all three adaptors — this fix makes the remaining methods consistent.

## Impact

Without this fix, skills with nested references (e.g. `references/api/endpoints.md`, `references/guides/quickstart.md`) were silently incomplete when:
- uploading to Gemini Files API
- uploading to OpenAI Vector Store
- enhancing `SKILL.md` via Gemini, Claude or OpenAI API

## Testing

```bash
# Verify no plain glob('*.md') remains in adaptors
grep -n '\.glob("\*\.md")' src/skill_seekers/cli/adaptors/gemini.py src/skill_seekers/cli/adaptors/claude.py src/skill_seekers/cli/adaptors/openai.py
# Should return no output
```