### PR TITLE
Add IBM Bob packaging target and agent install support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ skill-seekers create https://docs.react.dev/
 skill-seekers package output/react --target claude      # → Claude AI Skill (ZIP)
 skill-seekers package output/react --target langchain   # → LangChain Documents
 skill-seekers package output/react --target llama-index # → LlamaIndex TextNodes
-skill-seekers package output/react --target cursor      # → .cursorrules
+skill-seekers package output/react --target ibm-bob     # → IBM Bob skill directory
 ```
 
 ### What gets built
@@ -72,6 +72,7 @@ skill-seekers package output/react --target cursor      # → .cursorrules
 | **Haystack Documents** | `--target haystack` | Enterprise RAG pipelines |
 | **Pinecone-ready** (Markdown) | `--target markdown` | Vector upsert |
 | **ChromaDB / FAISS / Qdrant** | `--format chroma/faiss/qdrant` | Local vector DBs |
+| **IBM Bob Skill** (directory) | `--target ibm-bob` | IBM Bob project/global skills |
 | **Cursor** `.cursorrules` | `--target claude` → copy | Cursor IDE AI context |
 | **Windsurf / Cline / Continue** | `--target claude` → copy | VS Code, IntelliJ, Vim |
 
@@ -1006,11 +1007,14 @@ In Claude Code, just ask:
 
 ## 🤖 Installing to AI Agents
 
-Skill Seekers can automatically install skills to 18 AI coding agents.
+Skill Seekers can automatically install skills to 19 AI coding agents.
 
 ```bash
 # Install to specific agent
 skill-seekers install-agent output/react/ --agent cursor
+
+# Install to IBM Bob (project-local .bob/skills/)
+skill-seekers install-agent output/react/ --agent bob
 
 # Install to all agents at once
 skill-seekers install-agent output/react/ --agent all
@@ -1037,6 +1041,7 @@ skill-seekers install-agent output/react/ --agent cursor --dry-run
 | **Kilo Code** | `.kilo/skills/` | Project |
 | **Continue** | `~/.continue/skills/` | Global |
 | **Kimi Code** | `~/.kimi/skills/` | Global |
+| **IBM Bob** | `.bob/skills/` | Project |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ skill-seekers create https://docs.react.dev/
 skill-seekers package output/react --target claude      # → Claude AI Skill (ZIP)
 skill-seekers package output/react --target langchain   # → LangChain Documents
 skill-seekers package output/react --target llama-index # → LlamaIndex TextNodes
+skill-seekers package output/react --target cursor      # → .cursorrules
 skill-seekers package output/react --target ibm-bob     # → IBM Bob skill directory
 ```
 

--- a/src/skill_seekers/cli/adaptors/__init__.py
+++ b/src/skill_seekers/cli/adaptors/__init__.py
@@ -111,6 +111,11 @@ try:
 except ImportError:
     FireworksAdaptor = None
 
+try:
+    from .ibm_bob import IBMBobAdaptor
+except ImportError:
+    IBMBobAdaptor = None
+
 
 # Registry of available adaptors
 ADAPTORS: dict[str, type[SkillAdaptor]] = {}
@@ -156,6 +161,8 @@ if TogetherAdaptor:
     ADAPTORS["together"] = TogetherAdaptor
 if FireworksAdaptor:
     ADAPTORS["fireworks"] = FireworksAdaptor
+if IBMBobAdaptor:
+    ADAPTORS["ibm-bob"] = IBMBobAdaptor
 
 
 def get_adaptor(platform: str, config: dict = None) -> SkillAdaptor:

--- a/src/skill_seekers/cli/adaptors/ibm_bob.py
+++ b/src/skill_seekers/cli/adaptors/ibm_bob.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""
+IBM Bob Adaptor
+
+Generates skills in IBM Bob-compatible format.
+Bob discovers skills in project or global `.bob/skills/` directories.
+"""
+
+import re
+import shutil
+from pathlib import Path
+from typing import Any
+
+from .base import SkillAdaptor, SkillMetadata
+from skill_seekers.cli.arguments.common import DEFAULT_CHUNK_OVERLAP_TOKENS, DEFAULT_CHUNK_TOKENS
+
+
+class IBMBobAdaptor(SkillAdaptor):
+    """
+    IBM Bob platform adaptor.
+
+    Packages a skill into a Bob-ready directory layout:
+    `.bob/skills/<skill-name>/SKILL.md`
+    """
+
+    PLATFORM = "ibm-bob"
+    PLATFORM_NAME = "IBM Bob"
+    DEFAULT_API_ENDPOINT = None  # Local file-based, no upload API
+
+    @staticmethod
+    def _to_skill_dir_name(name: str) -> str:
+        """Normalize a skill name to a filesystem-friendly Bob directory name."""
+        result = name.lower()
+        result = re.sub(r"[_\s.]+", "-", result)
+        result = re.sub(r"[^a-z0-9-]", "", result)
+        result = re.sub(r"-+", "-", result)
+        result = result.strip("-")
+        return result or "skill"
+
+    @staticmethod
+    def _quote_yaml(value: str) -> str:
+        """Quote a YAML string to safely preserve punctuation."""
+        return f'"{value.replace(chr(34), r"\"")}"'
+
+    def format_skill_md(self, skill_dir: Path, metadata: SkillMetadata) -> str:
+        """
+        Format SKILL.md with Bob-compatible YAML frontmatter.
+
+        Bob requires `name` and `description` and accepts additional metadata.
+        """
+        existing_content = self._read_existing_content(skill_dir)
+        body = existing_content if existing_content else f"# {metadata.name}\n\n{metadata.description}\n"
+
+        tags = metadata.tags or [self._to_skill_dir_name(metadata.name)]
+        tag_lines = "\n".join(f"  - {tag}" for tag in tags)
+        author_line = f"\nauthor: {self._quote_yaml(metadata.author)}" if metadata.author else ""
+
+        frontmatter = (
+            f"---\n"
+            f"name: {self._quote_yaml(metadata.name)}\n"
+            f"description: {self._quote_yaml(metadata.description)}\n"
+            f"version: {self._quote_yaml(metadata.version)}\n"
+            f"tags:\n{tag_lines}"
+            f"{author_line}\n"
+            f"---"
+        )
+
+        return f"{frontmatter}\n\n{body.strip()}\n"
+
+    def package(
+        self,
+        skill_dir: Path,
+        output_path: Path,
+        enable_chunking: bool = False,
+        chunk_max_tokens: int = DEFAULT_CHUNK_TOKENS,
+        preserve_code_blocks: bool = True,
+        chunk_overlap_tokens: int = DEFAULT_CHUNK_OVERLAP_TOKENS,
+    ) -> Path:
+        """
+        Package a skill as a Bob-ready directory tree.
+
+        Creates:
+        `<output>/<name>-ibm-bob/.bob/skills/<normalized-name>/SKILL.md`
+        """
+        del enable_chunking, chunk_max_tokens, preserve_code_blocks, chunk_overlap_tokens
+
+        skill_dir = Path(skill_dir)
+        output_path = Path(output_path)
+        dir_name = f"{skill_dir.name}-ibm-bob"
+
+        if output_path.is_dir() or str(output_path).endswith("/"):
+            target_dir = output_path / dir_name
+        else:
+            target_dir = output_path
+
+        if target_dir.exists():
+            shutil.rmtree(target_dir)
+        target_dir.mkdir(parents=True, exist_ok=True)
+
+        metadata = self._build_skill_metadata(skill_dir)
+        skill_name = self._to_skill_dir_name(metadata.name or skill_dir.name)
+        bob_skill_dir = target_dir / ".bob" / "skills" / skill_name
+        bob_skill_dir.mkdir(parents=True, exist_ok=True)
+
+        (bob_skill_dir / "SKILL.md").write_text(
+            self.format_skill_md(skill_dir, metadata),
+            encoding="utf-8",
+        )
+
+        for subdir in ("references", "scripts", "assets"):
+            source_dir = skill_dir / subdir
+            if source_dir.exists():
+                shutil.copytree(
+                    source_dir,
+                    bob_skill_dir / subdir,
+                    ignore=shutil.ignore_patterns("*.backup", ".*"),
+                )
+
+        return target_dir
+
+    def upload(self, package_path: Path, api_key: str, **kwargs) -> dict[str, Any]:
+        """IBM Bob uses local project/global folders rather than an upload API."""
+        del api_key, kwargs
+        package_path = Path(package_path)
+        return {
+            "success": True,
+            "skill_id": None,
+            "url": None,
+            "message": f"IBM Bob skill packaged at: {package_path} (local install only)",
+        }
+
+    def validate_api_key(self, api_key: str) -> bool:
+        """No API key needed for IBM Bob."""
+        del api_key
+        return True
+
+    def get_env_var_name(self) -> str:
+        """IBM Bob packaging does not require an API key."""
+        return ""
+
+    def supports_enhancement(self) -> bool:
+        """IBM Bob does not expose a packaging-time enhancement API."""
+        return False

--- a/src/skill_seekers/cli/adaptors/ibm_bob.py
+++ b/src/skill_seekers/cli/adaptors/ibm_bob.py
@@ -12,10 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from .base import SkillAdaptor, SkillMetadata
-from skill_seekers.cli.arguments.common import (
-    DEFAULT_CHUNK_OVERLAP_TOKENS,
-    DEFAULT_CHUNK_TOKENS,
-)
+from skill_seekers.cli.arguments.common import DEFAULT_CHUNK_OVERLAP_TOKENS, DEFAULT_CHUNK_TOKENS
 
 
 class IBMBobAdaptor(SkillAdaptor):
@@ -61,9 +58,7 @@ class IBMBobAdaptor(SkillAdaptor):
 
         tags = metadata.tags or [self._to_skill_dir_name(metadata.name)]
         tag_lines = "\n".join(f"  - {tag}" for tag in tags)
-        author_line = (
-            f"\nauthor: {self._quote_yaml(metadata.author)}" if metadata.author else ""
-        )
+        author_line = f"\nauthor: {self._quote_yaml(metadata.author)}" if metadata.author else ""
 
         frontmatter = (
             f"---\n"

--- a/src/skill_seekers/cli/adaptors/ibm_bob.py
+++ b/src/skill_seekers/cli/adaptors/ibm_bob.py
@@ -12,7 +12,10 @@ from pathlib import Path
 from typing import Any
 
 from .base import SkillAdaptor, SkillMetadata
-from skill_seekers.cli.arguments.common import DEFAULT_CHUNK_OVERLAP_TOKENS, DEFAULT_CHUNK_TOKENS
+from skill_seekers.cli.arguments.common import (
+    DEFAULT_CHUNK_OVERLAP_TOKENS,
+    DEFAULT_CHUNK_TOKENS,
+)
 
 
 class IBMBobAdaptor(SkillAdaptor):
@@ -40,7 +43,8 @@ class IBMBobAdaptor(SkillAdaptor):
     @staticmethod
     def _quote_yaml(value: str) -> str:
         """Quote a YAML string to safely preserve punctuation."""
-        return f'"{value.replace(chr(34), r"\"")}"'
+        escaped = value.replace('"', '\\"')
+        return f'"{escaped}"'
 
     def format_skill_md(self, skill_dir: Path, metadata: SkillMetadata) -> str:
         """
@@ -49,11 +53,17 @@ class IBMBobAdaptor(SkillAdaptor):
         Bob requires `name` and `description` and accepts additional metadata.
         """
         existing_content = self._read_existing_content(skill_dir)
-        body = existing_content if existing_content else f"# {metadata.name}\n\n{metadata.description}\n"
+        body = (
+            existing_content
+            if existing_content
+            else f"# {metadata.name}\n\n{metadata.description}\n"
+        )
 
         tags = metadata.tags or [self._to_skill_dir_name(metadata.name)]
         tag_lines = "\n".join(f"  - {tag}" for tag in tags)
-        author_line = f"\nauthor: {self._quote_yaml(metadata.author)}" if metadata.author else ""
+        author_line = (
+            f"\nauthor: {self._quote_yaml(metadata.author)}" if metadata.author else ""
+        )
 
         frontmatter = (
             f"---\n"

--- a/src/skill_seekers/cli/arguments/package.py
+++ b/src/skill_seekers/cli/arguments/package.py
@@ -51,6 +51,7 @@ PACKAGE_ARGUMENTS: dict[str, dict[str, Any]] = {
                 "openrouter",
                 "together",
                 "fireworks",
+                "ibm-bob",
                 "markdown",
                 "langchain",
                 "llama-index",

--- a/src/skill_seekers/cli/install_agent.py
+++ b/src/skill_seekers/cli/install_agent.py
@@ -51,6 +51,7 @@ AGENT_PATHS = {
     "kilo": ".kilo/skills/",  # Project-relative (Kilo Code, Cline fork)
     "continue": "~/.continue/skills/",  # Global (Continue.dev)
     "kimi-code": "~/.kimi/skills/",  # Global (Kimi Code)
+    "bob": ".bob/skills/",  # Project-relative (IBM Bob)
 }
 
 
@@ -370,7 +371,7 @@ Examples:
 
 Supported agents:
   claude, cursor, vscode, copilot, amp, goose, opencode, letta, aide, windsurf,
-  neovate, roo, cline, aider, bolt, kilo, continue, kimi-code, all
+  neovate, roo, cline, aider, bolt, kilo, continue, kimi-code, bob, all
         """,
     )
 

--- a/src/skill_seekers/cli/package_skill.py
+++ b/src/skill_seekers/cli/package_skill.py
@@ -187,8 +187,13 @@ def package_skill(
         print(f"\n📂 Opening folder: {package_path.parent}")
         open_folder(package_path.parent)
 
-    # Print upload instructions
-    print_upload_instructions(package_path)
+    # Print next-step instructions
+    if adaptor.DEFAULT_API_ENDPOINT:
+        print_upload_instructions(package_path)
+    else:
+        print()
+        print("ℹ️  Local target packaged successfully.")
+        print(f"   Install or copy from: {package_path}")
 
     return True, package_path
 

--- a/src/skill_seekers/cli/parsers/install_agent_parser.py
+++ b/src/skill_seekers/cli/parsers/install_agent_parser.py
@@ -24,7 +24,7 @@ class InstallAgentParser(SubcommandParser):
         parser.add_argument(
             "--agent",
             required=True,
-            help="Agent name (claude, cursor, vscode, amp, goose, opencode, kimi-code, all)",
+            help="Agent name (claude, cursor, vscode, amp, goose, opencode, kimi-code, bob, all)",
         )
         parser.add_argument(
             "--force", action="store_true", help="Overwrite existing installation without asking"

--- a/tests/test_adaptors/test_base.py
+++ b/tests/test_adaptors/test_base.py
@@ -54,6 +54,7 @@ class TestAdaptorRegistry(unittest.TestCase):
         self.assertIsInstance(platforms, list)
         # Claude should always be available
         self.assertIn("claude", platforms)
+        self.assertIn("ibm-bob", platforms)
 
     def test_is_platform_available(self):
         """Test checking platform availability"""

--- a/tests/test_adaptors/test_ibm_bob_adaptor.py
+++ b/tests/test_adaptors/test_ibm_bob_adaptor.py
@@ -67,7 +67,9 @@ class TestIBMBobAdaptor(unittest.TestCase):
     def test_format_with_existing_content(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             skill_dir = Path(temp_dir)
-            existing = "---\nname: test\ndescription: desc\n---\n\n# Existing Content\n\n" + "x" * 200
+            existing = (
+                "---\nname: test\ndescription: desc\n---\n\n# Existing Content\n\n" + "x" * 200
+            )
             (skill_dir / "SKILL.md").write_text(existing)
 
             metadata = SkillMetadata(name="test", description="Test")

--- a/tests/test_adaptors/test_ibm_bob_adaptor.py
+++ b/tests/test_adaptors/test_ibm_bob_adaptor.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""
+Tests for IBM Bob adaptor.
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from skill_seekers.cli.adaptors import get_adaptor, is_platform_available
+from skill_seekers.cli.adaptors.base import SkillMetadata
+from skill_seekers.cli.adaptors.ibm_bob import IBMBobAdaptor
+
+
+class TestIBMBobAdaptor(unittest.TestCase):
+    """Test IBM Bob adaptor functionality."""
+
+    def setUp(self):
+        self.adaptor = get_adaptor("ibm-bob")
+
+    def test_platform_info(self):
+        self.assertEqual(self.adaptor.PLATFORM, "ibm-bob")
+        self.assertEqual(self.adaptor.PLATFORM_NAME, "IBM Bob")
+        self.assertIsNone(self.adaptor.DEFAULT_API_ENDPOINT)
+
+    def test_platform_available(self):
+        self.assertTrue(is_platform_available("ibm-bob"))
+
+    def test_validate_api_key_always_true(self):
+        self.assertTrue(self.adaptor.validate_api_key(""))
+        self.assertTrue(self.adaptor.validate_api_key("anything"))
+
+    def test_no_enhancement_support(self):
+        self.assertFalse(self.adaptor.supports_enhancement())
+
+    def test_upload_returns_local_path(self):
+        result = self.adaptor.upload(Path("/some/path"), "")
+        self.assertTrue(result["success"])
+        self.assertIn("local", result["message"].lower())
+
+    def test_skill_dir_name_normalization(self):
+        self.assertEqual(IBMBobAdaptor._to_skill_dir_name("My Cool Skill"), "my-cool-skill")
+        self.assertEqual(IBMBobAdaptor._to_skill_dir_name("Bob_skill.v2"), "bob-skill-v2")
+        self.assertEqual(IBMBobAdaptor._to_skill_dir_name("!!!"), "skill")
+
+    def test_format_skill_md_has_frontmatter(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            skill_dir = Path(temp_dir)
+            (skill_dir / "references").mkdir()
+            (skill_dir / "references" / "test.md").write_text("# Test content")
+
+            metadata = SkillMetadata(
+                name="django-orm",
+                description="Guide to Django ORM patterns and queries",
+                version="1.2.0",
+                tags=["django", "orm"],
+            )
+            formatted = self.adaptor.format_skill_md(skill_dir, metadata)
+
+            self.assertTrue(formatted.startswith("---"))
+            self.assertIn('name: "django-orm"', formatted)
+            self.assertIn('description: "Guide to Django ORM patterns and queries"', formatted)
+            self.assertIn('version: "1.2.0"', formatted)
+            self.assertIn("tags:", formatted)
+            self.assertIn("- django", formatted)
+
+    def test_format_with_existing_content(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            skill_dir = Path(temp_dir)
+            existing = "---\nname: test\ndescription: desc\n---\n\n# Existing Content\n\n" + "x" * 200
+            (skill_dir / "SKILL.md").write_text(existing)
+
+            metadata = SkillMetadata(name="test", description="Test")
+            formatted = self.adaptor.format_skill_md(skill_dir, metadata)
+
+            self.assertTrue(formatted.startswith("---"))
+            self.assertIn("Existing Content", formatted)
+
+    def test_package_creates_bob_layout(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            skill_dir = Path(temp_dir) / "test-skill"
+            skill_dir.mkdir()
+            (skill_dir / "SKILL.md").write_text(
+                "---\nname: Test Skill\ndescription: Test skill for Bob\nversion: 1.0.0\n---\n\n# Test"
+            )
+            refs = skill_dir / "references"
+            refs.mkdir()
+            (refs / "guide.md").write_text("# Guide")
+
+            output_dir = Path(temp_dir) / "output"
+            output_dir.mkdir()
+
+            result_path = self.adaptor.package(skill_dir, output_dir)
+            bob_skill_dir = result_path / ".bob" / "skills" / "test-skill"
+
+            self.assertTrue(result_path.exists())
+            self.assertTrue(result_path.is_dir())
+            self.assertTrue(bob_skill_dir.exists())
+            self.assertTrue((bob_skill_dir / "SKILL.md").exists())
+            self.assertTrue((bob_skill_dir / "references" / "guide.md").exists())
+
+    def test_package_excludes_backup_files(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            skill_dir = Path(temp_dir) / "test-skill"
+            skill_dir.mkdir()
+            (skill_dir / "SKILL.md").write_text("# Test")
+            refs = skill_dir / "references"
+            refs.mkdir()
+            (refs / "guide.md").write_text("# Guide")
+            (refs / "guide.md.backup").write_text("# Old")
+
+            output_dir = Path(temp_dir) / "output"
+            output_dir.mkdir()
+
+            result_path = self.adaptor.package(skill_dir, output_dir)
+            bob_skill_dir = result_path / ".bob" / "skills" / "test-skill"
+
+            self.assertTrue((bob_skill_dir / "references" / "guide.md").exists())
+            self.assertFalse((bob_skill_dir / "references" / "guide.md.backup").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cli_parsers.py
+++ b/tests/test_cli_parsers.py
@@ -117,6 +117,9 @@ class TestSpecificParsers:
         args = main_parser.parse_args(["package", "output/test/", "--target", "gemini"])
         assert args.target == "gemini"
 
+        args = main_parser.parse_args(["package", "output/test/", "--target", "ibm-bob"])
+        assert args.target == "ibm-bob"
+
         args = main_parser.parse_args(["package", "output/test/", "--no-open"])
         assert args.no_open is True
 

--- a/tests/test_install_agent.py
+++ b/tests/test_install_agent.py
@@ -66,9 +66,9 @@ class TestAgentPathMapping:
             get_agent_path("invalid_agent")
 
     def test_get_available_agents(self):
-        """Test that all 18 agents are listed."""
+        """Test that all 19 agents are listed."""
         agents = get_available_agents()
-        assert len(agents) == 18
+        assert len(agents) == 19
         assert "claude" in agents
         assert "cursor" in agents
         assert "vscode" in agents
@@ -82,6 +82,7 @@ class TestAgentPathMapping:
         assert "kilo" in agents
         assert "continue" in agents
         assert "kimi-code" in agents
+        assert "bob" in agents
         assert sorted(agents) == agents  # Should be sorted
 
     def test_new_agents_project_relative(self):
@@ -361,7 +362,7 @@ class TestInstallToAllAgents:
         shutil.rmtree(self.tmpdir, ignore_errors=True)
 
     def test_install_to_all_success(self):
-        """Test that install_to_all_agents attempts all 18 agents."""
+        """Test that install_to_all_agents attempts all 19 agents."""
         with tempfile.TemporaryDirectory() as agent_tmpdir:
 
             def mock_get_agent_path(agent_name, _project_root=None):
@@ -373,9 +374,10 @@ class TestInstallToAllAgents:
             ):
                 results = install_to_all_agents(self.skill_dir, force=True)
 
-                assert len(results) == 18
+                assert len(results) == 19
                 assert "claude" in results
                 assert "cursor" in results
+                assert "bob" in results
 
     def test_install_to_all_partial_success(self):
         """Test that install_to_all collects both successes and failures."""
@@ -383,7 +385,7 @@ class TestInstallToAllAgents:
         results = install_to_all_agents(self.skill_dir, dry_run=True)
 
         # All should succeed in dry-run mode
-        assert len(results) == 18
+        assert len(results) == 19
         for _agent_name, (success, message) in results.items():
             assert success is True
             assert "DRY RUN" in message
@@ -420,7 +422,7 @@ class TestInstallToAllAgents:
         results = install_to_all_agents(self.skill_dir, dry_run=True)
 
         assert isinstance(results, dict)
-        assert len(results) == 18
+        assert len(results) == 19
 
         for agent_name, (success, message) in results.items():
             assert isinstance(success, bool)

--- a/tests/test_package_skill.py
+++ b/tests/test_package_skill.py
@@ -154,6 +154,25 @@ class TestPackageSkill(unittest.TestCase):
             self.assertTrue(success)
             self.assertEqual(zip_path.name, "my-awesome-skill.zip")
 
+    def test_package_ibm_bob_creates_bob_directory(self):
+        """Test IBM Bob packaging creates a Bob-ready directory layout."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = self.create_test_skill_directory(tmpdir)
+
+            success, package_path = package_skill(
+                skill_dir,
+                open_folder_after=False,
+                skip_quality_check=True,
+                target="ibm-bob",
+            )
+
+            self.assertTrue(success)
+            self.assertIsNotNone(package_path)
+            self.assertTrue(package_path.is_dir())
+            self.assertTrue(
+                (package_path / ".bob" / "skills" / "test-skill" / "SKILL.md").exists()
+            )
+
 
 class TestPackageSkillCLI(unittest.TestCase):
     """Test package_skill.py command-line interface"""

--- a/tests/test_package_skill.py
+++ b/tests/test_package_skill.py
@@ -169,9 +169,7 @@ class TestPackageSkill(unittest.TestCase):
             self.assertTrue(success)
             self.assertIsNotNone(package_path)
             self.assertTrue(package_path.is_dir())
-            self.assertTrue(
-                (package_path / ".bob" / "skills" / "test-skill" / "SKILL.md").exists()
-            )
+            self.assertTrue((package_path / ".bob" / "skills" / "test-skill" / "SKILL.md").exists())
 
 
 class TestPackageSkillCLI(unittest.TestCase):


### PR DESCRIPTION
# Pull Request

## 📋 Description

Adds initial IBM Bob support to Skill Seekers.

This PR introduces a new `ibm-bob` packaging target that exports skills in a Bob-compatible directory layout, and adds `install-agent --agent bob` support for installing skills into project-local `.bob/skills/`.

This is an MVP integration focused on Bob skills packaging and installation. Advanced Bob-specific features such as custom modes and rules are intentionally deferred to a follow-up PR.

## 🔗 Related Issues

- none

## 🎯 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement
- [x] 🧪 Test update

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## 🧪 Testing

Ran focused local tests for the new Bob integration and related CLI surfaces.