### PR TITLE
feat: add Codex CLI plugin manifest

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "skill-seekers",
+  "version": "3.5.0",
+  "description": "Convert docs and repos into AI skills via MCP",
+  "author": {
+    "name": "yusufkaraaslan",
+    "url": "https://github.com/yusufkaraaslan/Skill_Seekers"
+  },
+  "homepage": "https://skillseekersweb.com/",
+  "repository": "https://github.com/yusufkaraaslan/Skill_Seekers",
+  "keywords": ["mcp", "codex", "skills", "documentation"],
+  "mcpServers": "./.mcp.json",
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Skill Seekers",
+    "shortDescription": "Convert docs and repos into AI skills via MCP",
+    "longDescription": "Convert documentation websites, GitHub repositories, and PDFs into AI skills with automatic conflict detection.",
+    "category": "Development",
+    "websiteURL": "https://skillseekersweb.com/"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ htmlcov/
 skill-seekers-configs/
 .claude/skills
 .mcp.json
+!/.mcp.json
 !distribution/claude-plugin/.mcp.json
 settings.json
 USER_GUIDE.md

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "skill-seekers": {
+      "command": "python",
+      "args": ["-m", "skill_seekers.mcp.server_fastmcp"]
+    }
+  }
+}

--- a/skills/skill-seekers/SKILL.md
+++ b/skills/skill-seekers/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: skill-builder
+description: Automatically detect source types and build AI skills using Skill Seekers. Use when the user wants to create skills from documentation, repos, PDFs, videos, or other knowledge sources.
+---
+
+# Skill Builder
+
+You have access to the Skill Seekers MCP server which provides 35 tools for converting knowledge sources into AI-ready skills.
+
+## When to Use This Skill
+
+Use this skill when the user:
+- Wants to create an AI skill from a documentation site, GitHub repo, PDF, video, or other source
+- Needs to convert documentation into a format suitable for LLM consumption
+- Wants to update or sync existing skills with their source documentation
+- Needs to export skills to vector databases (Weaviate, Chroma, FAISS, Qdrant)
+- Asks about scraping, converting, or packaging documentation for AI
+
+## Source Type Detection
+
+Automatically detect the source type from user input:
+
+| Input Pattern | Source Type | Tool to Use |
+|---------------|-------------|-------------|
+| `https://...` (not GitHub/YouTube) | Documentation | `scrape_docs` |
+| `owner/repo` or `github.com/...` | GitHub | `scrape_github` |
+| `*.pdf` | PDF | `scrape_pdf` |
+| YouTube/Vimeo URL or video file | Video | `scrape_video` |
+| Local directory path | Codebase | `scrape_codebase` |
+| `*.ipynb`, `*.html`, `*.yaml` (OpenAPI), `*.adoc`, `*.pptx`, `*.rss`, `*.1`-`.8` | Various | `scrape_generic` |
+| JSON config file | Unified | Use config with `scrape_docs` |
+
+## Recommended Workflow
+
+1. **Detect source type** from the user's input
+2. **Generate or fetch config** using `generate_config` or `fetch_config` if needed
+3. **Estimate scope** with `estimate_pages` for documentation sites
+4. **Scrape the source** using the appropriate scraping tool
+5. **Enhance** with `enhance_skill` if the user wants AI-powered improvements
+6. **Package** with `package_skill` for the target platform
+7. **Export to vector DB** if requested using `export_to_*` tools
+
+## Available MCP Tools
+
+### Config Management
+- `generate_config` — Generate a scraping config from a URL
+- `list_configs` — List available preset configs
+- `validate_config` — Validate a config file
+
+### Scraping (use based on source type)
+- `scrape_docs` — Documentation sites
+- `scrape_github` — GitHub repositories
+- `scrape_pdf` — PDF files
+- `scrape_video` — Video transcripts
+- `scrape_codebase` — Local code analysis
+- `scrape_generic` — Jupyter, HTML, OpenAPI, AsciiDoc, PPTX, RSS, manpage, Confluence, Notion, chat
+
+### Post-processing
+- `enhance_skill` — AI-powered skill enhancement
+- `package_skill` — Package for target platform
+- `upload_skill` — Upload to platform API
+- `install_skill` — End-to-end install workflow
+
+### Advanced
+- `detect_patterns` — Design pattern detection in code
+- `extract_test_examples` — Extract usage examples from tests
+- `build_how_to_guides` — Generate how-to guides from tests
+- `split_config` — Split large configs into focused skills
+- `export_to_weaviate`, `export_to_chroma`, `export_to_faiss`, `export_to_qdrant` — Vector DB export


### PR DESCRIPTION
## Summary

Add Codex CLI plugin support for discovery via [codex-plugin-scanner](https://github.com/hashgraph-online/codex-plugin-scanner) and [awesome-codex-plugins](https://github.com/internet-dot/awesome-codex-plugins).

**Based on #341 by @internet-dot** — rebased cleanly onto current `development` with `.mcp.json` fix (was running `pip install` instead of starting the MCP server).

## Changes

| File | Purpose |
|---|---|
| `.codex-plugin/plugin.json` | Codex plugin manifest |
| `.mcp.json` | MCP server config (starts `server_fastmcp`) |
| `skills/skill-seekers/SKILL.md` | Bundled skill for Codex |
| `.gitignore` | Allow root `.mcp.json` to be tracked |

## Fix from original PR

The `.mcp.json` in #341 ran `pip install skill-seekers` as the server command. Fixed to:
```json
{"command": "python", "args": ["-m", "skill_seekers.mcp.server_fastmcp"]}
```

## Test plan

- [x] `plugin.json` validates as JSON
- [x] `.mcp.json` validates as JSON and references correct server module
- [x] Skill file follows existing format from `distribution/claude-plugin/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)