### PR TITLE
fix: use scrape_all in docs scraper entrypoint

### DIFF
--- a/src/skill_seekers/cli/doc_scraper.py
+++ b/src/skill_seekers/cli/doc_scraper.py
@@ -2282,7 +2282,7 @@ def _run_scraping(config: dict[str, Any]) -> Optional["DocToSkillConverter"]:
     if not config.get("skip_scrape"):
         logger.info("\n🔍 Starting scrape...")
         try:
-            asyncio.run(converter.scrape())
+            converter.scrape_all()
         except KeyboardInterrupt:
             logger.info("\n\n⚠️  Interrupted by user")
             converter.save_checkpoint()

--- a/tests/test_doc_scraper_entrypoint.py
+++ b/tests/test_doc_scraper_entrypoint.py
@@ -1,0 +1,65 @@
+from skill_seekers.cli.doc_scraper import _run_scraping
+
+
+class DummyConverter:
+    def __init__(self):
+        self.checkpoint_loaded = False
+        self.checkpoint_cleared = False
+        self.scrape_all_called = False
+        self.build_skill_called = False
+        self.save_checkpoint_called = False
+
+    def checkpoint_exists(self):
+        return False
+
+    def load_checkpoint(self):
+        self.checkpoint_loaded = True
+
+    def clear_checkpoint(self):
+        self.checkpoint_cleared = True
+
+    def scrape_all(self):
+        self.scrape_all_called = True
+
+    def build_skill(self):
+        self.build_skill_called = True
+
+    def save_checkpoint(self):
+        self.save_checkpoint_called = True
+
+
+def test_run_scraping_uses_scrape_all(monkeypatch):
+    """Regression test for CLI entrypoint calling a nonexistent scrape() method."""
+    converter = DummyConverter()
+
+    monkeypatch.setattr(
+        "skill_seekers.cli.doc_scraper.DocToSkillConverter",
+        lambda config: converter,
+    )
+
+    result = _run_scraping({"name": "demo", "base_url": "https://example.com"})
+
+    assert result is converter
+    assert converter.scrape_all_called is True
+    assert converter.build_skill_called is True
+
+
+def test_run_scraping_saves_checkpoint_on_keyboard_interrupt(monkeypatch):
+    """KeyboardInterrupt during scrape_all() should preserve resume state."""
+    converter = DummyConverter()
+
+    def raise_interrupt():
+        raise KeyboardInterrupt
+
+    converter.scrape_all = raise_interrupt
+
+    monkeypatch.setattr(
+        "skill_seekers.cli.doc_scraper.DocToSkillConverter",
+        lambda config: converter,
+    )
+
+    result = _run_scraping({"name": "demo", "base_url": "https://example.com"})
+
+    assert result is None
+    assert converter.save_checkpoint_called is True
+    assert converter.build_skill_called is False


### PR DESCRIPTION
# Pull Request

## 📋 Description

This PR fixes a runtime regression in the documentation scraping entrypoint.

`_run_scraping()` was calling `asyncio.run(converter.scrape())`, but `DocToSkillConverter` exposes `scrape_all()` / `extract()` rather than a `scrape()` method. In practice this can raise an `AttributeError` before docs-based scraping starts.

### What changed
- replace the nonexistent `converter.scrape()` call with `converter.scrape_all()`
- add a focused regression test covering the normal entrypoint path
- add a focused regression test covering `KeyboardInterrupt` checkpoint-save behavior

## 🔗 Related Issues

Closes: N/A
Relates to: downstream docs-based build validation for Crawl4AI / Skill Seekers integration

## 🎯 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement
- [x] 🧪 Test update

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## 🧪 Testing

Describe the tests you ran to verify your changes.

**Executed successfully:**
- manual regression check with `PYTHONPATH=src` using the downstream `.venv` Python to verify `_run_scraping()` now delegates to `scrape_all()`
- manual regression check that `KeyboardInterrupt` still triggers `save_checkpoint()` and returns `None`
- `python -m py_compile src/skill_seekers/cli/doc_scraper.py tests/test_doc_scraper_entrypoint.py`
- `git diff --check`

**Attempted but blocked by environment/network bootstrap:**
- `uv run pytest tests/test_doc_scraper_entrypoint.py tests/test_unified_scraper_orchestration.py -q`
  - dependency bootstrap timed out while downloading `google-auth`
  - expected follow-up validation is left to CI in the PR

**Test Configuration:**
- Python version: 3.13.12 for manual regression checks; `uv` bootstrap used CPython 3.11.14
- OS: Linux 6.6
- Dependencies installed: downstream `SkillSeekers_Demo` virtualenv + `PYTHONPATH` pointing to this branch's `src/`

## 📸 Screenshots (if applicable)

N/A

## 📝 Additional Notes

This is intentionally a narrow first PR so the runtime regression can be reviewed independently from the larger unified-config and quality-alignment fixes discovered downstream.