### PR TITLE
feat: GitHub issue filtering, per-issue files, and Pinecone frontmatter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,11 @@ MCP_PORT=8765
 # DOCKER_CPU_LIMIT=2.0
 # DOCKER_MEMORY_LIMIT=4g
 
+# Pinecone API (Optional)
+# Required for Pinecone vector database upload
+# Get your key from: https://app.pinecone.io/
+PINECONE_API_KEY=
+
 # Vector Database Ports (Optional - change if needed)
 # WEAVIATE_PORT=8080
 # QDRANT_PORT=6333

--- a/src/skill_seekers/cli/adaptors/pinecone_adaptor.py
+++ b/src/skill_seekers/cli/adaptors/pinecone_adaptor.py
@@ -38,6 +38,34 @@ class PineconeAdaptor(SkillAdaptor):
         """Generate deterministic ID from content and metadata."""
         return self._generate_deterministic_id(content, metadata, format="hex")
 
+    @staticmethod
+    def _parse_ref_frontmatter(content: str) -> tuple[dict[str, Any], str]:
+        """Parse YAML frontmatter from reference file content.
+
+        Args:
+            content: File content potentially starting with ``---`` frontmatter
+
+        Returns:
+            Tuple of (frontmatter dict, content with frontmatter stripped).
+            If no frontmatter, returns ({}, original content).
+        """
+        if not content.startswith("---"):
+            return {}, content
+
+        parts = content.split("---", 2)
+        if len(parts) < 3:
+            return {}, content
+
+        try:
+            import yaml
+
+            fm = yaml.safe_load(parts[1])
+            if not isinstance(fm, dict):
+                return {}, content
+            return fm, parts[2].lstrip("\n")
+        except Exception:
+            return {}, content
+
     def _truncate_text_for_metadata(
         self, text: str, max_bytes: int = PINECONE_METADATA_BYTES_LIMIT
     ) -> str:
@@ -143,6 +171,9 @@ class PineconeAdaptor(SkillAdaptor):
             if ref_content.strip():
                 category = ref_file.stem.replace("_", " ").lower()
 
+                # Parse YAML frontmatter from per-issue files
+                frontmatter_fields, stripped_content = self._parse_ref_frontmatter(ref_content)
+
                 doc_metadata = {
                     "source": metadata.name,
                     "category": category,
@@ -151,6 +182,23 @@ class PineconeAdaptor(SkillAdaptor):
                     "version": metadata.version,
                     "doc_version": metadata.doc_version,
                 }
+
+                # Merge frontmatter fields into metadata for issue files
+                if frontmatter_fields.get("type") == "github_issue":
+                    doc_metadata["type"] = "github_issue"
+                    doc_metadata["category"] = f"{ref_file.stem}"
+                    for key in (
+                        "issue_number",
+                        "title",
+                        "state",
+                        "labels",
+                        "created_at",
+                        "updated_at",
+                        "url",
+                    ):
+                        if key in frontmatter_fields:
+                            doc_metadata[key] = frontmatter_fields[key]
+                    ref_content = stripped_content
 
                 chunks = self._maybe_chunk_content(
                     ref_content,

--- a/src/skill_seekers/cli/arguments/create.py
+++ b/src/skill_seekers/cli/arguments/create.py
@@ -356,9 +356,16 @@ GITHUB_ARGUMENTS: dict[str, dict[str, Any]] = {
         "flags": ("--max-comments",),
         "kwargs": {
             "type": int,
-            "default": 50,
-            "help": "Max comments to fetch per issue (default: 50)",
+            "default": 0,
+            "help": "Fetch up to N comments per issue (default: 0, disabled)",
             "metavar": "N",
+        },
+    },
+    "per_issue_files": {
+        "flags": ("--per-issue-files",),
+        "kwargs": {
+            "action": "store_true",
+            "help": "Write individual markdown files per issue (with YAML frontmatter)",
         },
     },
     "scrape_only": {

--- a/src/skill_seekers/cli/arguments/create.py
+++ b/src/skill_seekers/cli/arguments/create.py
@@ -325,6 +325,42 @@ GITHUB_ARGUMENTS: dict[str, dict[str, Any]] = {
             "help": "Max issues to fetch (default: 100)",
         },
     },
+    "since": {
+        "flags": ("--since",),
+        "kwargs": {
+            "type": str,
+            "default": None,
+            "help": "Only fetch issues updated after this date (ISO8601 or YYYY-MM-DD)",
+            "metavar": "DATE",
+        },
+    },
+    "issue_labels": {
+        "flags": ("--issue-labels",),
+        "kwargs": {
+            "type": str,
+            "default": None,
+            "help": "Filter issues by labels (comma-separated)",
+            "metavar": "LABELS",
+        },
+    },
+    "issue_state": {
+        "flags": ("--issue-state",),
+        "kwargs": {
+            "type": str,
+            "default": None,
+            "choices": ["open", "closed", "all"],
+            "help": "Filter issues by state (default: all)",
+        },
+    },
+    "max_comments": {
+        "flags": ("--max-comments",),
+        "kwargs": {
+            "type": int,
+            "default": 50,
+            "help": "Max comments to fetch per issue (default: 50)",
+            "metavar": "N",
+        },
+    },
     "scrape_only": {
         "flags": ("--scrape-only",),
         "kwargs": {

--- a/src/skill_seekers/cli/arguments/create.py
+++ b/src/skill_seekers/cli/arguments/create.py
@@ -330,7 +330,7 @@ GITHUB_ARGUMENTS: dict[str, dict[str, Any]] = {
         "kwargs": {
             "type": str,
             "default": None,
-            "help": "Only fetch issues updated after this date (ISO8601 or YYYY-MM-DD)",
+            "help": "Only fetch issues updated after this date (ISO8601, UTC 'Z' suffix accepted, or YYYY-MM-DD)",
             "metavar": "DATE",
         },
     },
@@ -357,7 +357,7 @@ GITHUB_ARGUMENTS: dict[str, dict[str, Any]] = {
         "kwargs": {
             "type": int,
             "default": 0,
-            "help": "Fetch up to N comments per issue (default: 0, disabled)",
+            "help": "Fetch up to N comments per issue (default: 0, disabled; costs 1+ extra API call per issue, paginated)",
             "metavar": "N",
         },
     },

--- a/src/skill_seekers/cli/arguments/github.py
+++ b/src/skill_seekers/cli/arguments/github.py
@@ -81,7 +81,7 @@ GITHUB_ARGUMENTS: dict[str, dict[str, Any]] = {
         "kwargs": {
             "type": str,
             "default": None,
-            "help": "Only fetch issues updated after this date (ISO8601 or YYYY-MM-DD, e.g. 2026-01-01)",
+            "help": "Only fetch issues updated after this date (ISO8601, UTC 'Z' suffix accepted, or YYYY-MM-DD; e.g. 2026-01-01T00:00:00Z)",
             "metavar": "DATE",
         },
     },
@@ -108,7 +108,7 @@ GITHUB_ARGUMENTS: dict[str, dict[str, Any]] = {
         "kwargs": {
             "type": int,
             "default": 0,
-            "help": "Fetch up to N comments per issue (default: 0, disabled)",
+            "help": "Fetch up to N comments per issue (default: 0, disabled; costs 1+ extra API call per issue, paginated)",
             "metavar": "N",
         },
     },

--- a/src/skill_seekers/cli/arguments/github.py
+++ b/src/skill_seekers/cli/arguments/github.py
@@ -107,9 +107,16 @@ GITHUB_ARGUMENTS: dict[str, dict[str, Any]] = {
         "flags": ("--max-comments",),
         "kwargs": {
             "type": int,
-            "default": 50,
-            "help": "Max comments to fetch per issue (default: 50)",
+            "default": 0,
+            "help": "Fetch up to N comments per issue (default: 0, disabled)",
             "metavar": "N",
+        },
+    },
+    "per_issue_files": {
+        "flags": ("--per-issue-files",),
+        "kwargs": {
+            "action": "store_true",
+            "help": "Write individual markdown files per issue (with YAML frontmatter)",
         },
     },
     # Control options

--- a/src/skill_seekers/cli/arguments/github.py
+++ b/src/skill_seekers/cli/arguments/github.py
@@ -76,6 +76,42 @@ GITHUB_ARGUMENTS: dict[str, dict[str, Any]] = {
             "metavar": "N",
         },
     },
+    "since": {
+        "flags": ("--since",),
+        "kwargs": {
+            "type": str,
+            "default": None,
+            "help": "Only fetch issues updated after this date (ISO8601 or YYYY-MM-DD, e.g. 2026-01-01)",
+            "metavar": "DATE",
+        },
+    },
+    "issue_labels": {
+        "flags": ("--issue-labels",),
+        "kwargs": {
+            "type": str,
+            "default": None,
+            "help": "Filter issues by labels (comma-separated, e.g. bug,enhancement)",
+            "metavar": "LABELS",
+        },
+    },
+    "issue_state": {
+        "flags": ("--issue-state",),
+        "kwargs": {
+            "type": str,
+            "default": None,
+            "choices": ["open", "closed", "all"],
+            "help": "Filter issues by state (default: all)",
+        },
+    },
+    "max_comments": {
+        "flags": ("--max-comments",),
+        "kwargs": {
+            "type": int,
+            "default": 50,
+            "help": "Max comments to fetch per issue (default: 50)",
+            "metavar": "N",
+        },
+    },
     # Control options
     "scrape_only": {
         "flags": ("--scrape-only",),

--- a/src/skill_seekers/cli/config_validator.py
+++ b/src/skill_seekers/cli/config_validator.py
@@ -275,6 +275,41 @@ class UniSkillConfigValidator:
         if "max_issues" in source and not isinstance(source["max_issues"], int):
             raise ValueError(f"Source {index} (github): 'max_issues' must be an integer")
 
+        # Validate issue_since if specified (ISO8601 date string)
+        if "issue_since" in source:
+            issue_since = source["issue_since"]
+            if not isinstance(issue_since, str):
+                raise ValueError(
+                    f"Source {index} (github): 'issue_since' must be an ISO8601 date string"
+                )
+            from datetime import datetime
+
+            try:
+                datetime.fromisoformat(issue_since)
+            except ValueError as err:
+                raise ValueError(
+                    f"Source {index} (github): 'issue_since' is not a valid ISO8601 date: '{issue_since}'"
+                ) from err
+
+        # Validate issue_labels if specified
+        if "issue_labels" in source:
+            issue_labels = source["issue_labels"]
+            if not isinstance(issue_labels, list) or not all(
+                isinstance(label, str) for label in issue_labels
+            ):
+                raise ValueError(
+                    f"Source {index} (github): 'issue_labels' must be a list of strings"
+                )
+
+        # Validate issue_state if specified
+        if "issue_state" in source:
+            valid_issue_states = {"open", "closed", "all"}
+            if source["issue_state"] not in valid_issue_states:
+                raise ValueError(
+                    f"Source {index} (github): Invalid issue_state '{source['issue_state']}'. "
+                    f"Must be one of {valid_issue_states}"
+                )
+
         # Validate enable_codebase_analysis if specified (C3.5)
         if "enable_codebase_analysis" in source and not isinstance(
             source["enable_codebase_analysis"], bool

--- a/src/skill_seekers/cli/config_validator.py
+++ b/src/skill_seekers/cli/config_validator.py
@@ -284,8 +284,9 @@ class UniSkillConfigValidator:
                 )
             from datetime import datetime
 
+            since_str = issue_since[:-1] + "+00:00" if issue_since.endswith("Z") else issue_since
             try:
-                datetime.fromisoformat(issue_since)
+                datetime.fromisoformat(since_str)
             except ValueError as err:
                 raise ValueError(
                     f"Source {index} (github): 'issue_since' is not a valid ISO8601 date: '{issue_since}'"

--- a/src/skill_seekers/cli/create_command.py
+++ b/src/skill_seekers/cli/create_command.py
@@ -229,6 +229,14 @@ class CreateCommand:
                     "local_repo_path": getattr(self.args, "local_repo_path", None),
                     "include_issues": getattr(self.args, "include_issues", True),
                     "max_issues": getattr(self.args, "max_issues", 100),
+                    "max_comments": getattr(self.args, "max_comments", 50),
+                    "issue_labels": (
+                        [lab.strip() for lab in self.args.issue_labels.split(",") if lab.strip()]
+                        if getattr(self.args, "issue_labels", None)
+                        else []
+                    ),
+                    "issue_state": getattr(self.args, "issue_state", None) or "all",
+                    "issue_since": getattr(self.args, "since", None),
                     "include_changelog": getattr(self.args, "include_changelog", True),
                     "include_releases": getattr(self.args, "include_releases", True),
                     "include_code": getattr(self.args, "include_code", True),

--- a/src/skill_seekers/cli/create_command.py
+++ b/src/skill_seekers/cli/create_command.py
@@ -229,7 +229,8 @@ class CreateCommand:
                     "local_repo_path": getattr(self.args, "local_repo_path", None),
                     "include_issues": getattr(self.args, "include_issues", True),
                     "max_issues": getattr(self.args, "max_issues", 100),
-                    "max_comments": getattr(self.args, "max_comments", 50),
+                    "max_comments": getattr(self.args, "max_comments", 0),
+                    "per_issue_files": getattr(self.args, "per_issue_files", False),
                     "issue_labels": (
                         [lab.strip() for lab in self.args.issue_labels.split(",") if lab.strip()]
                         if getattr(self.args, "issue_labels", None)

--- a/src/skill_seekers/cli/github_fetcher.py
+++ b/src/skill_seekers/cli/github_fetcher.py
@@ -82,6 +82,9 @@ class GitHubThreeStreamFetcher:
         github_token: str | None = None,
         interactive: bool = True,
         profile_name: str | None = None,
+        issue_since: str | None = None,
+        issue_labels: list[str] | None = None,
+        issue_state: str | None = None,
     ):
         """
         Initialize fetcher.
@@ -91,11 +94,17 @@ class GitHubThreeStreamFetcher:
             github_token: Optional GitHub API token for higher rate limits
             interactive: Whether to show interactive prompts (False for CI/CD)
             profile_name: Name of the GitHub profile being used
+            issue_since: Only fetch issues updated after this ISO8601 date
+            issue_labels: Filter issues by these label names
+            issue_state: Filter issues by state ("open", "closed", or "all")
         """
         self.repo_url = repo_url
         self.github_token = github_token or os.getenv("GITHUB_TOKEN")
         self.owner, self.repo = self.parse_repo_url(repo_url)
         self.interactive = interactive
+        self.issue_since = issue_since
+        self.issue_labels = issue_labels or []
+        self.issue_state = issue_state or "all"
 
         # Initialize rate limit handler
         config = get_config_manager()
@@ -267,7 +276,7 @@ class GitHubThreeStreamFetcher:
 
     def fetch_issues(self, max_issues: int = 100) -> list[dict]:
         """
-        Fetch GitHub issues (open + closed).
+        Fetch GitHub issues with optional state/label/since filters.
 
         Args:
             max_issues: Maximum number of issues to fetch
@@ -277,11 +286,13 @@ class GitHubThreeStreamFetcher:
         """
         all_issues = []
 
-        # Fetch open issues
-        all_issues.extend(self._fetch_issues_page(state="open", max_count=max_issues // 2))
-
-        # Fetch closed issues
-        all_issues.extend(self._fetch_issues_page(state="closed", max_count=max_issues // 2))
+        if self.issue_state in ("open", "closed"):
+            # Single-state fetch: use full quota
+            all_issues.extend(self._fetch_issues_page(state=self.issue_state, max_count=max_issues))
+        else:
+            # Default "all": split quota between open and closed
+            all_issues.extend(self._fetch_issues_page(state="open", max_count=max_issues // 2))
+            all_issues.extend(self._fetch_issues_page(state="closed", max_count=max_issues // 2))
 
         return all_issues
 
@@ -308,6 +319,10 @@ class GitHubThreeStreamFetcher:
             "sort": "comments",
             "direction": "desc",
         }
+        if self.issue_since:
+            params["since"] = self.issue_since
+        if self.issue_labels:
+            params["labels"] = ",".join(self.issue_labels)
 
         try:
             response = requests.get(url, headers=headers, params=params, timeout=10)

--- a/src/skill_seekers/cli/github_scraper.py
+++ b/src/skill_seekers/cli/github_scraper.py
@@ -259,10 +259,11 @@ class GitHubScraper(SkillConverter):
         # Options
         self.include_issues = config.get("include_issues", True)
         self.max_issues = config.get("max_issues", 100)
-        self.max_comments = config.get("max_comments", 50)
+        self.max_comments = config.get("max_comments", 0)
         self.issue_since = config.get("issue_since")
         self.issue_labels = config.get("issue_labels", [])
         self.issue_state = config.get("issue_state", "all")
+        self.per_issue_files = config.get("per_issue_files", False)
         self.include_changelog = config.get("include_changelog", True)
         self.include_releases = config.get("include_releases", True)
         self.include_code = config.get("include_code", True)
@@ -860,21 +861,24 @@ class GitHubScraper(SkillConverter):
                 if issue.pull_request:
                     continue
 
-                # Fetch comments for this issue
+                # Fetch comments only when explicitly requested
                 comments_list = []
-                try:
-                    for comment in issue.get_comments()[: self.max_comments]:
-                        comments_list.append(
-                            {
-                                "author": comment.user.login if comment.user else "unknown",
-                                "created_at": (
-                                    comment.created_at.isoformat() if comment.created_at else None
-                                ),
-                                "body": comment.body,
-                            }
-                        )
-                except Exception as e:
-                    logger.debug(f"Could not fetch comments for issue #{issue.number}: {e}")
+                if self.max_comments > 0:
+                    try:
+                        for comment in issue.get_comments()[: self.max_comments]:
+                            comments_list.append(
+                                {
+                                    "author": comment.user.login if comment.user else "unknown",
+                                    "created_at": (
+                                        comment.created_at.isoformat()
+                                        if comment.created_at
+                                        else None
+                                    ),
+                                    "body": comment.body,
+                                }
+                            )
+                    except Exception as e:
+                        logger.debug(f"Could not fetch comments for issue #{issue.number}: {e}")
 
                 issue_data = {
                     "number": issue.number,
@@ -886,7 +890,11 @@ class GitHubScraper(SkillConverter):
                     "updated_at": issue.updated_at.isoformat() if issue.updated_at else None,
                     "closed_at": issue.closed_at.isoformat() if issue.closed_at else None,
                     "url": issue.html_url,
-                    "body": issue.body or None,
+                    "body": (
+                        issue.body or None
+                        if self.per_issue_files
+                        else (issue.body[:500] if issue.body else None)
+                    ),  # Full body for per-issue files, truncated otherwise
                     "comments": comments_list,
                 }
                 issue_list.append(issue_data)
@@ -973,6 +981,7 @@ class GitHubToSkillConverter:
         self.config = config
         self.name = config.get("name", config["repo"].split("/")[-1])
         self.repo_short_name = config["repo"].split("/")[-1]
+        self.per_issue_files = config.get("per_issue_files", False)
 
         # Paths
         self.data_file = f"output/{self.name}_github_data.json"
@@ -1384,9 +1393,11 @@ Use this skill when you need to:
             f.write(content)
         logger.info(f"Generated: {issues_path}")
 
-        # --- Per-issue files ---
-        for issue in issues:
-            self._write_per_issue_file(issue)
+        # --- Per-issue files (opt-in) ---
+        if self.per_issue_files:
+            for issue in issues:
+                self._write_per_issue_file(issue)
+            logger.info(f"Generated {len(issues)} per-issue files")
 
     def _write_per_issue_file(self, issue: dict):
         """Write a single per-issue markdown file with YAML frontmatter.
@@ -1536,7 +1547,8 @@ def main():
         print(f"Include releases: {not getattr(args, 'no_releases', False)}")
         print(f"Include changelog: {not getattr(args, 'no_changelog', False)}")
         print(f"Max issues:     {getattr(args, 'max_issues', 100)}")
-        print(f"Max comments:   {getattr(args, 'max_comments', 50)}")
+        print(f"Max comments:   {getattr(args, 'max_comments', 0)}")
+        print(f"Per-issue files: {getattr(args, 'per_issue_files', False)}")
         since = getattr(args, "since", None)
         issue_labels = getattr(args, "issue_labels", None)
         issue_state = getattr(args, "issue_state", None)
@@ -1570,7 +1582,8 @@ def main():
             "include_changelog": not args.no_changelog,
             "include_releases": not args.no_releases,
             "max_issues": args.max_issues,
-            "max_comments": getattr(args, "max_comments", 50),
+            "max_comments": getattr(args, "max_comments", 0),
+            "per_issue_files": getattr(args, "per_issue_files", False),
             "issue_since": getattr(args, "since", None),
             "issue_labels": (
                 [lab.strip() for lab in args.issue_labels.split(",") if lab.strip()]

--- a/src/skill_seekers/cli/github_scraper.py
+++ b/src/skill_seekers/cli/github_scraper.py
@@ -14,7 +14,6 @@ Usage:
     skill-seekers github --repo owner/repo --token $GITHUB_TOKEN
 """
 
-import argparse
 import fnmatch
 import itertools
 import json
@@ -32,9 +31,7 @@ except ImportError:
     print("Error: PyGithub not installed. Run: pip install PyGithub")
     sys.exit(1)
 
-from skill_seekers.cli.arguments.github import add_github_arguments
 from skill_seekers.cli.skill_converter import SkillConverter
-from skill_seekers.cli.utils import setup_logging
 
 # Try to import pathspec for .gitignore support
 try:
@@ -846,11 +843,16 @@ class GitHubScraper(SkillConverter):
                 "direction": "desc",
             }
             if self.issue_labels:
-                kwargs["labels"] = [self.repo.get_label(name) for name in self.issue_labels]
+                kwargs["labels"] = self.issue_labels
             if self.issue_since:
                 from datetime import datetime
 
-                kwargs["since"] = datetime.fromisoformat(self.issue_since)
+                since_str = (
+                    self.issue_since[:-1] + "+00:00"
+                    if self.issue_since.endswith("Z")
+                    else self.issue_since
+                )
+                kwargs["since"] = datetime.fromisoformat(since_str)
 
             # Fetch issues with filters
             issues = self.repo.get_issues(**kwargs)
@@ -880,6 +882,10 @@ class GitHubScraper(SkillConverter):
                     except Exception as e:
                         logger.debug(f"Could not fetch comments for issue #{issue.number}: {e}")
 
+                # data.json body field: with per_issue_files=True the full body is
+                # mirrored here AND in references/issues/*.md. With per_issue_files=False
+                # we keep only a 500-char preview to keep data.json small. Downstream
+                # packagers needing the full text should fetch the live issue.
                 issue_data = {
                     "number": issue.number,
                     "title": issue.title,
@@ -894,7 +900,7 @@ class GitHubScraper(SkillConverter):
                         issue.body or None
                         if self.per_issue_files
                         else (issue.body[:500] if issue.body else None)
-                    ),  # Full body for per-issue files, truncated otherwise
+                    ),
                     "comments": comments_list,
                 }
                 issue_list.append(issue_data)
@@ -980,6 +986,7 @@ class GitHubToSkillConverter:
         """Initialize converter with configuration."""
         self.config = config
         self.name = config.get("name", config["repo"].split("/")[-1])
+        self.repo_owner = config["repo"].split("/")[0]
         self.repo_short_name = config["repo"].split("/")[-1]
         self.per_issue_files = config.get("per_issue_files", False)
 
@@ -1116,6 +1123,10 @@ Use this skill when you need to:
         skill_content += "- `references/README.md` - Complete README documentation\n"
         skill_content += "- `references/CHANGELOG.md` - Version history and changes\n"
         skill_content += "- `references/issues.md` - Recent GitHub issues\n"
+        if self.per_issue_files:
+            skill_content += (
+                "- `references/issues/` - Per-issue markdown files with YAML frontmatter\n"
+            )
         skill_content += "- `references/releases.md` - Release notes\n"
         skill_content += "- `references/file_structure.md` - Repository structure\n"
 
@@ -1395,6 +1406,7 @@ Use this skill when you need to:
 
         # --- Per-issue files (opt-in) ---
         if self.per_issue_files:
+            os.makedirs(f"{self.skill_dir}/references/issues", exist_ok=True)
             for issue in issues:
                 self._write_per_issue_file(issue)
             logger.info(f"Generated {len(issues)} per-issue files")
@@ -1448,8 +1460,8 @@ url: "{url}"
                 comment_body = comment.get("body", "")
                 file_content += f"\n### {author} — {comment_date}\n{comment_body}\n\n---\n"
 
-        filename = f"{self.repo_short_name}_{number}.md"
-        filepath = f"{self.skill_dir}/references/{filename}"
+        filename = f"{self.repo_owner}-{self.repo_short_name}-{number}.md"
+        filepath = f"{self.skill_dir}/references/issues/{filename}"
         with open(filepath, "w", encoding="utf-8") as f:
             f.write(file_content)
         logger.debug(f"Generated per-issue file: {filepath}")
@@ -1498,200 +1510,3 @@ url: "{url}"
         with open(structure_path, "w", encoding="utf-8") as f:
             f.write(content)
         logger.info(f"Generated: {structure_path}")
-
-
-def setup_argument_parser() -> argparse.ArgumentParser:
-    """Setup and configure command-line argument parser.
-
-    Creates an ArgumentParser with all CLI options for the github scraper.
-    All arguments are defined in skill_seekers.cli.arguments.github to ensure
-    consistency between the standalone scraper and unified CLI.
-
-    Returns:
-        argparse.ArgumentParser: Configured argument parser
-    """
-    parser = argparse.ArgumentParser(
-        description="GitHub Repository to Claude Skill Converter",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog="""
-Examples:
-  skill-seekers github --repo facebook/react
-  skill-seekers github --config configs/react_github.json
-  skill-seekers github --repo owner/repo --token $GITHUB_TOKEN
-        """,
-    )
-
-    # Add all github arguments from shared definitions
-    # This ensures the standalone scraper and unified CLI stay in sync
-    add_github_arguments(parser)
-
-    return parser
-
-
-def main():
-    """C1.10: CLI tool entry point."""
-    parser = setup_argument_parser()
-    args = parser.parse_args()
-
-    setup_logging(verbose=getattr(args, "verbose", False), quiet=getattr(args, "quiet", False))
-
-    # Handle --dry-run
-    if getattr(args, "dry_run", False):
-        repo = args.repo or (args.config and "(from config)")
-        print(f"\n{'=' * 60}")
-        print(f"DRY RUN: GitHub Repository Analysis")
-        print(f"{'=' * 60}")
-        print(f"Repository:     {repo}")
-        print(f"Name:           {getattr(args, 'name', None) or '(auto-detect)'}")
-        print(f"Include issues: {not getattr(args, 'no_issues', False)}")
-        print(f"Include releases: {not getattr(args, 'no_releases', False)}")
-        print(f"Include changelog: {not getattr(args, 'no_changelog', False)}")
-        print(f"Max issues:     {getattr(args, 'max_issues', 100)}")
-        print(f"Max comments:   {getattr(args, 'max_comments', 0)}")
-        print(f"Per-issue files: {getattr(args, 'per_issue_files', False)}")
-        since = getattr(args, "since", None)
-        issue_labels = getattr(args, "issue_labels", None)
-        issue_state = getattr(args, "issue_state", None)
-        if since:
-            print(f"Since:          {since}")
-        if issue_labels:
-            print(f"Issue labels:   {issue_labels}")
-        if issue_state:
-            print(f"Issue state:    {issue_state}")
-        print(f"Enhance level:  {getattr(args, 'enhance_level', 0)}")
-        print(f"Profile:        {getattr(args, 'profile', None) or '(default)'}")
-        print(f"\n✅ Dry run complete")
-        return 0
-
-    # Build config from args or file
-    if args.config:
-        with open(args.config, encoding="utf-8") as f:
-            config = json.load(f)
-        # Override with CLI args if provided
-        if args.non_interactive:
-            config["interactive"] = False
-        if args.profile:
-            config["github_profile"] = args.profile
-    elif args.repo:
-        config = {
-            "repo": args.repo,
-            "name": args.name or args.repo.split("/")[-1],
-            "description": args.description or f"Use when working with {args.repo.split('/')[-1]}",
-            "github_token": args.token,
-            "include_issues": not args.no_issues,
-            "include_changelog": not args.no_changelog,
-            "include_releases": not args.no_releases,
-            "max_issues": args.max_issues,
-            "max_comments": getattr(args, "max_comments", 0),
-            "per_issue_files": getattr(args, "per_issue_files", False),
-            "issue_since": getattr(args, "since", None),
-            "issue_labels": (
-                [lab.strip() for lab in args.issue_labels.split(",") if lab.strip()]
-                if getattr(args, "issue_labels", None)
-                else []
-            ),
-            "issue_state": getattr(args, "issue_state", None) or "all",
-            "interactive": not args.non_interactive,
-            "github_profile": args.profile,
-            "local_repo_path": getattr(args, "local_repo_path", None),
-        }
-    else:
-        parser.error("Either --repo or --config is required")
-
-    try:
-        # Phase 1: Scrape GitHub repository
-        scraper = GitHubScraper(config)
-        scraper.scrape()
-
-        if args.scrape_only:
-            logger.info("Scrape complete (--scrape-only mode)")
-            return
-
-        # Phase 2: Build skill
-        converter = GitHubToSkillConverter(config)
-        converter.build_skill()
-
-        skill_name = config.get("name", config["repo"].split("/")[-1])
-        skill_dir = f"output/{skill_name}"
-
-        # ============================================================
-        # WORKFLOW SYSTEM INTEGRATION (Phase 2 - github_scraper)
-        # ============================================================
-        from skill_seekers.cli.workflow_runner import run_workflows
-
-        # Pass GitHub-specific context to workflows
-        github_context = {
-            "repo": config.get("repo", ""),
-            "name": skill_name,
-            "description": config.get("description", ""),
-        }
-
-        workflow_executed, workflow_names = run_workflows(args, context=github_context)
-        workflow_name = ", ".join(workflow_names) if workflow_names else None
-
-        # Phase 3: Optional enhancement with auto-detected mode
-        # Note: Runs independently of workflow system (they complement each other)
-        if getattr(args, "enhance_level", 0) > 0:
-            import os
-
-            # Auto-detect mode based on API key availability
-            api_key = args.api_key or os.environ.get("ANTHROPIC_API_KEY")
-            mode = "API" if api_key else "LOCAL"
-
-            logger.info("\n" + "=" * 80)
-            logger.info(f"🤖 Traditional AI Enhancement ({mode} mode, level {args.enhance_level})")
-            logger.info("=" * 80)
-            if workflow_executed:
-                logger.info(f"   Running after workflow: {workflow_name}")
-                logger.info(
-                    "   (Workflow provides specialized analysis, enhancement provides general improvements)"
-                )
-            logger.info("")
-
-            if api_key:
-                # API-based enhancement
-                try:
-                    from skill_seekers.cli.enhance_skill import enhance_skill_md
-
-                    enhance_skill_md(skill_dir, api_key)
-                    logger.info("✅ API enhancement complete!")
-                except ImportError:
-                    logger.error("❌ API enhancement not available. Install: pip install anthropic")
-                    logger.info("💡 Falling back to LOCAL mode...")
-                    # Fall back to LOCAL mode
-                    from pathlib import Path
-                    from skill_seekers.cli.enhance_skill_local import LocalSkillEnhancer
-
-                    enhancer = LocalSkillEnhancer(Path(skill_dir))
-                    enhancer.run(headless=True)
-                    logger.info("✅ Local enhancement complete!")
-            else:
-                # LOCAL enhancement (no API key)
-                from pathlib import Path
-                from skill_seekers.cli.enhance_skill_local import LocalSkillEnhancer
-
-                enhancer = LocalSkillEnhancer(Path(skill_dir))
-                enhancer.run(headless=True)
-                logger.info("✅ Local enhancement complete!")
-
-        logger.info(f"\n✅ Success! Skill created at: {skill_dir}/")
-
-        # Only suggest enhancement if neither workflow nor traditional enhancement was done
-        if not workflow_executed and getattr(args, "enhance_level", 0) == 0:
-            logger.info("\n💡 Optional: Enhance SKILL.md with Claude:")
-            logger.info(f"  skill-seekers enhance {skill_dir}/ --enhance-level 2")
-            logger.info("  (auto-detects API vs LOCAL mode based on ANTHROPIC_API_KEY)")
-            logger.info("\n💡 Or use a workflow:")
-            logger.info(
-                f"  skill-seekers github --repo {config['repo']} --enhance-workflow architecture-comprehensive"
-            )
-
-        logger.info(f"\nNext step: skill-seekers package {skill_dir}/")
-
-    except Exception as e:
-        logger.error(f"Error: {e}")
-        sys.exit(1)
-
-
-if __name__ == "__main__":
-    main()

--- a/src/skill_seekers/cli/github_scraper.py
+++ b/src/skill_seekers/cli/github_scraper.py
@@ -14,6 +14,7 @@ Usage:
     skill-seekers github --repo owner/repo --token $GITHUB_TOKEN
 """
 
+import argparse
 import fnmatch
 import itertools
 import json
@@ -31,7 +32,9 @@ except ImportError:
     print("Error: PyGithub not installed. Run: pip install PyGithub")
     sys.exit(1)
 
+from skill_seekers.cli.arguments.github import add_github_arguments
 from skill_seekers.cli.skill_converter import SkillConverter
+from skill_seekers.cli.utils import setup_logging
 
 # Try to import pathspec for .gitignore support
 try:
@@ -256,6 +259,10 @@ class GitHubScraper(SkillConverter):
         # Options
         self.include_issues = config.get("include_issues", True)
         self.max_issues = config.get("max_issues", 100)
+        self.max_comments = config.get("max_comments", 50)
+        self.issue_since = config.get("issue_since")
+        self.issue_labels = config.get("issue_labels", [])
+        self.issue_state = config.get("issue_state", "all")
         self.include_changelog = config.get("include_changelog", True)
         self.include_releases = config.get("include_releases", True)
         self.include_code = config.get("include_code", True)
@@ -831,14 +838,43 @@ class GitHubScraper(SkillConverter):
         logger.info(f"Extracting GitHub Issues (max {self.max_issues})...")
 
         try:
-            # Fetch recent issues (open + closed)
-            issues = self.repo.get_issues(state="all", sort="updated", direction="desc")
+            # Build kwargs for get_issues
+            kwargs: dict[str, Any] = {
+                "state": self.issue_state or "all",
+                "sort": "updated",
+                "direction": "desc",
+            }
+            if self.issue_labels:
+                kwargs["labels"] = [self.repo.get_label(name) for name in self.issue_labels]
+            if self.issue_since:
+                from datetime import datetime
+
+                kwargs["since"] = datetime.fromisoformat(self.issue_since)
+
+            # Fetch issues with filters
+            issues = self.repo.get_issues(**kwargs)
 
             issue_list = []
             for issue in itertools.islice(issues, self.max_issues):
                 # Skip pull requests (they appear in issues)
                 if issue.pull_request:
                     continue
+
+                # Fetch comments for this issue
+                comments_list = []
+                try:
+                    for comment in issue.get_comments()[: self.max_comments]:
+                        comments_list.append(
+                            {
+                                "author": comment.user.login if comment.user else "unknown",
+                                "created_at": (
+                                    comment.created_at.isoformat() if comment.created_at else None
+                                ),
+                                "body": comment.body,
+                            }
+                        )
+                except Exception as e:
+                    logger.debug(f"Could not fetch comments for issue #{issue.number}: {e}")
 
                 issue_data = {
                     "number": issue.number,
@@ -850,7 +886,8 @@ class GitHubScraper(SkillConverter):
                     "updated_at": issue.updated_at.isoformat() if issue.updated_at else None,
                     "closed_at": issue.closed_at.isoformat() if issue.closed_at else None,
                     "url": issue.html_url,
-                    "body": issue.body[:500] if issue.body else None,  # First 500 chars
+                    "body": issue.body or None,
+                    "comments": comments_list,
                 }
                 issue_list.append(issue_data)
 
@@ -935,6 +972,7 @@ class GitHubToSkillConverter:
         """Initialize converter with configuration."""
         self.config = config
         self.name = config.get("name", config["repo"].split("/")[-1])
+        self.repo_short_name = config["repo"].split("/")[-1]
 
         # Paths
         self.data_file = f"output/{self.name}_github_data.json"
@@ -1315,9 +1353,10 @@ Use this skill when you need to:
             self._generate_file_structure_reference()
 
     def _generate_issues_reference(self):
-        """Generate issues.md reference file."""
+        """Generate issues.md summary and per-issue reference files."""
         issues = self.data["issues"]
 
+        # --- Summary file (issues.md) ---
         content = f"# GitHub Issues\n\nRecent issues from the repository ({len(issues)} total).\n\n"
 
         # Group by state
@@ -1344,6 +1383,65 @@ Use this skill when you need to:
         with open(issues_path, "w", encoding="utf-8") as f:
             f.write(content)
         logger.info(f"Generated: {issues_path}")
+
+        # --- Per-issue files ---
+        for issue in issues:
+            self._write_per_issue_file(issue)
+
+    def _write_per_issue_file(self, issue: dict):
+        """Write a single per-issue markdown file with YAML frontmatter.
+
+        Args:
+            issue: Issue data dict with number, title, body, comments, etc.
+        """
+        number = issue["number"]
+        title = issue["title"]
+        state = issue["state"]
+        labels = issue.get("labels", [])
+        created_at = issue.get("created_at") or "N/A"
+        updated_at = issue.get("updated_at") or "N/A"
+        url = issue.get("url", "")
+        body = issue.get("body") or ""
+        comments = issue.get("comments", [])
+
+        # Escape title for YAML (wrap in quotes)
+        yaml_title = title.replace('"', '\\"')
+        labels_yaml = json.dumps(labels)
+
+        file_content = f"""---
+type: github_issue
+issue_number: {number}
+title: "{yaml_title}"
+state: {state}
+labels: {labels_yaml}
+created_at: "{created_at}"
+updated_at: "{updated_at}"
+url: "{url}"
+---
+
+# Issue #{number}: {title}
+
+**State:** {state} | **Labels:** {", ".join(labels) if labels else "None"} | **Created:** {created_at[:10]}
+**URL:** {url}
+
+## Description
+
+{body}
+"""
+
+        if comments:
+            file_content += f"\n## Comments ({len(comments)})\n"
+            for comment in comments:
+                author = comment.get("author", "unknown")
+                comment_date = comment.get("created_at", "N/A")
+                comment_body = comment.get("body", "")
+                file_content += f"\n### {author} — {comment_date}\n{comment_body}\n\n---\n"
+
+        filename = f"{self.repo_short_name}_{number}.md"
+        filepath = f"{self.skill_dir}/references/{filename}"
+        with open(filepath, "w", encoding="utf-8") as f:
+            f.write(file_content)
+        logger.debug(f"Generated per-issue file: {filepath}")
 
     def _generate_releases_reference(self):
         """Generate releases.md reference file."""
@@ -1389,3 +1487,198 @@ Use this skill when you need to:
         with open(structure_path, "w", encoding="utf-8") as f:
             f.write(content)
         logger.info(f"Generated: {structure_path}")
+
+
+def setup_argument_parser() -> argparse.ArgumentParser:
+    """Setup and configure command-line argument parser.
+
+    Creates an ArgumentParser with all CLI options for the github scraper.
+    All arguments are defined in skill_seekers.cli.arguments.github to ensure
+    consistency between the standalone scraper and unified CLI.
+
+    Returns:
+        argparse.ArgumentParser: Configured argument parser
+    """
+    parser = argparse.ArgumentParser(
+        description="GitHub Repository to Claude Skill Converter",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  skill-seekers github --repo facebook/react
+  skill-seekers github --config configs/react_github.json
+  skill-seekers github --repo owner/repo --token $GITHUB_TOKEN
+        """,
+    )
+
+    # Add all github arguments from shared definitions
+    # This ensures the standalone scraper and unified CLI stay in sync
+    add_github_arguments(parser)
+
+    return parser
+
+
+def main():
+    """C1.10: CLI tool entry point."""
+    parser = setup_argument_parser()
+    args = parser.parse_args()
+
+    setup_logging(verbose=getattr(args, "verbose", False), quiet=getattr(args, "quiet", False))
+
+    # Handle --dry-run
+    if getattr(args, "dry_run", False):
+        repo = args.repo or (args.config and "(from config)")
+        print(f"\n{'=' * 60}")
+        print(f"DRY RUN: GitHub Repository Analysis")
+        print(f"{'=' * 60}")
+        print(f"Repository:     {repo}")
+        print(f"Name:           {getattr(args, 'name', None) or '(auto-detect)'}")
+        print(f"Include issues: {not getattr(args, 'no_issues', False)}")
+        print(f"Include releases: {not getattr(args, 'no_releases', False)}")
+        print(f"Include changelog: {not getattr(args, 'no_changelog', False)}")
+        print(f"Max issues:     {getattr(args, 'max_issues', 100)}")
+        print(f"Max comments:   {getattr(args, 'max_comments', 50)}")
+        since = getattr(args, "since", None)
+        issue_labels = getattr(args, "issue_labels", None)
+        issue_state = getattr(args, "issue_state", None)
+        if since:
+            print(f"Since:          {since}")
+        if issue_labels:
+            print(f"Issue labels:   {issue_labels}")
+        if issue_state:
+            print(f"Issue state:    {issue_state}")
+        print(f"Enhance level:  {getattr(args, 'enhance_level', 0)}")
+        print(f"Profile:        {getattr(args, 'profile', None) or '(default)'}")
+        print(f"\n✅ Dry run complete")
+        return 0
+
+    # Build config from args or file
+    if args.config:
+        with open(args.config, encoding="utf-8") as f:
+            config = json.load(f)
+        # Override with CLI args if provided
+        if args.non_interactive:
+            config["interactive"] = False
+        if args.profile:
+            config["github_profile"] = args.profile
+    elif args.repo:
+        config = {
+            "repo": args.repo,
+            "name": args.name or args.repo.split("/")[-1],
+            "description": args.description or f"Use when working with {args.repo.split('/')[-1]}",
+            "github_token": args.token,
+            "include_issues": not args.no_issues,
+            "include_changelog": not args.no_changelog,
+            "include_releases": not args.no_releases,
+            "max_issues": args.max_issues,
+            "max_comments": getattr(args, "max_comments", 50),
+            "issue_since": getattr(args, "since", None),
+            "issue_labels": (
+                [lab.strip() for lab in args.issue_labels.split(",") if lab.strip()]
+                if getattr(args, "issue_labels", None)
+                else []
+            ),
+            "issue_state": getattr(args, "issue_state", None) or "all",
+            "interactive": not args.non_interactive,
+            "github_profile": args.profile,
+            "local_repo_path": getattr(args, "local_repo_path", None),
+        }
+    else:
+        parser.error("Either --repo or --config is required")
+
+    try:
+        # Phase 1: Scrape GitHub repository
+        scraper = GitHubScraper(config)
+        scraper.scrape()
+
+        if args.scrape_only:
+            logger.info("Scrape complete (--scrape-only mode)")
+            return
+
+        # Phase 2: Build skill
+        converter = GitHubToSkillConverter(config)
+        converter.build_skill()
+
+        skill_name = config.get("name", config["repo"].split("/")[-1])
+        skill_dir = f"output/{skill_name}"
+
+        # ============================================================
+        # WORKFLOW SYSTEM INTEGRATION (Phase 2 - github_scraper)
+        # ============================================================
+        from skill_seekers.cli.workflow_runner import run_workflows
+
+        # Pass GitHub-specific context to workflows
+        github_context = {
+            "repo": config.get("repo", ""),
+            "name": skill_name,
+            "description": config.get("description", ""),
+        }
+
+        workflow_executed, workflow_names = run_workflows(args, context=github_context)
+        workflow_name = ", ".join(workflow_names) if workflow_names else None
+
+        # Phase 3: Optional enhancement with auto-detected mode
+        # Note: Runs independently of workflow system (they complement each other)
+        if getattr(args, "enhance_level", 0) > 0:
+            import os
+
+            # Auto-detect mode based on API key availability
+            api_key = args.api_key or os.environ.get("ANTHROPIC_API_KEY")
+            mode = "API" if api_key else "LOCAL"
+
+            logger.info("\n" + "=" * 80)
+            logger.info(f"🤖 Traditional AI Enhancement ({mode} mode, level {args.enhance_level})")
+            logger.info("=" * 80)
+            if workflow_executed:
+                logger.info(f"   Running after workflow: {workflow_name}")
+                logger.info(
+                    "   (Workflow provides specialized analysis, enhancement provides general improvements)"
+                )
+            logger.info("")
+
+            if api_key:
+                # API-based enhancement
+                try:
+                    from skill_seekers.cli.enhance_skill import enhance_skill_md
+
+                    enhance_skill_md(skill_dir, api_key)
+                    logger.info("✅ API enhancement complete!")
+                except ImportError:
+                    logger.error("❌ API enhancement not available. Install: pip install anthropic")
+                    logger.info("💡 Falling back to LOCAL mode...")
+                    # Fall back to LOCAL mode
+                    from pathlib import Path
+                    from skill_seekers.cli.enhance_skill_local import LocalSkillEnhancer
+
+                    enhancer = LocalSkillEnhancer(Path(skill_dir))
+                    enhancer.run(headless=True)
+                    logger.info("✅ Local enhancement complete!")
+            else:
+                # LOCAL enhancement (no API key)
+                from pathlib import Path
+                from skill_seekers.cli.enhance_skill_local import LocalSkillEnhancer
+
+                enhancer = LocalSkillEnhancer(Path(skill_dir))
+                enhancer.run(headless=True)
+                logger.info("✅ Local enhancement complete!")
+
+        logger.info(f"\n✅ Success! Skill created at: {skill_dir}/")
+
+        # Only suggest enhancement if neither workflow nor traditional enhancement was done
+        if not workflow_executed and getattr(args, "enhance_level", 0) == 0:
+            logger.info("\n💡 Optional: Enhance SKILL.md with Claude:")
+            logger.info(f"  skill-seekers enhance {skill_dir}/ --enhance-level 2")
+            logger.info("  (auto-detects API vs LOCAL mode based on ANTHROPIC_API_KEY)")
+            logger.info("\n💡 Or use a workflow:")
+            logger.info(
+                f"  skill-seekers github --repo {config['repo']} --enhance-workflow architecture-comprehensive"
+            )
+
+        logger.info(f"\nNext step: skill-seekers package {skill_dir}/")
+
+    except Exception as e:
+        logger.error(f"Error: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_github_fetcher.py
+++ b/tests/test_github_fetcher.py
@@ -438,3 +438,136 @@ class TestIntegration:
         # Verify insights stream
         assert three_streams.insights_stream.metadata["stars"] == 1234
         assert len(three_streams.insights_stream.common_problems) > 0
+
+
+class TestIssueFiltering:
+    """Test issue filtering parameters (since, labels, state)."""
+
+    @patch("requests.get")
+    def test_fetch_issues_page_sends_since_param(self, mock_get):
+        """Test that _fetch_issues_page sends 'since' when set."""
+        mock_response = Mock()
+        mock_response.json.return_value = []
+        mock_response.raise_for_status = Mock()
+        mock_get.return_value = mock_response
+
+        fetcher = GitHubThreeStreamFetcher(
+            "https://github.com/test/repo", issue_since="2026-01-01T00:00:00"
+        )
+        fetcher._fetch_issues_page(state="open", max_count=50)
+
+        call_kwargs = mock_get.call_args
+        params = (
+            call_kwargs[1]["params"] if "params" in call_kwargs[1] else call_kwargs.kwargs["params"]
+        )
+        assert params["since"] == "2026-01-01T00:00:00"
+
+    @patch("requests.get")
+    def test_fetch_issues_page_sends_labels_param(self, mock_get):
+        """Test that _fetch_issues_page sends 'labels' when set."""
+        mock_response = Mock()
+        mock_response.json.return_value = []
+        mock_response.raise_for_status = Mock()
+        mock_get.return_value = mock_response
+
+        fetcher = GitHubThreeStreamFetcher(
+            "https://github.com/test/repo", issue_labels=["bug", "enhancement"]
+        )
+        fetcher._fetch_issues_page(state="open", max_count=50)
+
+        call_kwargs = mock_get.call_args
+        params = (
+            call_kwargs[1]["params"] if "params" in call_kwargs[1] else call_kwargs.kwargs["params"]
+        )
+        assert params["labels"] == "bug,enhancement"
+
+    @patch("requests.get")
+    def test_fetch_issues_page_no_extra_params_by_default(self, mock_get):
+        """Test that since/labels are NOT sent when not set."""
+        mock_response = Mock()
+        mock_response.json.return_value = []
+        mock_response.raise_for_status = Mock()
+        mock_get.return_value = mock_response
+
+        fetcher = GitHubThreeStreamFetcher("https://github.com/test/repo")
+        fetcher._fetch_issues_page(state="open", max_count=50)
+
+        call_kwargs = mock_get.call_args
+        params = (
+            call_kwargs[1]["params"] if "params" in call_kwargs[1] else call_kwargs.kwargs["params"]
+        )
+        assert "since" not in params
+        assert "labels" not in params
+
+    @patch("requests.get")
+    def test_fetch_issues_single_state_open(self, mock_get):
+        """Test fetch_issues with issue_state='open' makes one call."""
+        mock_response = Mock()
+        mock_response.json.return_value = [
+            {"title": "Bug", "number": 1, "state": "open", "comments": 5, "labels": []}
+        ]
+        mock_response.raise_for_status = Mock()
+        mock_get.return_value = mock_response
+
+        fetcher = GitHubThreeStreamFetcher("https://github.com/test/repo", issue_state="open")
+        fetcher.fetch_issues(max_issues=100)
+
+        # Should only call once (not 50/50 split)
+        assert mock_get.call_count == 1
+        # Verify it requested "open" state
+        call_kwargs = mock_get.call_args
+        params = (
+            call_kwargs[1]["params"] if "params" in call_kwargs[1] else call_kwargs.kwargs["params"]
+        )
+        assert params["state"] == "open"
+        assert params["per_page"] == 100
+
+    @patch("requests.get")
+    def test_fetch_issues_single_state_closed(self, mock_get):
+        """Test fetch_issues with issue_state='closed' makes one call."""
+        mock_response = Mock()
+        mock_response.json.return_value = []
+        mock_response.raise_for_status = Mock()
+        mock_get.return_value = mock_response
+
+        fetcher = GitHubThreeStreamFetcher("https://github.com/test/repo", issue_state="closed")
+        fetcher.fetch_issues(max_issues=100)
+
+        assert mock_get.call_count == 1
+        call_kwargs = mock_get.call_args
+        params = (
+            call_kwargs[1]["params"] if "params" in call_kwargs[1] else call_kwargs.kwargs["params"]
+        )
+        assert params["state"] == "closed"
+
+    @patch("requests.get")
+    def test_fetch_issues_all_state_makes_two_calls(self, mock_get):
+        """Test fetch_issues with issue_state='all' makes two calls (50/50 split)."""
+        mock_response = Mock()
+        mock_response.json.return_value = []
+        mock_response.raise_for_status = Mock()
+        mock_get.return_value = mock_response
+
+        fetcher = GitHubThreeStreamFetcher("https://github.com/test/repo", issue_state="all")
+        fetcher.fetch_issues(max_issues=100)
+
+        assert mock_get.call_count == 2
+
+    def test_init_stores_issue_filters(self):
+        """Test that __init__ stores issue filter parameters."""
+        fetcher = GitHubThreeStreamFetcher(
+            "https://github.com/test/repo",
+            issue_since="2026-01-01",
+            issue_labels=["bug"],
+            issue_state="open",
+        )
+        assert fetcher.issue_since == "2026-01-01"
+        assert fetcher.issue_labels == ["bug"]
+        assert fetcher.issue_state == "open"
+
+    def test_init_defaults_for_issue_filters(self):
+        """Test default values for issue filter parameters."""
+        fetcher = GitHubThreeStreamFetcher("https://github.com/test/repo")
+        assert fetcher.issue_since is None
+        assert fetcher.issue_labels == []
+        assert fetcher.issue_state == "all"

--- a/tests/test_github_scraper.py
+++ b/tests/test_github_scraper.py
@@ -1191,9 +1191,9 @@ class TestExtractIssuesFullBodyAndComments(unittest.TestCase):
         comment.body = body
         return comment
 
-    def test_full_body_not_truncated(self):
-        """Issue body is stored in full without truncation."""
-        long_body = "x" * 2000  # Well over the old 500-char limit
+    def test_body_truncated_by_default(self):
+        """Issue body is truncated to 500 chars by default."""
+        long_body = "x" * 2000
         mock_issue = self._make_mock_issue(body=long_body)
 
         config = {"repo": "test/repo", "name": "repo", "github_token": None, "max_issues": 10}
@@ -1205,15 +1205,59 @@ class TestExtractIssuesFullBodyAndComments(unittest.TestCase):
             scraper._extract_issues()
 
             issues = scraper.extracted_data["issues"]
+            self.assertEqual(len(issues[0]["body"]), 500)
+
+    def test_full_body_with_per_issue_files(self):
+        """Issue body is stored in full when per_issue_files is enabled."""
+        long_body = "x" * 2000
+        mock_issue = self._make_mock_issue(body=long_body)
+
+        config = {
+            "repo": "test/repo",
+            "name": "repo",
+            "github_token": None,
+            "max_issues": 10,
+            "per_issue_files": True,
+        }
+        with patch("skill_seekers.cli.github_scraper.Github"):
+            scraper = self.GitHubScraper(config)
+            scraper.repo = Mock()
+            scraper.repo.get_issues.return_value = [mock_issue]
+
+            scraper._extract_issues()
+
+            issues = scraper.extracted_data["issues"]
             self.assertEqual(len(issues[0]["body"]), 2000)
 
+    def test_comments_not_fetched_by_default(self):
+        """Comments are NOT fetched when max_comments is 0 (default)."""
+        comment1 = self._make_mock_comment(author="alice", body="First comment")
+        mock_issue = self._make_mock_issue(comments=[comment1])
+
+        config = {"repo": "test/repo", "name": "repo", "github_token": None, "max_issues": 10}
+        with patch("skill_seekers.cli.github_scraper.Github"):
+            scraper = self.GitHubScraper(config)
+            scraper.repo = Mock()
+            scraper.repo.get_issues.return_value = [mock_issue]
+
+            scraper._extract_issues()
+
+            issues = scraper.extracted_data["issues"]
+            self.assertEqual(len(issues[0]["comments"]), 0)
+
     def test_comments_fetched(self):
-        """Comments are fetched via issue.get_comments()."""
+        """Comments are fetched when max_comments > 0."""
         comment1 = self._make_mock_comment(author="alice", body="First comment")
         comment2 = self._make_mock_comment(author="bob", body="Second comment")
         mock_issue = self._make_mock_issue(comments=[comment1, comment2])
 
-        config = {"repo": "test/repo", "name": "repo", "github_token": None, "max_issues": 10}
+        config = {
+            "repo": "test/repo",
+            "name": "repo",
+            "github_token": None,
+            "max_issues": 10,
+            "max_comments": 50,
+        }
         with patch("skill_seekers.cli.github_scraper.Github"):
             scraper = self.GitHubScraper(config)
             scraper.repo = Mock()
@@ -1250,11 +1294,11 @@ class TestExtractIssuesFullBodyAndComments(unittest.TestCase):
             self.assertEqual(len(issues[0]["comments"]), 3)
 
     def test_max_comments_config_default(self):
-        """max_comments defaults to 50 in config."""
+        """max_comments defaults to 0 (disabled) in config."""
         config = {"repo": "test/repo", "name": "repo", "github_token": None}
         with patch("skill_seekers.cli.github_scraper.Github"):
             scraper = self.GitHubScraper(config)
-            self.assertEqual(scraper.max_comments, 50)
+            self.assertEqual(scraper.max_comments, 0)
 
 
 class TestPerIssueFileGeneration(unittest.TestCase):
@@ -1289,7 +1333,7 @@ class TestPerIssueFileGeneration(unittest.TestCase):
         with open(data_file, "w") as f:
             json.dump(data, f)
 
-        config = {"repo": "test/test-repo", "name": name}
+        config = {"repo": "test/test-repo", "name": name, "per_issue_files": True}
 
         # Patch the data file path
         with patch.object(

--- a/tests/test_github_scraper.py
+++ b/tests/test_github_scraper.py
@@ -1065,7 +1065,7 @@ class TestErrorHandling(unittest.TestCase):
             self.assertEqual(call_kwargs["state"], "open")
 
     def test_extract_issues_passes_labels_filter(self):
-        """Test that _extract_issues passes issue_labels to get_issues."""
+        """Test that _extract_issues passes issue_labels as plain strings to get_issues."""
         config = {
             "repo": "facebook/react",
             "name": "react",
@@ -1074,26 +1074,45 @@ class TestErrorHandling(unittest.TestCase):
             "issue_labels": ["bug", "enhancement"],
         }
 
-        mock_label_bug = Mock()
-        mock_label_bug.name = "bug"
-        mock_label_enh = Mock()
-        mock_label_enh.name = "enhancement"
-
         with patch("skill_seekers.cli.github_scraper.Github"):
             scraper = self.GitHubScraper(config)
             scraper.repo = Mock()
-            scraper.repo.get_label.side_effect = [mock_label_bug, mock_label_enh]
             scraper.repo.get_issues.return_value = []
 
             scraper._extract_issues()
 
-            # Verify get_label was called for each label
-            self.assertEqual(scraper.repo.get_label.call_count, 2)
-            scraper.repo.get_label.assert_any_call("bug")
-            scraper.repo.get_label.assert_any_call("enhancement")
-            # Verify labels were passed to get_issues
+            # PyGithub's get_issues(labels=...) accepts plain strings; we should
+            # NEVER call get_label (which costs an extra API call per label and
+            # 404s if the label doesn't exist).
+            scraper.repo.get_label.assert_not_called()
             call_kwargs = scraper.repo.get_issues.call_args[1]
-            self.assertIn("labels", call_kwargs)
+            self.assertEqual(call_kwargs["labels"], ["bug", "enhancement"])
+
+    def test_extract_issues_since_z_suffix(self):
+        """Test that _extract_issues accepts ISO8601 'Z' (UTC) suffix on Python 3.10."""
+        config = {
+            "repo": "facebook/react",
+            "name": "react",
+            "github_token": None,
+            "max_issues": 10,
+            "issue_since": "2024-01-01T00:00:00Z",
+        }
+
+        with patch("skill_seekers.cli.github_scraper.Github"):
+            scraper = self.GitHubScraper(config)
+            scraper.repo = Mock()
+            scraper.repo.get_issues.return_value = []
+
+            # Must not raise — Python 3.10's fromisoformat rejects raw 'Z'.
+            scraper._extract_issues()
+
+            call_kwargs = scraper.repo.get_issues.call_args[1]
+            self.assertIn("since", call_kwargs)
+            since = call_kwargs["since"]
+            self.assertEqual(since.year, 2024)
+            self.assertEqual(since.month, 1)
+            self.assertEqual(since.day, 1)
+            self.assertIsNotNone(since.tzinfo)
 
     def test_extract_issues_passes_since_filter(self):
         """Test that _extract_issues passes issue_since to get_issues."""
@@ -1349,7 +1368,7 @@ class TestPerIssueFileGeneration(unittest.TestCase):
         return converter
 
     def test_per_issue_files_created(self):
-        """Per-issue files are created with correct naming."""
+        """Per-issue files live in references/issues/ with {owner}-{repo}-{n}.md naming."""
         issues = [
             {
                 "number": 42,
@@ -1367,8 +1386,56 @@ class TestPerIssueFileGeneration(unittest.TestCase):
         converter = self._setup_converter(issues)
         converter._generate_issues_reference()
 
-        expected_file = os.path.join(converter.skill_dir, "references", "test-repo_42.md")
+        expected_file = os.path.join(
+            converter.skill_dir, "references", "issues", "test-test-repo-42.md"
+        )
         self.assertTrue(os.path.exists(expected_file))
+
+        # Old flat path must NOT exist (regression guard for the rename).
+        old_file = os.path.join(converter.skill_dir, "references", "test-repo_42.md")
+        self.assertFalse(os.path.exists(old_file))
+
+    def test_per_issue_files_no_collision_across_repos(self):
+        """Two repos sharing a skill_dir + issue number write distinct files."""
+        issues = [
+            {
+                "number": 1,
+                "title": "Same number",
+                "state": "open",
+                "labels": [],
+                "created_at": "2023-01-01T00:00:00",
+                "updated_at": "2023-01-02T00:00:00",
+                "closed_at": None,
+                "url": "https://github.com/alpha/proj/issues/1",
+                "body": "Issue from alpha/proj",
+                "comments": [],
+            },
+        ]
+
+        # First repo: alpha/proj
+        skill_dir = os.path.join(self.temp_dir, "shared-skill")
+        os.makedirs(os.path.join(skill_dir, "references"), exist_ok=True)
+
+        config_a = {"repo": "alpha/proj", "name": "shared-skill", "per_issue_files": True}
+        with patch.object(self.GitHubToSkillConverter, "_load_data", return_value={}):
+            converter_a = self.GitHubToSkillConverter(config_a)
+        converter_a.data = {"issues": issues}
+        converter_a.skill_dir = skill_dir
+        converter_a._generate_issues_reference()
+
+        # Second repo: beta/proj — same issue number, same skill_dir.
+        issues_b = [{**issues[0], "url": "https://github.com/beta/proj/issues/1"}]
+        config_b = {"repo": "beta/proj", "name": "shared-skill", "per_issue_files": True}
+        with patch.object(self.GitHubToSkillConverter, "_load_data", return_value={}):
+            converter_b = self.GitHubToSkillConverter(config_b)
+        converter_b.data = {"issues": issues_b}
+        converter_b.skill_dir = skill_dir
+        converter_b._generate_issues_reference()
+
+        alpha_file = os.path.join(skill_dir, "references", "issues", "alpha-proj-1.md")
+        beta_file = os.path.join(skill_dir, "references", "issues", "beta-proj-1.md")
+        self.assertTrue(os.path.exists(alpha_file))
+        self.assertTrue(os.path.exists(beta_file))
 
     def test_per_issue_file_content(self):
         """Per-issue file contains full body and YAML frontmatter."""
@@ -1389,7 +1456,7 @@ class TestPerIssueFileGeneration(unittest.TestCase):
         converter = self._setup_converter(issues)
         converter._generate_issues_reference()
 
-        filepath = os.path.join(converter.skill_dir, "references", "test-repo_99.md")
+        filepath = os.path.join(converter.skill_dir, "references", "issues", "test-test-repo-99.md")
         content = Path(filepath).read_text()
 
         # Check YAML frontmatter
@@ -1431,7 +1498,7 @@ class TestPerIssueFileGeneration(unittest.TestCase):
         converter = self._setup_converter(issues)
         converter._generate_issues_reference()
 
-        filepath = os.path.join(converter.skill_dir, "references", "test-repo_7.md")
+        filepath = os.path.join(converter.skill_dir, "references", "issues", "test-test-repo-7.md")
         content = Path(filepath).read_text()
 
         self.assertIn("## Comments (2)", content)

--- a/tests/test_github_scraper.py
+++ b/tests/test_github_scraper.py
@@ -296,6 +296,7 @@ class TestIssuesExtraction(unittest.TestCase):
         mock_issue1.html_url = "https://github.com/facebook/react/issues/123"
         mock_issue1.body = "Issue description"
         mock_issue1.pull_request = None
+        mock_issue1.get_comments.return_value = []
 
         mock_label3 = Mock()
         mock_label3.name = "enhancement"
@@ -312,6 +313,7 @@ class TestIssuesExtraction(unittest.TestCase):
         mock_issue2.html_url = "https://github.com/facebook/react/issues/124"
         mock_issue2.body = "Feature description"
         mock_issue2.pull_request = None
+        mock_issue2.get_comments.return_value = []
 
         with patch("skill_seekers.cli.github_scraper.Github"):
             scraper = self.GitHubScraper(config)
@@ -358,6 +360,7 @@ class TestIssuesExtraction(unittest.TestCase):
         mock_issue.html_url = "https://github.com/test/repo/issues/123"
         mock_issue.body = "Issue body"
         mock_issue.pull_request = None
+        mock_issue.get_comments.return_value = []
 
         mock_pr = Mock()
         mock_pr.number = 124
@@ -400,6 +403,7 @@ class TestIssuesExtraction(unittest.TestCase):
             mock_issue.html_url = f"https://github.com/test/repo/issues/{i}"
             mock_issue.body = None
             mock_issue.pull_request = None
+            mock_issue.get_comments.return_value = []
             mock_issues.append(mock_issue)
 
         with patch("skill_seekers.cli.github_scraper.Github"):
@@ -1039,6 +1043,380 @@ class TestErrorHandling(unittest.TestCase):
             # Should handle gracefully and log warning
             scraper._extract_issues()
             # Should not crash, just log warning
+
+    def test_extract_issues_passes_state_filter(self):
+        """Test that _extract_issues passes issue_state to get_issues."""
+        config = {
+            "repo": "facebook/react",
+            "name": "react",
+            "github_token": None,
+            "max_issues": 10,
+            "issue_state": "open",
+        }
+
+        with patch("skill_seekers.cli.github_scraper.Github"):
+            scraper = self.GitHubScraper(config)
+            scraper.repo = Mock()
+            scraper.repo.get_issues.return_value = []
+
+            scraper._extract_issues()
+
+            call_kwargs = scraper.repo.get_issues.call_args[1]
+            self.assertEqual(call_kwargs["state"], "open")
+
+    def test_extract_issues_passes_labels_filter(self):
+        """Test that _extract_issues passes issue_labels to get_issues."""
+        config = {
+            "repo": "facebook/react",
+            "name": "react",
+            "github_token": None,
+            "max_issues": 10,
+            "issue_labels": ["bug", "enhancement"],
+        }
+
+        mock_label_bug = Mock()
+        mock_label_bug.name = "bug"
+        mock_label_enh = Mock()
+        mock_label_enh.name = "enhancement"
+
+        with patch("skill_seekers.cli.github_scraper.Github"):
+            scraper = self.GitHubScraper(config)
+            scraper.repo = Mock()
+            scraper.repo.get_label.side_effect = [mock_label_bug, mock_label_enh]
+            scraper.repo.get_issues.return_value = []
+
+            scraper._extract_issues()
+
+            # Verify get_label was called for each label
+            self.assertEqual(scraper.repo.get_label.call_count, 2)
+            scraper.repo.get_label.assert_any_call("bug")
+            scraper.repo.get_label.assert_any_call("enhancement")
+            # Verify labels were passed to get_issues
+            call_kwargs = scraper.repo.get_issues.call_args[1]
+            self.assertIn("labels", call_kwargs)
+
+    def test_extract_issues_passes_since_filter(self):
+        """Test that _extract_issues passes issue_since to get_issues."""
+        config = {
+            "repo": "facebook/react",
+            "name": "react",
+            "github_token": None,
+            "max_issues": 10,
+            "issue_since": "2026-01-01",
+        }
+
+        with patch("skill_seekers.cli.github_scraper.Github"):
+            scraper = self.GitHubScraper(config)
+            scraper.repo = Mock()
+            scraper.repo.get_issues.return_value = []
+
+            scraper._extract_issues()
+
+            call_kwargs = scraper.repo.get_issues.call_args[1]
+            self.assertIn("since", call_kwargs)
+            self.assertEqual(call_kwargs["since"], datetime.fromisoformat("2026-01-01"))
+
+    def test_extract_issues_no_filters_by_default(self):
+        """Test that _extract_issues uses defaults when no filters set."""
+        config = {
+            "repo": "facebook/react",
+            "name": "react",
+            "github_token": None,
+            "max_issues": 10,
+        }
+
+        with patch("skill_seekers.cli.github_scraper.Github"):
+            scraper = self.GitHubScraper(config)
+            scraper.repo = Mock()
+            scraper.repo.get_issues.return_value = []
+
+            scraper._extract_issues()
+
+            call_kwargs = scraper.repo.get_issues.call_args[1]
+            self.assertEqual(call_kwargs["state"], "all")
+            self.assertNotIn("labels", call_kwargs)
+            self.assertNotIn("since", call_kwargs)
+
+    def test_issue_filter_args_in_config(self):
+        """Test that issue filter config keys are read in __init__."""
+        config = {
+            "repo": "facebook/react",
+            "name": "react",
+            "github_token": None,
+            "issue_since": "2026-03-01",
+            "issue_labels": ["bug"],
+            "issue_state": "closed",
+        }
+
+        with patch("skill_seekers.cli.github_scraper.Github"):
+            scraper = self.GitHubScraper(config)
+            self.assertEqual(scraper.issue_since, "2026-03-01")
+            self.assertEqual(scraper.issue_labels, ["bug"])
+            self.assertEqual(scraper.issue_state, "closed")
+
+
+class TestExtractIssuesFullBodyAndComments(unittest.TestCase):
+    """Test full issue body and comment fetching."""
+
+    def setUp(self):
+        if not PYGITHUB_AVAILABLE:
+            self.skipTest("PyGithub not installed")
+        from skill_seekers.cli.github_scraper import GitHubScraper
+
+        self.GitHubScraper = GitHubScraper
+
+    def _make_mock_issue(self, number=1, body="Full body text here", comments=None):
+        """Helper to create a mock issue with comments."""
+        mock_issue = Mock()
+        mock_issue.number = number
+        mock_issue.title = f"Issue {number}"
+        mock_issue.state = "open"
+        mock_issue.labels = []
+        mock_issue.milestone = None
+        mock_issue.created_at = datetime(2023, 1, 1)
+        mock_issue.updated_at = datetime(2023, 1, 2)
+        mock_issue.closed_at = None
+        mock_issue.html_url = f"https://github.com/test/repo/issues/{number}"
+        mock_issue.body = body
+        mock_issue.pull_request = None
+        mock_issue.get_comments.return_value = comments or []
+        return mock_issue
+
+    def _make_mock_comment(self, author="alice", body="Comment body", date=None):
+        """Helper to create a mock comment."""
+        comment = Mock()
+        comment.user = Mock()
+        comment.user.login = author
+        comment.created_at = date or datetime(2023, 2, 1)
+        comment.body = body
+        return comment
+
+    def test_full_body_not_truncated(self):
+        """Issue body is stored in full without truncation."""
+        long_body = "x" * 2000  # Well over the old 500-char limit
+        mock_issue = self._make_mock_issue(body=long_body)
+
+        config = {"repo": "test/repo", "name": "repo", "github_token": None, "max_issues": 10}
+        with patch("skill_seekers.cli.github_scraper.Github"):
+            scraper = self.GitHubScraper(config)
+            scraper.repo = Mock()
+            scraper.repo.get_issues.return_value = [mock_issue]
+
+            scraper._extract_issues()
+
+            issues = scraper.extracted_data["issues"]
+            self.assertEqual(len(issues[0]["body"]), 2000)
+
+    def test_comments_fetched(self):
+        """Comments are fetched via issue.get_comments()."""
+        comment1 = self._make_mock_comment(author="alice", body="First comment")
+        comment2 = self._make_mock_comment(author="bob", body="Second comment")
+        mock_issue = self._make_mock_issue(comments=[comment1, comment2])
+
+        config = {"repo": "test/repo", "name": "repo", "github_token": None, "max_issues": 10}
+        with patch("skill_seekers.cli.github_scraper.Github"):
+            scraper = self.GitHubScraper(config)
+            scraper.repo = Mock()
+            scraper.repo.get_issues.return_value = [mock_issue]
+
+            scraper._extract_issues()
+
+            issues = scraper.extracted_data["issues"]
+            self.assertEqual(len(issues[0]["comments"]), 2)
+            self.assertEqual(issues[0]["comments"][0]["author"], "alice")
+            self.assertEqual(issues[0]["comments"][0]["body"], "First comment")
+            self.assertEqual(issues[0]["comments"][1]["author"], "bob")
+
+    def test_max_comments_respected(self):
+        """Only max_comments comments are stored per issue."""
+        comments = [self._make_mock_comment(author=f"user{i}") for i in range(10)]
+        mock_issue = self._make_mock_issue(comments=comments)
+
+        config = {
+            "repo": "test/repo",
+            "name": "repo",
+            "github_token": None,
+            "max_issues": 10,
+            "max_comments": 3,
+        }
+        with patch("skill_seekers.cli.github_scraper.Github"):
+            scraper = self.GitHubScraper(config)
+            scraper.repo = Mock()
+            scraper.repo.get_issues.return_value = [mock_issue]
+
+            scraper._extract_issues()
+
+            issues = scraper.extracted_data["issues"]
+            self.assertEqual(len(issues[0]["comments"]), 3)
+
+    def test_max_comments_config_default(self):
+        """max_comments defaults to 50 in config."""
+        config = {"repo": "test/repo", "name": "repo", "github_token": None}
+        with patch("skill_seekers.cli.github_scraper.Github"):
+            scraper = self.GitHubScraper(config)
+            self.assertEqual(scraper.max_comments, 50)
+
+
+class TestPerIssueFileGeneration(unittest.TestCase):
+    """Test per-issue markdown file generation."""
+
+    def setUp(self):
+        if not PYGITHUB_AVAILABLE:
+            self.skipTest("PyGithub not installed")
+        from skill_seekers.cli.github_scraper import GitHubToSkillConverter
+
+        self.GitHubToSkillConverter = GitHubToSkillConverter
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        if hasattr(self, "temp_dir"):
+            shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _setup_converter(self, issues):
+        """Create a converter with pre-built data."""
+        name = "test-repo"
+        data_dir = os.path.join(self.temp_dir, "output")
+        os.makedirs(data_dir, exist_ok=True)
+
+        # Write extracted data
+        data = {
+            "readme": "# Test Repo",
+            "issues": issues,
+            "releases": [],
+            "file_tree": [],
+        }
+        data_file = os.path.join(data_dir, f"{name}_github_data.json")
+        with open(data_file, "w") as f:
+            json.dump(data, f)
+
+        config = {"repo": "test/test-repo", "name": name}
+
+        # Patch the data file path
+        with patch.object(
+            self.GitHubToSkillConverter,
+            "_load_data",
+            return_value=data,
+        ):
+            converter = self.GitHubToSkillConverter(config)
+
+        converter.data = data
+        converter.skill_dir = os.path.join(data_dir, name)
+        os.makedirs(os.path.join(converter.skill_dir, "references"), exist_ok=True)
+        return converter
+
+    def test_per_issue_files_created(self):
+        """Per-issue files are created with correct naming."""
+        issues = [
+            {
+                "number": 42,
+                "title": "Bug report",
+                "state": "open",
+                "labels": ["bug"],
+                "created_at": "2023-01-01T00:00:00",
+                "updated_at": "2023-01-02T00:00:00",
+                "closed_at": None,
+                "url": "https://github.com/test/test-repo/issues/42",
+                "body": "Full bug description here",
+                "comments": [],
+            },
+        ]
+        converter = self._setup_converter(issues)
+        converter._generate_issues_reference()
+
+        expected_file = os.path.join(converter.skill_dir, "references", "test-repo_42.md")
+        self.assertTrue(os.path.exists(expected_file))
+
+    def test_per_issue_file_content(self):
+        """Per-issue file contains full body and YAML frontmatter."""
+        issues = [
+            {
+                "number": 99,
+                "title": "Feature request",
+                "state": "open",
+                "labels": ["enhancement"],
+                "created_at": "2023-01-01T00:00:00",
+                "updated_at": "2023-01-02T00:00:00",
+                "closed_at": None,
+                "url": "https://github.com/test/repo/issues/99",
+                "body": "Please add dark mode support",
+                "comments": [],
+            },
+        ]
+        converter = self._setup_converter(issues)
+        converter._generate_issues_reference()
+
+        filepath = os.path.join(converter.skill_dir, "references", "test-repo_99.md")
+        content = Path(filepath).read_text()
+
+        # Check YAML frontmatter
+        self.assertTrue(content.startswith("---"))
+        self.assertIn("type: github_issue", content)
+        self.assertIn("issue_number: 99", content)
+        self.assertIn("state: open", content)
+
+        # Check body
+        self.assertIn("Please add dark mode support", content)
+
+    def test_per_issue_file_with_comments(self):
+        """Per-issue file includes comments section."""
+        issues = [
+            {
+                "number": 7,
+                "title": "Question",
+                "state": "open",
+                "labels": [],
+                "created_at": "2023-01-01T00:00:00",
+                "updated_at": "2023-01-02T00:00:00",
+                "closed_at": None,
+                "url": "https://github.com/test/repo/issues/7",
+                "body": "How do I configure X?",
+                "comments": [
+                    {
+                        "author": "maintainer",
+                        "created_at": "2023-01-03T00:00:00",
+                        "body": "You can configure X by editing config.yaml",
+                    },
+                    {
+                        "author": "user123",
+                        "created_at": "2023-01-04T00:00:00",
+                        "body": "Thanks, that worked!",
+                    },
+                ],
+            },
+        ]
+        converter = self._setup_converter(issues)
+        converter._generate_issues_reference()
+
+        filepath = os.path.join(converter.skill_dir, "references", "test-repo_7.md")
+        content = Path(filepath).read_text()
+
+        self.assertIn("## Comments (2)", content)
+        self.assertIn("### maintainer", content)
+        self.assertIn("You can configure X by editing config.yaml", content)
+        self.assertIn("### user123", content)
+        self.assertIn("Thanks, that worked!", content)
+
+    def test_summary_file_still_generated(self):
+        """issues.md summary file is still generated alongside per-issue files."""
+        issues = [
+            {
+                "number": 1,
+                "title": "Test",
+                "state": "open",
+                "labels": [],
+                "created_at": "2023-01-01T00:00:00",
+                "updated_at": "2023-01-02T00:00:00",
+                "closed_at": None,
+                "url": "https://github.com/test/repo/issues/1",
+                "body": "Test body",
+                "comments": [],
+            },
+        ]
+        converter = self._setup_converter(issues)
+        converter._generate_issues_reference()
+
+        summary_file = os.path.join(converter.skill_dir, "references", "issues.md")
+        self.assertTrue(os.path.exists(summary_file))
 
 
 if __name__ == "__main__":

--- a/tests/test_new_source_types.py
+++ b/tests/test_new_source_types.py
@@ -379,6 +379,32 @@ class TestConfigValidatorNewTypes:
         validator = ConfigValidator(config)
         assert validator.validate() is True
 
+    def test_github_issue_since_accepts_z_suffix(self):
+        """github source: issue_since with UTC 'Z' suffix passes on Python 3.10."""
+        config = self._make_config(
+            {
+                "type": "github",
+                "repo": "octocat/Hello-World",
+                "issue_since": "2024-01-01T00:00:00Z",
+            }
+        )
+        validator = ConfigValidator(config)
+        # Must not raise — Python 3.10's fromisoformat rejects raw 'Z'.
+        assert validator.validate() is True
+
+    def test_github_issue_since_rejects_garbage(self):
+        """github source: malformed issue_since still raises ValueError."""
+        config = self._make_config(
+            {
+                "type": "github",
+                "repo": "octocat/Hello-World",
+                "issue_since": "not-a-date",
+            }
+        )
+        validator = ConfigValidator(config)
+        with pytest.raises(ValueError, match="not a valid ISO8601 date"):
+            validator.validate()
+
 
 # ---------------------------------------------------------------------------
 # 3. UnifiedSkillBuilder — generic merge system

--- a/tests/test_pinecone_adaptor.py
+++ b/tests/test_pinecone_adaptor.py
@@ -554,6 +554,57 @@ class TestPineconeAdaptor:
 
 
 # ---------------------------------------------------------------------------
+# _parse_ref_frontmatter — malformed YAML resilience
+# ---------------------------------------------------------------------------
+
+
+class TestParseRefFrontmatter:
+    """_parse_ref_frontmatter must never raise on malformed YAML."""
+
+    def test_parse_valid_frontmatter(self):
+        """Valid YAML frontmatter parses to dict + content."""
+        from skill_seekers.cli.adaptors.pinecone_adaptor import PineconeAdaptor
+
+        content = "---\nfoo: bar\nnum: 42\n---\nbody text\n"
+        fm, body = PineconeAdaptor._parse_ref_frontmatter(content)
+        assert fm == {"foo": "bar", "num": 42}
+        assert body == "body text\n"
+
+    def test_parse_no_frontmatter(self):
+        """Content without leading --- returns empty dict + original content."""
+        from skill_seekers.cli.adaptors.pinecone_adaptor import PineconeAdaptor
+
+        content = "no frontmatter here"
+        fm, body = PineconeAdaptor._parse_ref_frontmatter(content)
+        assert fm == {}
+        assert body == content
+
+    def test_parse_malformed_yaml_does_not_raise(self):
+        """Malformed YAML returns ({}, original content) instead of raising."""
+        from skill_seekers.cli.adaptors.pinecone_adaptor import PineconeAdaptor
+
+        # Two flavors of broken YAML — both must fall through to the except.
+        broken_colons = "---\n: : :\n---\nbody"
+        fm, body = PineconeAdaptor._parse_ref_frontmatter(broken_colons)
+        assert fm == {}
+        assert body == broken_colons
+
+        unbalanced = "---\n[unbalanced\n---\nbody"
+        fm, body = PineconeAdaptor._parse_ref_frontmatter(unbalanced)
+        assert fm == {}
+        assert body == unbalanced
+
+    def test_parse_non_dict_yaml_returns_empty(self):
+        """Frontmatter that parses to a non-dict (e.g. a list) returns empty dict."""
+        from skill_seekers.cli.adaptors.pinecone_adaptor import PineconeAdaptor
+
+        content = "---\n- just\n- a list\n---\nbody"
+        fm, body = PineconeAdaptor._parse_ref_frontmatter(content)
+        assert fm == {}
+        assert body == content
+
+
+# ---------------------------------------------------------------------------
 # doc_version Metadata Tests (cross-adaptor)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_pinecone_adaptor.py
+++ b/tests/test_pinecone_adaptor.py
@@ -448,6 +448,93 @@ class TestPineconeAdaptor:
         call_kwargs = mock_pc.create_index.call_args
         assert call_kwargs.kwargs["dimension"] == 768
 
+    def test_frontmatter_parsed_into_metadata(self, tmp_path):
+        """YAML frontmatter from per-issue files is parsed and merged into vector metadata."""
+        from skill_seekers.cli.adaptors.pinecone_adaptor import PineconeAdaptor
+
+        skill_dir = tmp_path / "issue-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: issue-skill\ndescription: test\n---\n\n# Skill\n\nContent.\n"
+        )
+        refs = skill_dir / "references"
+        refs.mkdir()
+        (refs / "myrepo_42.md").write_text(
+            '---\ntype: github_issue\nissue_number: 42\ntitle: "Bug"\n'
+            'state: open\nlabels: ["bug"]\ncreated_at: "2023-01-01"\n'
+            'updated_at: "2023-01-02"\nurl: "https://github.com/test/repo/issues/42"\n'
+            "---\n\n# Issue #42: Bug\n\nFull body here.\n"
+        )
+
+        adaptor = PineconeAdaptor()
+        metadata = SkillMetadata(name="issue-skill", description="test")
+        result = adaptor.format_skill_md(skill_dir, metadata)
+        data = json.loads(result)
+
+        # Find the vector for the issue file
+        issue_vecs = [v for v in data["vectors"] if v["metadata"]["file"] == "myrepo_42.md"]
+        assert len(issue_vecs) == 1
+
+        meta = issue_vecs[0]["metadata"]
+        assert meta["type"] == "github_issue"
+        assert meta["issue_number"] == 42
+        assert meta["state"] == "open"
+        assert meta["labels"] == ["bug"]
+        assert meta["url"] == "https://github.com/test/repo/issues/42"
+
+    def test_frontmatter_stripped_from_text(self, tmp_path):
+        """Frontmatter is stripped from the text content of the vector."""
+        from skill_seekers.cli.adaptors.pinecone_adaptor import PineconeAdaptor
+
+        skill_dir = tmp_path / "strip-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: strip-skill\ndescription: test\n---\n\n# Skill\n\nContent.\n"
+        )
+        refs = skill_dir / "references"
+        refs.mkdir()
+        (refs / "repo_1.md").write_text(
+            '---\ntype: github_issue\nissue_number: 1\ntitle: "Test"\n'
+            'state: open\nlabels: []\ncreated_at: "2023-01-01"\n'
+            'updated_at: "2023-01-02"\nurl: "https://example.com"\n---\n\n'
+            "# Issue #1: Test\n\nActual content.\n"
+        )
+
+        adaptor = PineconeAdaptor()
+        metadata = SkillMetadata(name="strip-skill", description="test")
+        result = adaptor.format_skill_md(skill_dir, metadata)
+        data = json.loads(result)
+
+        issue_vecs = [v for v in data["vectors"] if v["metadata"]["file"] == "repo_1.md"]
+        text = issue_vecs[0]["metadata"]["text"]
+        assert "---" not in text.split("\n")[0]  # No frontmatter markers
+        assert "type: github_issue" not in text
+        assert "# Issue #1: Test" in text
+        assert "Actual content." in text
+
+    def test_non_frontmatter_files_unaffected(self, tmp_path):
+        """Reference files without frontmatter are processed normally."""
+        from skill_seekers.cli.adaptors.pinecone_adaptor import PineconeAdaptor
+
+        skill_dir = tmp_path / "normal-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: normal-skill\ndescription: test\n---\n\n# Skill\n\nContent.\n"
+        )
+        refs = skill_dir / "references"
+        refs.mkdir()
+        (refs / "api_reference.md").write_text("# API Reference\n\nSome API docs.\n")
+
+        adaptor = PineconeAdaptor()
+        metadata = SkillMetadata(name="normal-skill", description="test")
+        result = adaptor.format_skill_md(skill_dir, metadata)
+        data = json.loads(result)
+
+        ref_vecs = [v for v in data["vectors"] if v["metadata"]["file"] == "api_reference.md"]
+        assert len(ref_vecs) == 1
+        assert ref_vecs[0]["metadata"]["type"] == "reference"
+        assert "# API Reference" in ref_vecs[0]["metadata"]["text"]
+
     def test_deterministic_ids(self, sample_skill_dir):
         """IDs are deterministic — same input produces same ID."""
         from skill_seekers.cli.adaptors.pinecone_adaptor import PineconeAdaptor

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -221,12 +221,39 @@ wheels = [
 ]
 
 [[package]]
+name = "asciidoc"
+version = "10.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/e7/315a82f2d256e9270977aa3c15e8fe281fd7c40b8e2a0b97e0cb61ca8fa0/asciidoc-10.2.1.tar.gz", hash = "sha256:d9f13c285981b3c7eb660d02ca0a2779981e88d48105de81bb40445e60dddb83", size = 230179, upload-time = "2024-07-17T03:12:52.681Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/1f/87941eaa96e86aa22086064f67e4187e2710fb76c147312979ea29278dac/asciidoc-10.2.1-py2.py3-none-any.whl", hash = "sha256:3f277a636b617c9ce7e0b87bcaea51f144500e9a5c8a6488421ee24594850d40", size = 272433, upload-time = "2024-07-17T03:12:49.012Z" },
+]
+
+[[package]]
 name = "async-timeout"
 version = "5.0.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274, upload-time = "2024-11-06T16:41:39.6Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233, upload-time = "2024-11-06T16:41:37.9Z" },
+]
+
+[[package]]
+name = "atlassian-python-api"
+version = "4.0.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "deprecated" },
+    { name = "jmespath" },
+    { name = "oauthlib" },
+    { name = "requests" },
+    { name = "requests-oauthlib" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/e8/f23b7273e410c6fe9f98f9db25268c6736572f22a9566d1dc9ed3614bb68/atlassian_python_api-4.0.7.tar.gz", hash = "sha256:8d9cc6068b1d2a48eb434e22e57f6bbd918a47fac9e46b95b7a3cefb00fceacb", size = 271149, upload-time = "2025-08-21T13:19:40.746Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/83/e4f9976ce3c933a079b8931325e7a9c0a8bba7030a2cb85764c0048f3479/atlassian_python_api-4.0.7-py3-none-any.whl", hash = "sha256:46a70cb29eaab87c0a1697fccd3e25df1aa477e6aa4fb9ba936a9d46b425933c", size = 197746, upload-time = "2025-08-21T13:19:39.044Z" },
 ]
 
 [[package]]
@@ -1079,6 +1106,19 @@ wheels = [
 ]
 
 [[package]]
+name = "ebooklib"
+version = "0.20"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lxml" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/85/322e8882a582d4b707220d1929cfb74c125f2ba513991edbce40dbc462de/ebooklib-0.20.tar.gz", hash = "sha256:35e2f9d7d39907be8d39ae2deb261b19848945903ae3dbb6577b187ead69e985", size = 127066, upload-time = "2025-10-26T20:56:20.968Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/ee/aa015c5de8b0dc42a8e507eae8c2de5d1c0e068c896858fec6d502402ed6/ebooklib-0.20-py3-none-any.whl", hash = "sha256:fff5322517a37e31c972d27be7d982cc3928c16b3dcc5fd7e8f7c0f5d7bcf42b", size = 40995, upload-time = "2025-10-26T20:56:19.104Z" },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1120,6 +1160,27 @@ dependencies = [
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/05/99/49ee85903dee060d9f08297b4a342e5e0bcfca2f027a07b4ee0a38ab13f9/faster_whisper-1.2.1-py3-none-any.whl", hash = "sha256:79a66ad50688c0b794dd501dc340a736992a6342f7f95e5811be60b5224a26a7", size = 1118909, upload-time = "2025-10-31T11:35:47.794Z" },
+]
+
+[[package]]
+name = "fastjsonschema"
+version = "2.21.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/b5/23b216d9d985a956623b6bd12d4086b60f0059b27799f23016af04a74ea1/fastjsonschema-2.21.2.tar.gz", hash = "sha256:b1eb43748041c880796cd077f1a07c3d94e93ae84bba5ed36800a33554ae05de", size = 374130, upload-time = "2025-08-14T18:49:36.666Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/a8/20d0723294217e47de6d9e2e40fd4a9d2f7c4b6ef974babd482a59743694/fastjsonschema-2.21.2-py3-none-any.whl", hash = "sha256:1c797122d0a86c5cace2e54bf4e819c36223b552017172f32c5c024a6b77e463", size = 24024, upload-time = "2025-08-14T18:49:34.776Z" },
+]
+
+[[package]]
+name = "feedparser"
+version = "6.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sgmllib3k" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/79/db7edb5e77d6dfbc54d7d9df72828be4318275b2e580549ff45a962f6461/feedparser-6.0.12.tar.gz", hash = "sha256:64f76ce90ae3e8ef5d1ede0f8d3b50ce26bcce71dd8ae5e82b1cd2d4a5f94228", size = 286579, upload-time = "2025-09-10T13:33:59.486Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/eb/c96d64137e29ae17d83ad2552470bafe3a7a915e85434d9942077d7fd011/feedparser-6.0.12-py3-none-any.whl", hash = "sha256:6bbff10f5a52662c00a2e3f86a38928c37c48f77b3c511aedcd51de933549324", size = 81480, upload-time = "2025-09-10T13:33:58.022Z" },
 ]
 
 [[package]]
@@ -1614,6 +1675,7 @@ dependencies = [
     { name = "griffecli" },
     { name = "griffelib" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/04/56/28a0accac339c164b52a92c6cfc45a903acc0c174caa5c1713803467b533/griffe-2.0.0.tar.gz", hash = "sha256:c68979cd8395422083a51ea7cf02f9c119d889646d99b7b656ee43725de1b80f", size = 293906, upload-time = "2026-03-23T21:06:53.402Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/94/ee21d41e7eb4f823b94603b9d40f86d3c7fde80eacc2c3c71845476dddaa/griffe-2.0.0-py3-none-any.whl", hash = "sha256:5418081135a391c3e6e757a7f3f156f1a1a746cc7b4023868ff7d5e2f9a980aa", size = 5214, upload-time = "2026-02-09T19:09:44.105Z" },
 ]
@@ -1626,6 +1688,7 @@ dependencies = [
     { name = "colorama" },
     { name = "griffelib" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/f8/2e129fd4a86e52e58eefe664de05e7d502decf766e7316cc9e70fdec3e18/griffecli-2.0.0.tar.gz", hash = "sha256:312fa5ebb4ce6afc786356e2d0ce85b06c1c20d45abc42d74f0cda65e159f6ef", size = 56213, upload-time = "2026-03-23T21:06:54.8Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/ed/d93f7a447bbf7a935d8868e9617cbe1cadf9ee9ee6bd275d3040fbf93d60/griffecli-2.0.0-py3-none-any.whl", hash = "sha256:9f7cd9ee9b21d55e91689358978d2385ae65c22f307a63fb3269acf3f21e643d", size = 9345, upload-time = "2026-02-09T19:09:42.554Z" },
 ]
@@ -1634,6 +1697,7 @@ wheels = [
 name = "griffelib"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/06/eccbd311c9e2b3ca45dbc063b93134c57a1ccc7607c5e545264ad092c4a9/griffelib-2.0.0.tar.gz", hash = "sha256:e504d637a089f5cab9b5daf18f7645970509bf4f53eda8d79ed71cce8bd97934", size = 166312, upload-time = "2026-03-23T21:06:55.954Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/51/c936033e16d12b627ea334aaaaf42229c37620d0f15593456ab69ab48161/griffelib-2.0.0-py3-none-any.whl", hash = "sha256:01284878c966508b6d6f1dbff9b6fa607bc062d8261c5c7253cb285b06422a7f", size = 142004, upload-time = "2026-02-09T19:09:40.561Z" },
 ]
@@ -2085,6 +2149,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "jupyter-core"
+version = "5.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "platformdirs" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/49/9d1284d0dc65e2c757b74c6687b6d319b02f822ad039e5c512df9194d9dd/jupyter_core-5.9.1.tar.gz", hash = "sha256:4d09aaff303b9566c3ce657f580bd089ff5c91f5f89cf7d8846c3cdf465b5508", size = 89814, upload-time = "2025-10-16T19:19:18.444Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/e7/80988e32bf6f73919a113473a604f5a8f09094de312b9d52b79c2df7612b/jupyter_core-5.9.1-py3-none-any.whl", hash = "sha256:ebf87fdc6073d142e114c72c9e29a9d7ca03fad818c5d300ce2adc1fb0743407", size = 29032, upload-time = "2025-10-16T19:19:16.783Z" },
 ]
 
 [[package]]
@@ -3110,6 +3187,21 @@ wheels = [
 ]
 
 [[package]]
+name = "nbformat"
+version = "5.10.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fastjsonschema" },
+    { name = "jsonschema" },
+    { name = "jupyter-core" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/fd/91545e604bc3dad7dca9ed03284086039b294c6b3d75c0d2fa45f9e9caf3/nbformat-5.10.4.tar.gz", hash = "sha256:322168b14f937a5d11362988ecac2a4952d3d8e3a2cbeb2319584631226d5b3a", size = 142749, upload-time = "2024-04-04T11:20:37.371Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl", hash = "sha256:3b48d6c8fbca4b299bf3982ea7db1af21580e4fec269ad087b9e81588891200b", size = 78454, upload-time = "2024-04-04T11:20:34.895Z" },
+]
+
+[[package]]
 name = "nest-asyncio"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3158,6 +3250,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f9/76/3a5e4312c19a028770f86fd7c058cf9f4ec4321c6cf7526bab998a5b683c/nltk-3.9.2.tar.gz", hash = "sha256:0f409e9b069ca4177c1903c3e843eef90c7e92992fa4931ae607da6de49e1419", size = 2887629, upload-time = "2025-10-01T07:19:23.764Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/60/90/81ac364ef94209c100e12579629dc92bf7a709a84af32f8c551b02c07e94/nltk-3.9.2-py3-none-any.whl", hash = "sha256:1e209d2b3009110635ed9709a67a1a3e33a10f799490fa71cf4bec218c11c88a", size = 1513404, upload-time = "2025-10-01T07:19:21.648Z" },
+]
+
+[[package]]
+name = "notion-client"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a5/39/60afcbc0148c3dafaaefe851ae3f058077db49d66288dfb218a11a57b997/notion_client-3.0.0.tar.gz", hash = "sha256:05c4d2b4fa3491dc0de21c9c826277202ea8b8714077ee7f51a6e1a09ab23d0f", size = 31357, upload-time = "2026-02-16T11:15:48.024Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/ce/6b03f9aedd2edfcc28e23ced5c2582d543f6ddbb2be5c570533f02890b27/notion_client-3.0.0-py2.py3-none-any.whl", hash = "sha256:177fc3d2ace7e8ef69cf96f46269e8a66071c2c7c526194bf06ce7925853e759", size = 18746, upload-time = "2026-02-16T11:15:46.602Z" },
 ]
 
 [[package]]
@@ -4001,6 +4105,25 @@ wheels = [
 ]
 
 [[package]]
+name = "playwright"
+version = "1.58.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/c9/9c6061d5703267f1baae6a4647bfd1862e386fbfdb97d889f6f6ae9e3f64/playwright-1.58.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:96e3204aac292ee639edbfdef6298b4be2ea0a55a16b7068df91adac077cc606", size = 42251098, upload-time = "2026-01-30T15:09:24.028Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/40/59d34a756e02f8c670f0fee987d46f7ee53d05447d43cd114ca015cb168c/playwright-1.58.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:70c763694739d28df71ed578b9c8202bb83e8fe8fb9268c04dd13afe36301f71", size = 41039625, upload-time = "2026-01-30T15:09:27.558Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/ee/3ce6209c9c74a650aac9028c621f357a34ea5cd4d950700f8e2c4b7fe2c4/playwright-1.58.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:185e0132578733d02802dfddfbbc35f42be23a45ff49ccae5081f25952238117", size = 42251098, upload-time = "2026-01-30T15:09:30.461Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/af/009958cbf23fac551a940d34e3206e6c7eed2b8c940d0c3afd1feb0b0589/playwright-1.58.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:c95568ba1eda83812598c1dc9be60b4406dffd60b149bc1536180ad108723d6b", size = 46235268, upload-time = "2026-01-30T15:09:33.787Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/a6/0e66ad04b6d3440dae73efb39540c5685c5fc95b17c8b29340b62abbd952/playwright-1.58.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f9999948f1ab541d98812de25e3a8c410776aa516d948807140aff797b4bffa", size = 45964214, upload-time = "2026-01-30T15:09:36.751Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/236e60ab9f6d62ed0fd32150d61f1f494cefbf02304c0061e78ed80c1c32/playwright-1.58.0-py3-none-win32.whl", hash = "sha256:1e03be090e75a0fabbdaeab65ce17c308c425d879fa48bb1d7986f96bfad0b99", size = 36815998, upload-time = "2026-01-30T15:09:39.627Z" },
+    { url = "https://files.pythonhosted.org/packages/41/f8/5ec599c5e59d2f2f336a05b4f318e733077cd5044f24adb6f86900c3e6a7/playwright-1.58.0-py3-none-win_amd64.whl", hash = "sha256:a2bf639d0ce33b3ba38de777e08697b0d8f3dc07ab6802e4ac53fb65e3907af8", size = 36816005, upload-time = "2026-01-30T15:09:42.449Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c4/cc0229fea55c87d6c9c67fe44a21e2cd28d1d558a5478ed4d617e9fb0c93/playwright-1.58.0-py3-none-win_arm64.whl", hash = "sha256:32ffe5c303901a13a0ecab91d1c3f74baf73b84f4bedbb6b935f5bc11cc98e1b", size = 33085919, upload-time = "2026-01-30T15:09:45.71Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4544,6 +4667,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
+]
+
+[[package]]
 name = "pygithub"
 version = "2.8.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4774,6 +4909,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/78/96/804520d0850c7db98e5ccb70282e29208723f0964e88ffd9d0da2f52ea09/python_multipart-0.0.21.tar.gz", hash = "sha256:7137ebd4d3bbf70ea1622998f902b97a29434a9e8dc40eb203bbcf7c2a2cba92", size = 37196, upload-time = "2025-12-17T09:24:22.446Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/aa/76/03af049af4dcee5d27442f71b6924f01f3efb5d2bd34f23fcd563f2cc5f5/python_multipart-0.0.21-py3-none-any.whl", hash = "sha256:cf7a6713e01c87aa35387f4774e812c4361150938d20d232800f75ffcf266090", size = 24541, upload-time = "2025-12-17T09:24:21.153Z" },
+]
+
+[[package]]
+name = "python-pptx"
+version = "1.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lxml" },
+    { name = "pillow" },
+    { name = "typing-extensions" },
+    { name = "xlsxwriter" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/a9/0c0db8d37b2b8a645666f7fd8accea4c6224e013c42b1d5c17c93590cd06/python_pptx-1.0.2.tar.gz", hash = "sha256:479a8af0eaf0f0d76b6f00b0887732874ad2e3188230315290cd1f9dd9cc7095", size = 10109297, upload-time = "2024-08-07T17:33:37.772Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/4f/00be2196329ebbff56ce564aa94efb0fbc828d00de250b1980de1a34ab49/python_pptx-1.0.2-py3-none-any.whl", hash = "sha256:160838e0b8565a8b1f67947675886e9fea18aa5e795db7ae531606d68e785cba", size = 472788, upload-time = "2024-08-07T17:33:28.192Z" },
 ]
 
 [[package]]
@@ -5558,6 +5708,12 @@ wheels = [
 ]
 
 [[package]]
+name = "sgmllib3k"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/bd/3704a8c3e0942d711c1299ebf7b9091930adae6675d7c8f476a7ce48653c/sgmllib3k-1.0.0.tar.gz", hash = "sha256:7868fb1c8bfa764c1ac563d3cf369c381d1325d36124933a726f29fcdaa812e9", size = 5750, upload-time = "2010-08-24T14:33:52.445Z" }
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -5577,7 +5733,7 @@ wheels = [
 
 [[package]]
 name = "skill-seekers"
-version = "3.2.0"
+version = "3.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
@@ -5606,22 +5762,30 @@ dependencies = [
 
 [package.optional-dependencies]
 all = [
+    { name = "asciidoc" },
+    { name = "atlassian-python-api" },
     { name = "azure-storage-blob" },
     { name = "boto3" },
     { name = "chromadb" },
+    { name = "ebooklib" },
     { name = "fastapi" },
+    { name = "feedparser" },
     { name = "google-cloud-storage" },
     { name = "google-generativeai" },
     { name = "httpx" },
     { name = "httpx-sse" },
     { name = "mammoth" },
     { name = "mcp" },
+    { name = "nbformat" },
+    { name = "notion-client" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "openai" },
     { name = "pinecone" },
     { name = "python-docx" },
+    { name = "python-pptx" },
     { name = "sentence-transformers" },
+    { name = "slack-sdk" },
     { name = "sse-starlette" },
     { name = "starlette" },
     { name = "uvicorn" },
@@ -5639,11 +5803,26 @@ all-llms = [
     { name = "google-generativeai" },
     { name = "openai" },
 ]
+asciidoc = [
+    { name = "asciidoc" },
+]
 azure = [
     { name = "azure-storage-blob" },
 ]
+browser = [
+    { name = "playwright" },
+]
+chat = [
+    { name = "slack-sdk" },
+]
 chroma = [
     { name = "chromadb" },
+]
+confluence = [
+    { name = "atlassian-python-api" },
+]
+deepseek = [
+    { name = "openai" },
 ]
 docx = [
     { name = "mammoth" },
@@ -5657,11 +5836,23 @@ embedding = [
     { name = "uvicorn" },
     { name = "voyageai" },
 ]
+epub = [
+    { name = "ebooklib" },
+]
+fireworks = [
+    { name = "openai" },
+]
 gcs = [
     { name = "google-cloud-storage" },
 ]
 gemini = [
     { name = "google-generativeai" },
+]
+jupyter = [
+    { name = "nbformat" },
+]
+kimi = [
+    { name = "openai" },
 ]
 mcp = [
     { name = "httpx" },
@@ -5671,11 +5862,26 @@ mcp = [
     { name = "starlette" },
     { name = "uvicorn" },
 ]
+minimax = [
+    { name = "openai" },
+]
+notion = [
+    { name = "notion-client" },
+]
 openai = [
+    { name = "openai" },
+]
+openrouter = [
     { name = "openai" },
 ]
 pinecone = [
     { name = "pinecone" },
+]
+pptx = [
+    { name = "python-pptx" },
+]
+qwen = [
+    { name = "openai" },
 ]
 rag-upload = [
     { name = "chromadb" },
@@ -5683,11 +5889,17 @@ rag-upload = [
     { name = "sentence-transformers" },
     { name = "weaviate-client" },
 ]
+rss = [
+    { name = "feedparser" },
+]
 s3 = [
     { name = "boto3" },
 ]
 sentence-transformers = [
     { name = "sentence-transformers" },
+]
+together = [
+    { name = "openai" },
 ]
 video = [
     { name = "youtube-transcript-api" },
@@ -5726,6 +5938,10 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = ">=0.76.0" },
+    { name = "asciidoc", marker = "extra == 'all'", specifier = ">=10.0.0" },
+    { name = "asciidoc", marker = "extra == 'asciidoc'", specifier = ">=10.0.0" },
+    { name = "atlassian-python-api", marker = "extra == 'all'", specifier = ">=3.41.0" },
+    { name = "atlassian-python-api", marker = "extra == 'confluence'", specifier = ">=3.41.0" },
     { name = "azure-storage-blob", marker = "extra == 'all'", specifier = ">=12.19.0" },
     { name = "azure-storage-blob", marker = "extra == 'all-cloud'", specifier = ">=12.19.0" },
     { name = "azure-storage-blob", marker = "extra == 'azure'", specifier = ">=12.19.0" },
@@ -5737,9 +5953,13 @@ requires-dist = [
     { name = "chromadb", marker = "extra == 'chroma'", specifier = ">=0.4.0" },
     { name = "chromadb", marker = "extra == 'rag-upload'", specifier = ">=0.4.0" },
     { name = "click", specifier = ">=8.3.0" },
+    { name = "ebooklib", marker = "extra == 'all'", specifier = ">=0.18" },
+    { name = "ebooklib", marker = "extra == 'epub'", specifier = ">=0.18" },
     { name = "fastapi", marker = "extra == 'all'", specifier = ">=0.109.0" },
     { name = "fastapi", marker = "extra == 'embedding'", specifier = ">=0.109.0" },
     { name = "faster-whisper", marker = "extra == 'video-full'", specifier = ">=1.0.0" },
+    { name = "feedparser", marker = "extra == 'all'", specifier = ">=6.0.0" },
+    { name = "feedparser", marker = "extra == 'rss'", specifier = ">=6.0.0" },
     { name = "gitpython", specifier = ">=3.1.40" },
     { name = "google-cloud-storage", marker = "extra == 'all'", specifier = ">=2.10.0" },
     { name = "google-cloud-storage", marker = "extra == 'all-cloud'", specifier = ">=2.10.0" },
@@ -5759,18 +5979,30 @@ requires-dist = [
     { name = "mammoth", marker = "extra == 'docx'", specifier = ">=1.6.0" },
     { name = "mcp", marker = "extra == 'all'", specifier = ">=1.25,<2" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.25,<2" },
+    { name = "nbformat", marker = "extra == 'all'", specifier = ">=5.9.0" },
+    { name = "nbformat", marker = "extra == 'jupyter'", specifier = ">=5.9.0" },
     { name = "networkx", specifier = ">=3.0" },
+    { name = "notion-client", marker = "extra == 'all'", specifier = ">=2.0.0" },
+    { name = "notion-client", marker = "extra == 'notion'", specifier = ">=2.0.0" },
     { name = "numpy", marker = "extra == 'all'", specifier = ">=1.24.0" },
     { name = "numpy", marker = "extra == 'embedding'", specifier = ">=1.24.0" },
     { name = "openai", marker = "extra == 'all'", specifier = ">=1.0.0" },
     { name = "openai", marker = "extra == 'all-llms'", specifier = ">=1.0.0" },
+    { name = "openai", marker = "extra == 'deepseek'", specifier = ">=1.0.0" },
+    { name = "openai", marker = "extra == 'fireworks'", specifier = ">=1.0.0" },
+    { name = "openai", marker = "extra == 'kimi'", specifier = ">=1.0.0" },
+    { name = "openai", marker = "extra == 'minimax'", specifier = ">=1.0.0" },
     { name = "openai", marker = "extra == 'openai'", specifier = ">=1.0.0" },
+    { name = "openai", marker = "extra == 'openrouter'", specifier = ">=1.0.0" },
+    { name = "openai", marker = "extra == 'qwen'", specifier = ">=1.0.0" },
+    { name = "openai", marker = "extra == 'together'", specifier = ">=1.0.0" },
     { name = "opencv-python-headless", marker = "extra == 'video-full'", specifier = ">=4.9.0" },
     { name = "pathspec", specifier = ">=0.12.1" },
     { name = "pillow", specifier = ">=11.0.0" },
     { name = "pinecone", marker = "extra == 'all'", specifier = ">=5.0.0" },
     { name = "pinecone", marker = "extra == 'pinecone'", specifier = ">=5.0.0" },
     { name = "pinecone", marker = "extra == 'rag-upload'", specifier = ">=5.0.0" },
+    { name = "playwright", marker = "extra == 'browser'", specifier = ">=1.40.0" },
     { name = "pydantic", specifier = ">=2.12.3" },
     { name = "pydantic-settings", specifier = ">=2.11.0" },
     { name = "pygithub", specifier = ">=2.5.0" },
@@ -5780,6 +6012,8 @@ requires-dist = [
     { name = "python-docx", marker = "extra == 'all'", specifier = ">=1.1.0" },
     { name = "python-docx", marker = "extra == 'docx'", specifier = ">=1.1.0" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
+    { name = "python-pptx", marker = "extra == 'all'", specifier = ">=0.6.21" },
+    { name = "python-pptx", marker = "extra == 'pptx'", specifier = ">=0.6.21" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "requests", specifier = ">=2.32.5" },
     { name = "scenedetect", extras = ["opencv"], marker = "extra == 'video-full'", specifier = ">=0.6.4" },
@@ -5788,6 +6022,8 @@ requires-dist = [
     { name = "sentence-transformers", marker = "extra == 'embedding'", specifier = ">=2.3.0" },
     { name = "sentence-transformers", marker = "extra == 'rag-upload'", specifier = ">=2.2.0" },
     { name = "sentence-transformers", marker = "extra == 'sentence-transformers'", specifier = ">=2.2.0" },
+    { name = "slack-sdk", marker = "extra == 'all'", specifier = ">=3.27.0" },
+    { name = "slack-sdk", marker = "extra == 'chat'", specifier = ">=3.27.0" },
     { name = "sse-starlette", marker = "extra == 'all'", specifier = ">=3.0.2" },
     { name = "sse-starlette", marker = "extra == 'mcp'", specifier = ">=3.0.2" },
     { name = "starlette", marker = "extra == 'all'", specifier = ">=0.48.0" },
@@ -5808,7 +6044,7 @@ requires-dist = [
     { name = "yt-dlp", marker = "extra == 'video'", specifier = ">=2024.12.0" },
     { name = "yt-dlp", marker = "extra == 'video-full'", specifier = ">=2024.12.0" },
 ]
-provides-extras = ["mcp", "gemini", "openai", "all-llms", "s3", "gcs", "azure", "docx", "video", "video-full", "chroma", "weaviate", "sentence-transformers", "pinecone", "rag-upload", "all-cloud", "embedding", "all"]
+provides-extras = ["mcp", "gemini", "openai", "minimax", "kimi", "deepseek", "qwen", "openrouter", "together", "fireworks", "all-llms", "s3", "gcs", "azure", "docx", "epub", "video", "video-full", "chroma", "weaviate", "sentence-transformers", "pinecone", "rag-upload", "all-cloud", "jupyter", "asciidoc", "pptx", "confluence", "notion", "rss", "chat", "browser", "embedding", "all"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -5825,6 +6061,15 @@ dev = [
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "ruff", specifier = ">=0.14.13" },
     { name = "starlette", specifier = ">=0.31.0" },
+]
+
+[[package]]
+name = "slack-sdk"
+version = "3.41.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/35/fc009118a13187dd9731657c60138e5a7c2dea88681a7f04dc406af5da7d/slack_sdk-3.41.0.tar.gz", hash = "sha256:eb61eb12a65bebeca9cb5d36b3f799e836ed2be21b456d15df2627cfe34076ca", size = 250568, upload-time = "2026-03-12T16:10:11.381Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/df/2e4be347ff98281b505cc0ccf141408cdd25eb5ca9f3830deb361b2472d3/slack_sdk-3.41.0-py2.py3-none-any.whl", hash = "sha256:bb18dcdfff1413ec448e759cf807ec3324090993d8ab9111c74081623b692a89", size = 313885, upload-time = "2026-03-12T16:10:09.811Z" },
 ]
 
 [[package]]
@@ -6212,6 +6457,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540, upload-time = "2024-11-24T20:12:19.698Z" },
+]
+
+[[package]]
+name = "traitlets"
+version = "5.14.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
 ]
 
 [[package]]
@@ -6732,6 +6986,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/79/d9/7cfd5a312760ac4dd8bf0184a6ee9e43c33e47f3dadc303032ce012b8fa3/wrapt-1.17.3-cp314-cp314t-win_amd64.whl", hash = "sha256:73d496de46cd2cdbdbcce4ae4bcdb4afb6a11234a1df9c085249d55166b95116", size = 41334, upload-time = "2025-08-12T05:53:14.178Z" },
     { url = "https://files.pythonhosted.org/packages/46/78/10ad9781128ed2f99dbc474f43283b13fea8ba58723e98844367531c18e9/wrapt-1.17.3-cp314-cp314t-win_arm64.whl", hash = "sha256:f38e60678850c42461d4202739f9bf1e3a737c7ad283638251e79cc49effb6b6", size = 38471, upload-time = "2025-08-12T05:52:57.784Z" },
     { url = "https://files.pythonhosted.org/packages/1f/f6/a933bd70f98e9cf3e08167fc5cd7aaaca49147e48411c0bd5ae701bb2194/wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22", size = 23591, upload-time = "2025-08-12T05:53:20.674Z" },
+]
+
+[[package]]
+name = "xlsxwriter"
+version = "3.2.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/2c/c06ef49dc36e7954e55b802a8b231770d286a9758b3d936bd1e04ce5ba88/xlsxwriter-3.2.9.tar.gz", hash = "sha256:254b1c37a368c444eac6e2f867405cc9e461b0ed97a3233b2ac1e574efb4140c", size = 215940, upload-time = "2025-09-16T00:16:21.63Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/0c/3662f4a66880196a590b202f0db82d919dd2f89e99a27fadef91c4a33d41/xlsxwriter-3.2.9-py3-none-any.whl", hash = "sha256:9a5db42bc5dff014806c58a20b9eae7322a134abb6fce3c92c181bfb275ec5b3", size = 175315, upload-time = "2025-09-16T00:16:20.108Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -221,39 +221,12 @@ wheels = [
 ]
 
 [[package]]
-name = "asciidoc"
-version = "10.2.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1d/e7/315a82f2d256e9270977aa3c15e8fe281fd7c40b8e2a0b97e0cb61ca8fa0/asciidoc-10.2.1.tar.gz", hash = "sha256:d9f13c285981b3c7eb660d02ca0a2779981e88d48105de81bb40445e60dddb83", size = 230179, upload-time = "2024-07-17T03:12:52.681Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/1f/87941eaa96e86aa22086064f67e4187e2710fb76c147312979ea29278dac/asciidoc-10.2.1-py2.py3-none-any.whl", hash = "sha256:3f277a636b617c9ce7e0b87bcaea51f144500e9a5c8a6488421ee24594850d40", size = 272433, upload-time = "2024-07-17T03:12:49.012Z" },
-]
-
-[[package]]
 name = "async-timeout"
 version = "5.0.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274, upload-time = "2024-11-06T16:41:39.6Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233, upload-time = "2024-11-06T16:41:37.9Z" },
-]
-
-[[package]]
-name = "atlassian-python-api"
-version = "4.0.7"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "beautifulsoup4" },
-    { name = "deprecated" },
-    { name = "jmespath" },
-    { name = "oauthlib" },
-    { name = "requests" },
-    { name = "requests-oauthlib" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/40/e8/f23b7273e410c6fe9f98f9db25268c6736572f22a9566d1dc9ed3614bb68/atlassian_python_api-4.0.7.tar.gz", hash = "sha256:8d9cc6068b1d2a48eb434e22e57f6bbd918a47fac9e46b95b7a3cefb00fceacb", size = 271149, upload-time = "2025-08-21T13:19:40.746Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/83/e4f9976ce3c933a079b8931325e7a9c0a8bba7030a2cb85764c0048f3479/atlassian_python_api-4.0.7-py3-none-any.whl", hash = "sha256:46a70cb29eaab87c0a1697fccd3e25df1aa477e6aa4fb9ba936a9d46b425933c", size = 197746, upload-time = "2025-08-21T13:19:39.044Z" },
 ]
 
 [[package]]
@@ -1106,19 +1079,6 @@ wheels = [
 ]
 
 [[package]]
-name = "ebooklib"
-version = "0.20"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "lxml" },
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/77/85/322e8882a582d4b707220d1929cfb74c125f2ba513991edbce40dbc462de/ebooklib-0.20.tar.gz", hash = "sha256:35e2f9d7d39907be8d39ae2deb261b19848945903ae3dbb6577b187ead69e985", size = 127066, upload-time = "2025-10-26T20:56:20.968Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/ee/aa015c5de8b0dc42a8e507eae8c2de5d1c0e068c896858fec6d502402ed6/ebooklib-0.20-py3-none-any.whl", hash = "sha256:fff5322517a37e31c972d27be7d982cc3928c16b3dcc5fd7e8f7c0f5d7bcf42b", size = 40995, upload-time = "2025-10-26T20:56:19.104Z" },
-]
-
-[[package]]
 name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1160,27 +1120,6 @@ dependencies = [
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/05/99/49ee85903dee060d9f08297b4a342e5e0bcfca2f027a07b4ee0a38ab13f9/faster_whisper-1.2.1-py3-none-any.whl", hash = "sha256:79a66ad50688c0b794dd501dc340a736992a6342f7f95e5811be60b5224a26a7", size = 1118909, upload-time = "2025-10-31T11:35:47.794Z" },
-]
-
-[[package]]
-name = "fastjsonschema"
-version = "2.21.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/20/b5/23b216d9d985a956623b6bd12d4086b60f0059b27799f23016af04a74ea1/fastjsonschema-2.21.2.tar.gz", hash = "sha256:b1eb43748041c880796cd077f1a07c3d94e93ae84bba5ed36800a33554ae05de", size = 374130, upload-time = "2025-08-14T18:49:36.666Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/a8/20d0723294217e47de6d9e2e40fd4a9d2f7c4b6ef974babd482a59743694/fastjsonschema-2.21.2-py3-none-any.whl", hash = "sha256:1c797122d0a86c5cace2e54bf4e819c36223b552017172f32c5c024a6b77e463", size = 24024, upload-time = "2025-08-14T18:49:34.776Z" },
-]
-
-[[package]]
-name = "feedparser"
-version = "6.0.12"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "sgmllib3k" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/dc/79/db7edb5e77d6dfbc54d7d9df72828be4318275b2e580549ff45a962f6461/feedparser-6.0.12.tar.gz", hash = "sha256:64f76ce90ae3e8ef5d1ede0f8d3b50ce26bcce71dd8ae5e82b1cd2d4a5f94228", size = 286579, upload-time = "2025-09-10T13:33:59.486Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/eb/c96d64137e29ae17d83ad2552470bafe3a7a915e85434d9942077d7fd011/feedparser-6.0.12-py3-none-any.whl", hash = "sha256:6bbff10f5a52662c00a2e3f86a38928c37c48f77b3c511aedcd51de933549324", size = 81480, upload-time = "2025-09-10T13:33:58.022Z" },
 ]
 
 [[package]]
@@ -1675,7 +1614,6 @@ dependencies = [
     { name = "griffecli" },
     { name = "griffelib" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/04/56/28a0accac339c164b52a92c6cfc45a903acc0c174caa5c1713803467b533/griffe-2.0.0.tar.gz", hash = "sha256:c68979cd8395422083a51ea7cf02f9c119d889646d99b7b656ee43725de1b80f", size = 293906, upload-time = "2026-03-23T21:06:53.402Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/94/ee21d41e7eb4f823b94603b9d40f86d3c7fde80eacc2c3c71845476dddaa/griffe-2.0.0-py3-none-any.whl", hash = "sha256:5418081135a391c3e6e757a7f3f156f1a1a746cc7b4023868ff7d5e2f9a980aa", size = 5214, upload-time = "2026-02-09T19:09:44.105Z" },
 ]
@@ -1688,7 +1626,6 @@ dependencies = [
     { name = "colorama" },
     { name = "griffelib" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a4/f8/2e129fd4a86e52e58eefe664de05e7d502decf766e7316cc9e70fdec3e18/griffecli-2.0.0.tar.gz", hash = "sha256:312fa5ebb4ce6afc786356e2d0ce85b06c1c20d45abc42d74f0cda65e159f6ef", size = 56213, upload-time = "2026-03-23T21:06:54.8Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/ed/d93f7a447bbf7a935d8868e9617cbe1cadf9ee9ee6bd275d3040fbf93d60/griffecli-2.0.0-py3-none-any.whl", hash = "sha256:9f7cd9ee9b21d55e91689358978d2385ae65c22f307a63fb3269acf3f21e643d", size = 9345, upload-time = "2026-02-09T19:09:42.554Z" },
 ]
@@ -1697,7 +1634,6 @@ wheels = [
 name = "griffelib"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ad/06/eccbd311c9e2b3ca45dbc063b93134c57a1ccc7607c5e545264ad092c4a9/griffelib-2.0.0.tar.gz", hash = "sha256:e504d637a089f5cab9b5daf18f7645970509bf4f53eda8d79ed71cce8bd97934", size = 166312, upload-time = "2026-03-23T21:06:55.954Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/51/c936033e16d12b627ea334aaaaf42229c37620d0f15593456ab69ab48161/griffelib-2.0.0-py3-none-any.whl", hash = "sha256:01284878c966508b6d6f1dbff9b6fa607bc062d8261c5c7253cb285b06422a7f", size = 142004, upload-time = "2026-02-09T19:09:40.561Z" },
 ]
@@ -2149,19 +2085,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
-]
-
-[[package]]
-name = "jupyter-core"
-version = "5.9.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "platformdirs" },
-    { name = "traitlets" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/02/49/9d1284d0dc65e2c757b74c6687b6d319b02f822ad039e5c512df9194d9dd/jupyter_core-5.9.1.tar.gz", hash = "sha256:4d09aaff303b9566c3ce657f580bd089ff5c91f5f89cf7d8846c3cdf465b5508", size = 89814, upload-time = "2025-10-16T19:19:18.444Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/e7/80988e32bf6f73919a113473a604f5a8f09094de312b9d52b79c2df7612b/jupyter_core-5.9.1-py3-none-any.whl", hash = "sha256:ebf87fdc6073d142e114c72c9e29a9d7ca03fad818c5d300ce2adc1fb0743407", size = 29032, upload-time = "2025-10-16T19:19:16.783Z" },
 ]
 
 [[package]]
@@ -3187,21 +3110,6 @@ wheels = [
 ]
 
 [[package]]
-name = "nbformat"
-version = "5.10.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "fastjsonschema" },
-    { name = "jsonschema" },
-    { name = "jupyter-core" },
-    { name = "traitlets" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/fd/91545e604bc3dad7dca9ed03284086039b294c6b3d75c0d2fa45f9e9caf3/nbformat-5.10.4.tar.gz", hash = "sha256:322168b14f937a5d11362988ecac2a4952d3d8e3a2cbeb2319584631226d5b3a", size = 142749, upload-time = "2024-04-04T11:20:37.371Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl", hash = "sha256:3b48d6c8fbca4b299bf3982ea7db1af21580e4fec269ad087b9e81588891200b", size = 78454, upload-time = "2024-04-04T11:20:34.895Z" },
-]
-
-[[package]]
 name = "nest-asyncio"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3250,18 +3158,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f9/76/3a5e4312c19a028770f86fd7c058cf9f4ec4321c6cf7526bab998a5b683c/nltk-3.9.2.tar.gz", hash = "sha256:0f409e9b069ca4177c1903c3e843eef90c7e92992fa4931ae607da6de49e1419", size = 2887629, upload-time = "2025-10-01T07:19:23.764Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/60/90/81ac364ef94209c100e12579629dc92bf7a709a84af32f8c551b02c07e94/nltk-3.9.2-py3-none-any.whl", hash = "sha256:1e209d2b3009110635ed9709a67a1a3e33a10f799490fa71cf4bec218c11c88a", size = 1513404, upload-time = "2025-10-01T07:19:21.648Z" },
-]
-
-[[package]]
-name = "notion-client"
-version = "3.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "httpx" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a5/39/60afcbc0148c3dafaaefe851ae3f058077db49d66288dfb218a11a57b997/notion_client-3.0.0.tar.gz", hash = "sha256:05c4d2b4fa3491dc0de21c9c826277202ea8b8714077ee7f51a6e1a09ab23d0f", size = 31357, upload-time = "2026-02-16T11:15:48.024Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/aa/ce/6b03f9aedd2edfcc28e23ced5c2582d543f6ddbb2be5c570533f02890b27/notion_client-3.0.0-py2.py3-none-any.whl", hash = "sha256:177fc3d2ace7e8ef69cf96f46269e8a66071c2c7c526194bf06ce7925853e759", size = 18746, upload-time = "2026-02-16T11:15:46.602Z" },
 ]
 
 [[package]]
@@ -4105,25 +4001,6 @@ wheels = [
 ]
 
 [[package]]
-name = "playwright"
-version = "1.58.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "greenlet" },
-    { name = "pyee" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/c9/9c6061d5703267f1baae6a4647bfd1862e386fbfdb97d889f6f6ae9e3f64/playwright-1.58.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:96e3204aac292ee639edbfdef6298b4be2ea0a55a16b7068df91adac077cc606", size = 42251098, upload-time = "2026-01-30T15:09:24.028Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/40/59d34a756e02f8c670f0fee987d46f7ee53d05447d43cd114ca015cb168c/playwright-1.58.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:70c763694739d28df71ed578b9c8202bb83e8fe8fb9268c04dd13afe36301f71", size = 41039625, upload-time = "2026-01-30T15:09:27.558Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/ee/3ce6209c9c74a650aac9028c621f357a34ea5cd4d950700f8e2c4b7fe2c4/playwright-1.58.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:185e0132578733d02802dfddfbbc35f42be23a45ff49ccae5081f25952238117", size = 42251098, upload-time = "2026-01-30T15:09:30.461Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/af/009958cbf23fac551a940d34e3206e6c7eed2b8c940d0c3afd1feb0b0589/playwright-1.58.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:c95568ba1eda83812598c1dc9be60b4406dffd60b149bc1536180ad108723d6b", size = 46235268, upload-time = "2026-01-30T15:09:33.787Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/a6/0e66ad04b6d3440dae73efb39540c5685c5fc95b17c8b29340b62abbd952/playwright-1.58.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f9999948f1ab541d98812de25e3a8c410776aa516d948807140aff797b4bffa", size = 45964214, upload-time = "2026-01-30T15:09:36.751Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/4b/236e60ab9f6d62ed0fd32150d61f1f494cefbf02304c0061e78ed80c1c32/playwright-1.58.0-py3-none-win32.whl", hash = "sha256:1e03be090e75a0fabbdaeab65ce17c308c425d879fa48bb1d7986f96bfad0b99", size = 36815998, upload-time = "2026-01-30T15:09:39.627Z" },
-    { url = "https://files.pythonhosted.org/packages/41/f8/5ec599c5e59d2f2f336a05b4f318e733077cd5044f24adb6f86900c3e6a7/playwright-1.58.0-py3-none-win_amd64.whl", hash = "sha256:a2bf639d0ce33b3ba38de777e08697b0d8f3dc07ab6802e4ac53fb65e3907af8", size = 36816005, upload-time = "2026-01-30T15:09:42.449Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/c4/cc0229fea55c87d6c9c67fe44a21e2cd28d1d558a5478ed4d617e9fb0c93/playwright-1.58.0-py3-none-win_arm64.whl", hash = "sha256:32ffe5c303901a13a0ecab91d1c3f74baf73b84f4bedbb6b935f5bc11cc98e1b", size = 33085919, upload-time = "2026-01-30T15:09:45.71Z" },
-]
-
-[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4667,18 +4544,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyee"
-version = "13.0.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
-]
-
-[[package]]
 name = "pygithub"
 version = "2.8.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4909,21 +4774,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/78/96/804520d0850c7db98e5ccb70282e29208723f0964e88ffd9d0da2f52ea09/python_multipart-0.0.21.tar.gz", hash = "sha256:7137ebd4d3bbf70ea1622998f902b97a29434a9e8dc40eb203bbcf7c2a2cba92", size = 37196, upload-time = "2025-12-17T09:24:22.446Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/aa/76/03af049af4dcee5d27442f71b6924f01f3efb5d2bd34f23fcd563f2cc5f5/python_multipart-0.0.21-py3-none-any.whl", hash = "sha256:cf7a6713e01c87aa35387f4774e812c4361150938d20d232800f75ffcf266090", size = 24541, upload-time = "2025-12-17T09:24:21.153Z" },
-]
-
-[[package]]
-name = "python-pptx"
-version = "1.0.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "lxml" },
-    { name = "pillow" },
-    { name = "typing-extensions" },
-    { name = "xlsxwriter" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/52/a9/0c0db8d37b2b8a645666f7fd8accea4c6224e013c42b1d5c17c93590cd06/python_pptx-1.0.2.tar.gz", hash = "sha256:479a8af0eaf0f0d76b6f00b0887732874ad2e3188230315290cd1f9dd9cc7095", size = 10109297, upload-time = "2024-08-07T17:33:37.772Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/4f/00be2196329ebbff56ce564aa94efb0fbc828d00de250b1980de1a34ab49/python_pptx-1.0.2-py3-none-any.whl", hash = "sha256:160838e0b8565a8b1f67947675886e9fea18aa5e795db7ae531606d68e785cba", size = 472788, upload-time = "2024-08-07T17:33:28.192Z" },
 ]
 
 [[package]]
@@ -5708,12 +5558,6 @@ wheels = [
 ]
 
 [[package]]
-name = "sgmllib3k"
-version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9e/bd/3704a8c3e0942d711c1299ebf7b9091930adae6675d7c8f476a7ce48653c/sgmllib3k-1.0.0.tar.gz", hash = "sha256:7868fb1c8bfa764c1ac563d3cf369c381d1325d36124933a726f29fcdaa812e9", size = 5750, upload-time = "2010-08-24T14:33:52.445Z" }
-
-[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -5733,7 +5577,7 @@ wheels = [
 
 [[package]]
 name = "skill-seekers"
-version = "3.5.0"
+version = "3.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
@@ -5762,30 +5606,22 @@ dependencies = [
 
 [package.optional-dependencies]
 all = [
-    { name = "asciidoc" },
-    { name = "atlassian-python-api" },
     { name = "azure-storage-blob" },
     { name = "boto3" },
     { name = "chromadb" },
-    { name = "ebooklib" },
     { name = "fastapi" },
-    { name = "feedparser" },
     { name = "google-cloud-storage" },
     { name = "google-generativeai" },
     { name = "httpx" },
     { name = "httpx-sse" },
     { name = "mammoth" },
     { name = "mcp" },
-    { name = "nbformat" },
-    { name = "notion-client" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "openai" },
     { name = "pinecone" },
     { name = "python-docx" },
-    { name = "python-pptx" },
     { name = "sentence-transformers" },
-    { name = "slack-sdk" },
     { name = "sse-starlette" },
     { name = "starlette" },
     { name = "uvicorn" },
@@ -5803,26 +5639,11 @@ all-llms = [
     { name = "google-generativeai" },
     { name = "openai" },
 ]
-asciidoc = [
-    { name = "asciidoc" },
-]
 azure = [
     { name = "azure-storage-blob" },
 ]
-browser = [
-    { name = "playwright" },
-]
-chat = [
-    { name = "slack-sdk" },
-]
 chroma = [
     { name = "chromadb" },
-]
-confluence = [
-    { name = "atlassian-python-api" },
-]
-deepseek = [
-    { name = "openai" },
 ]
 docx = [
     { name = "mammoth" },
@@ -5836,23 +5657,11 @@ embedding = [
     { name = "uvicorn" },
     { name = "voyageai" },
 ]
-epub = [
-    { name = "ebooklib" },
-]
-fireworks = [
-    { name = "openai" },
-]
 gcs = [
     { name = "google-cloud-storage" },
 ]
 gemini = [
     { name = "google-generativeai" },
-]
-jupyter = [
-    { name = "nbformat" },
-]
-kimi = [
-    { name = "openai" },
 ]
 mcp = [
     { name = "httpx" },
@@ -5862,26 +5671,11 @@ mcp = [
     { name = "starlette" },
     { name = "uvicorn" },
 ]
-minimax = [
-    { name = "openai" },
-]
-notion = [
-    { name = "notion-client" },
-]
 openai = [
-    { name = "openai" },
-]
-openrouter = [
     { name = "openai" },
 ]
 pinecone = [
     { name = "pinecone" },
-]
-pptx = [
-    { name = "python-pptx" },
-]
-qwen = [
-    { name = "openai" },
 ]
 rag-upload = [
     { name = "chromadb" },
@@ -5889,17 +5683,11 @@ rag-upload = [
     { name = "sentence-transformers" },
     { name = "weaviate-client" },
 ]
-rss = [
-    { name = "feedparser" },
-]
 s3 = [
     { name = "boto3" },
 ]
 sentence-transformers = [
     { name = "sentence-transformers" },
-]
-together = [
-    { name = "openai" },
 ]
 video = [
     { name = "youtube-transcript-api" },
@@ -5938,10 +5726,6 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = ">=0.76.0" },
-    { name = "asciidoc", marker = "extra == 'all'", specifier = ">=10.0.0" },
-    { name = "asciidoc", marker = "extra == 'asciidoc'", specifier = ">=10.0.0" },
-    { name = "atlassian-python-api", marker = "extra == 'all'", specifier = ">=3.41.0" },
-    { name = "atlassian-python-api", marker = "extra == 'confluence'", specifier = ">=3.41.0" },
     { name = "azure-storage-blob", marker = "extra == 'all'", specifier = ">=12.19.0" },
     { name = "azure-storage-blob", marker = "extra == 'all-cloud'", specifier = ">=12.19.0" },
     { name = "azure-storage-blob", marker = "extra == 'azure'", specifier = ">=12.19.0" },
@@ -5953,13 +5737,9 @@ requires-dist = [
     { name = "chromadb", marker = "extra == 'chroma'", specifier = ">=0.4.0" },
     { name = "chromadb", marker = "extra == 'rag-upload'", specifier = ">=0.4.0" },
     { name = "click", specifier = ">=8.3.0" },
-    { name = "ebooklib", marker = "extra == 'all'", specifier = ">=0.18" },
-    { name = "ebooklib", marker = "extra == 'epub'", specifier = ">=0.18" },
     { name = "fastapi", marker = "extra == 'all'", specifier = ">=0.109.0" },
     { name = "fastapi", marker = "extra == 'embedding'", specifier = ">=0.109.0" },
     { name = "faster-whisper", marker = "extra == 'video-full'", specifier = ">=1.0.0" },
-    { name = "feedparser", marker = "extra == 'all'", specifier = ">=6.0.0" },
-    { name = "feedparser", marker = "extra == 'rss'", specifier = ">=6.0.0" },
     { name = "gitpython", specifier = ">=3.1.40" },
     { name = "google-cloud-storage", marker = "extra == 'all'", specifier = ">=2.10.0" },
     { name = "google-cloud-storage", marker = "extra == 'all-cloud'", specifier = ">=2.10.0" },
@@ -5979,30 +5759,18 @@ requires-dist = [
     { name = "mammoth", marker = "extra == 'docx'", specifier = ">=1.6.0" },
     { name = "mcp", marker = "extra == 'all'", specifier = ">=1.25,<2" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.25,<2" },
-    { name = "nbformat", marker = "extra == 'all'", specifier = ">=5.9.0" },
-    { name = "nbformat", marker = "extra == 'jupyter'", specifier = ">=5.9.0" },
     { name = "networkx", specifier = ">=3.0" },
-    { name = "notion-client", marker = "extra == 'all'", specifier = ">=2.0.0" },
-    { name = "notion-client", marker = "extra == 'notion'", specifier = ">=2.0.0" },
     { name = "numpy", marker = "extra == 'all'", specifier = ">=1.24.0" },
     { name = "numpy", marker = "extra == 'embedding'", specifier = ">=1.24.0" },
     { name = "openai", marker = "extra == 'all'", specifier = ">=1.0.0" },
     { name = "openai", marker = "extra == 'all-llms'", specifier = ">=1.0.0" },
-    { name = "openai", marker = "extra == 'deepseek'", specifier = ">=1.0.0" },
-    { name = "openai", marker = "extra == 'fireworks'", specifier = ">=1.0.0" },
-    { name = "openai", marker = "extra == 'kimi'", specifier = ">=1.0.0" },
-    { name = "openai", marker = "extra == 'minimax'", specifier = ">=1.0.0" },
     { name = "openai", marker = "extra == 'openai'", specifier = ">=1.0.0" },
-    { name = "openai", marker = "extra == 'openrouter'", specifier = ">=1.0.0" },
-    { name = "openai", marker = "extra == 'qwen'", specifier = ">=1.0.0" },
-    { name = "openai", marker = "extra == 'together'", specifier = ">=1.0.0" },
     { name = "opencv-python-headless", marker = "extra == 'video-full'", specifier = ">=4.9.0" },
     { name = "pathspec", specifier = ">=0.12.1" },
     { name = "pillow", specifier = ">=11.0.0" },
     { name = "pinecone", marker = "extra == 'all'", specifier = ">=5.0.0" },
     { name = "pinecone", marker = "extra == 'pinecone'", specifier = ">=5.0.0" },
     { name = "pinecone", marker = "extra == 'rag-upload'", specifier = ">=5.0.0" },
-    { name = "playwright", marker = "extra == 'browser'", specifier = ">=1.40.0" },
     { name = "pydantic", specifier = ">=2.12.3" },
     { name = "pydantic-settings", specifier = ">=2.11.0" },
     { name = "pygithub", specifier = ">=2.5.0" },
@@ -6012,8 +5780,6 @@ requires-dist = [
     { name = "python-docx", marker = "extra == 'all'", specifier = ">=1.1.0" },
     { name = "python-docx", marker = "extra == 'docx'", specifier = ">=1.1.0" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
-    { name = "python-pptx", marker = "extra == 'all'", specifier = ">=0.6.21" },
-    { name = "python-pptx", marker = "extra == 'pptx'", specifier = ">=0.6.21" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "requests", specifier = ">=2.32.5" },
     { name = "scenedetect", extras = ["opencv"], marker = "extra == 'video-full'", specifier = ">=0.6.4" },
@@ -6022,8 +5788,6 @@ requires-dist = [
     { name = "sentence-transformers", marker = "extra == 'embedding'", specifier = ">=2.3.0" },
     { name = "sentence-transformers", marker = "extra == 'rag-upload'", specifier = ">=2.2.0" },
     { name = "sentence-transformers", marker = "extra == 'sentence-transformers'", specifier = ">=2.2.0" },
-    { name = "slack-sdk", marker = "extra == 'all'", specifier = ">=3.27.0" },
-    { name = "slack-sdk", marker = "extra == 'chat'", specifier = ">=3.27.0" },
     { name = "sse-starlette", marker = "extra == 'all'", specifier = ">=3.0.2" },
     { name = "sse-starlette", marker = "extra == 'mcp'", specifier = ">=3.0.2" },
     { name = "starlette", marker = "extra == 'all'", specifier = ">=0.48.0" },
@@ -6044,7 +5808,7 @@ requires-dist = [
     { name = "yt-dlp", marker = "extra == 'video'", specifier = ">=2024.12.0" },
     { name = "yt-dlp", marker = "extra == 'video-full'", specifier = ">=2024.12.0" },
 ]
-provides-extras = ["mcp", "gemini", "openai", "minimax", "kimi", "deepseek", "qwen", "openrouter", "together", "fireworks", "all-llms", "s3", "gcs", "azure", "docx", "epub", "video", "video-full", "chroma", "weaviate", "sentence-transformers", "pinecone", "rag-upload", "all-cloud", "jupyter", "asciidoc", "pptx", "confluence", "notion", "rss", "chat", "browser", "embedding", "all"]
+provides-extras = ["mcp", "gemini", "openai", "all-llms", "s3", "gcs", "azure", "docx", "video", "video-full", "chroma", "weaviate", "sentence-transformers", "pinecone", "rag-upload", "all-cloud", "embedding", "all"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -6061,15 +5825,6 @@ dev = [
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "ruff", specifier = ">=0.14.13" },
     { name = "starlette", specifier = ">=0.31.0" },
-]
-
-[[package]]
-name = "slack-sdk"
-version = "3.41.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/22/35/fc009118a13187dd9731657c60138e5a7c2dea88681a7f04dc406af5da7d/slack_sdk-3.41.0.tar.gz", hash = "sha256:eb61eb12a65bebeca9cb5d36b3f799e836ed2be21b456d15df2627cfe34076ca", size = 250568, upload-time = "2026-03-12T16:10:11.381Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a1/df/2e4be347ff98281b505cc0ccf141408cdd25eb5ca9f3830deb361b2472d3/slack_sdk-3.41.0-py2.py3-none-any.whl", hash = "sha256:bb18dcdfff1413ec448e759cf807ec3324090993d8ab9111c74081623b692a89", size = 313885, upload-time = "2026-03-12T16:10:09.811Z" },
 ]
 
 [[package]]
@@ -6457,15 +6212,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540, upload-time = "2024-11-24T20:12:19.698Z" },
-]
-
-[[package]]
-name = "traitlets"
-version = "5.14.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
 ]
 
 [[package]]
@@ -6986,15 +6732,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/79/d9/7cfd5a312760ac4dd8bf0184a6ee9e43c33e47f3dadc303032ce012b8fa3/wrapt-1.17.3-cp314-cp314t-win_amd64.whl", hash = "sha256:73d496de46cd2cdbdbcce4ae4bcdb4afb6a11234a1df9c085249d55166b95116", size = 41334, upload-time = "2025-08-12T05:53:14.178Z" },
     { url = "https://files.pythonhosted.org/packages/46/78/10ad9781128ed2f99dbc474f43283b13fea8ba58723e98844367531c18e9/wrapt-1.17.3-cp314-cp314t-win_arm64.whl", hash = "sha256:f38e60678850c42461d4202739f9bf1e3a737c7ad283638251e79cc49effb6b6", size = 38471, upload-time = "2025-08-12T05:52:57.784Z" },
     { url = "https://files.pythonhosted.org/packages/1f/f6/a933bd70f98e9cf3e08167fc5cd7aaaca49147e48411c0bd5ae701bb2194/wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22", size = 23591, upload-time = "2025-08-12T05:53:20.674Z" },
-]
-
-[[package]]
-name = "xlsxwriter"
-version = "3.2.9"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/46/2c/c06ef49dc36e7954e55b802a8b231770d286a9758b3d936bd1e04ce5ba88/xlsxwriter-3.2.9.tar.gz", hash = "sha256:254b1c37a368c444eac6e2f867405cc9e461b0ed97a3233b2ac1e574efb4140c", size = 215940, upload-time = "2025-09-16T00:16:21.63Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/0c/3662f4a66880196a590b202f0db82d919dd2f89e99a27fadef91c4a33d41/xlsxwriter-3.2.9-py3-none-any.whl", hash = "sha256:9a5db42bc5dff014806c58a20b9eae7322a134abb6fce3c92c181bfb275ec5b3", size = 175315, upload-time = "2025-09-16T00:16:20.108Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **5 new CLI flags** for GitHub issue scraping: `--issue-labels`, `--issue-state`, `--since`, `--max-comments`, `--per-issue-files`
- **All new features are opt-in** — zero behavior changes for existing users
- Per-issue markdown files with YAML frontmatter (behind `--per-issue-files`)
- Comment fetching disabled by default (`--max-comments 0`)
- Issue body truncated to 500 chars by default (full body only with `--per-issue-files`)
- Pinecone adaptor parses frontmatter into vector metadata
- Config validation for new fields (ISO8601 dates, label format, state enum)

## Files Changed (12)

**Source (7):**
- `github_scraper.py` — filtering logic, per-issue file generation, `setup_argument_parser()`, `main()`
- `github_fetcher.py` — filter params forwarded to GitHub API
- `arguments/github.py` — 5 new CLI argument definitions
- `arguments/create.py` — same 5 args registered for unified `create` command
- `create_command.py` — forward new args via `_build_config()`
- `config_validator.py` — validate new config fields
- `adaptors/pinecone_adaptor.py` — frontmatter parsing into vector metadata

**Tests (3):**
- `test_github_scraper.py` — per-issue files, filtering, body truncation, comments
- `test_github_fetcher.py` — filtered fetch tests
- `test_pinecone_adaptor.py` — frontmatter parsing tests

**Other (2):**
- `.env.example` — added PINECONE_API_KEY, PINECONE_ASSISTANT
- `uv.lock` — lock file sync

## Test plan

- [x] 140 targeted tests pass (`test_github_scraper`, `test_github_fetcher`, `test_pinecone_adaptor`)
- [x] Full suite: 3026 passed, 11 known skips
- [x] Lint clean (`ruff check`, `ruff format --check`)
- [ ] Reviewer: verify new flags work end-to-end with a real GitHub repo