### PR TITLE
fix: coerce language byte counts to int in _extract_languages

### DIFF
--- a/src/skill_seekers/cli/github_scraper.py
+++ b/src/skill_seekers/cli/github_scraper.py
@@ -518,7 +518,7 @@ class GitHubScraper:
         logger.info("Detecting programming languages...")
 
         try:
-            languages = {lang: int(b) for lang, b in self.repo.get_languages().items()}
+            languages = {lang: b for lang, b in self.repo.get_languages().items() if isinstance(b, int)}
             total_bytes = sum(languages.values())
 
             self.extracted_data["languages"] = {

--- a/src/skill_seekers/cli/github_scraper.py
+++ b/src/skill_seekers/cli/github_scraper.py
@@ -518,7 +518,7 @@ class GitHubScraper:
         logger.info("Detecting programming languages...")
 
         try:
-            languages = self.repo.get_languages()
+            languages = {lang: int(b) for lang, b in self.repo.get_languages().items()}
             total_bytes = sum(languages.values())
 
             self.extracted_data["languages"] = {


### PR DESCRIPTION
## Summary

- `_extract_languages()` crashes with `TypeError` because PyGithub 2.9.0 leaks a `url` key into the dict returned by `repo.get_languages()`:
  ```python
  {'Ruby': 148281, 'C': 104615, ..., 'url': 'https://api.github.com/repos/.../languages'}
  ```
- `sum(languages.values())` then attempts `int + str` and raises `TypeError: unsupported operand type(s) for +: 'int' and 'str'`
- Fix: filter to `isinstance(b, int)` to drop the leaked metadata key

## Reproducer

```
$ skill-seekers-github --repo Faveod/ruby-tree-sitter
...
Detecting programming languages...
Unexpected error during scraping: unsupported operand type(s) for +: 'int' and 'str'
```

**Environment:** Python 3.14, PyGithub 2.9.0

## Change

One-line change in `src/skill_seekers/cli/github_scraper.py`:

```diff
-            languages = self.repo.get_languages()
+            languages = {lang: b for lang, b in self.repo.get_languages().items() if isinstance(b, int)}
```

## Test plan

- [ ] Run `skill-seekers-github --repo Faveod/ruby-tree-sitter` — should complete without TypeError
- [ ] Run against a repo that already works (e.g., `--repo facebook/react`) — no regression
