### PR TITLE
fix: detect Unity via C# imports to prevent misidentification as Unreal

### DIFF
--- a/src/skill_seekers/cli/architectural_pattern_detector.py
+++ b/src/skill_seekers/cli/architectural_pattern_detector.py
@@ -95,6 +95,8 @@ class ArchitecturalPatternDetector:
             "ProjectSettings/ProjectVersion.txt",
             ".unity",
             "Library/",
+            "UnityEngine",  # Import: using UnityEngine; in C# scripts
+            "Packages/manifest.json",  # Unity Package Manager manifest
         ],
         "Unreal": ["Source/", ".uproject", "Config/DefaultEngine.ini", "Binaries/", "Content/"],
         "Godot": ["project.godot", ".godot", ".tscn", ".tres", ".gd"],
@@ -261,14 +263,21 @@ class ArchitecturalPatternDetector:
         for framework in ["Unity", "Unreal", "Godot"]:
             if framework in self.FRAMEWORK_MARKERS:
                 markers = self.FRAMEWORK_MARKERS[framework]
-                # Check both analyzed files AND directory structure
+                # Check analyzed file paths, directory structure, AND imports
                 file_matches = sum(1 for marker in markers if marker.lower() in all_content.lower())
                 dir_matches = sum(1 for marker in markers if marker.lower() in dir_content.lower())
-                total_matches = file_matches + dir_matches
+                import_matches = sum(
+                    1 for marker in markers if marker.lower() in import_content.lower()
+                )
 
-                if total_matches >= 2:
+                # Import-based detection is high confidence (single match sufficient)
+                # Path/directory-based detection requires 2+ matches to avoid false positives
+                if import_matches >= 1 or (file_matches + dir_matches) >= 2:
                     detected.append(framework)
-                    logger.info(f"  📦 Detected framework: {framework}")
+                    logger.info(
+                        f"  📦 Detected framework: {framework} "
+                        f"(imports:{import_matches} path:{file_matches} dir:{dir_matches})"
+                    )
                     # Return early to prevent web framework false positives
                     return detected
 

--- a/tests/test_architectural_pattern_detector.py
+++ b/tests/test_architectural_pattern_detector.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""
+Tests for architectural_pattern_detector.py - Framework detection.
+
+Regression tests for:
+- Issue #365: Unity C# projects misidentified as Unreal
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from skill_seekers.cli.architectural_pattern_detector import ArchitecturalPatternDetector
+
+
+@pytest.fixture
+def detector():
+    return ArchitecturalPatternDetector(enhance_with_ai=False)
+
+
+def _unity_files(root: str) -> list[dict]:
+    """Simulate files_analysis for a Unity C# project."""
+    return [
+        {
+            "file": f"{root}/Assets/Scripts/Player.cs",
+            "language": "C#",
+            "imports": ["UnityEngine", "UnityEngine.UI", "System.Collections"],
+        },
+        {
+            "file": f"{root}/Assets/Scripts/GameManager.cs",
+            "language": "C#",
+            "imports": ["UnityEngine", "Zenject"],
+        },
+        {
+            "file": f"{root}/Assets/Scripts/Enemy.cs",
+            "language": "C#",
+            "imports": ["UnityEngine", "System.Collections.Generic"],
+        },
+    ]
+
+
+def _make_unity_dir(tmp_path: Path) -> Path:
+    """Create a minimal Unity project directory structure."""
+    (tmp_path / "Assets").mkdir()
+    (tmp_path / "Library").mkdir()
+    (tmp_path / "Packages").mkdir()
+    (tmp_path / "ProjectSettings").mkdir()
+    (tmp_path / "Packages" / "manifest.json").write_text(
+        '{"dependencies": {"com.unity.2d.sprite": "1.0.0"}}'
+    )
+    (tmp_path / "ProjectSettings" / "ProjectVersion.txt").write_text("m_EditorVersion: 2022.3.10f1")
+    return tmp_path
+
+
+class TestUnityFrameworkDetection:
+    """Regression tests for Unity vs Unreal framework detection (Issue #365)."""
+
+    def test_unity_detected_via_imports(self, detector, tmp_path):
+        """Unity project is detected correctly when C# files import UnityEngine."""
+        root = str(tmp_path)
+        _make_unity_dir(tmp_path)
+        files = _unity_files(root)
+
+        frameworks = detector._detect_frameworks(tmp_path, files)
+
+        assert "Unity" in frameworks, f"Expected Unity, got {frameworks}"
+        assert "Unreal" not in frameworks, f"Unreal should not be detected: {frameworks}"
+
+    def test_unity_not_misidentified_as_unreal_with_source_dir(self, detector, tmp_path):
+        """Unity project with a 'Source' subfolder must NOT be identified as Unreal (Issue #365)."""
+        root = str(tmp_path)
+        _make_unity_dir(tmp_path)
+        # Simulate the common pattern: Assets/Scripts/Source/... exists
+        source_dir = tmp_path / "Assets" / "Scripts" / "Source"
+        source_dir.mkdir(parents=True)
+
+        files = _unity_files(root)
+        # Add a file whose path contains 'Source/' (the false-positive trigger for Unreal)
+        files.append(
+            {
+                "file": f"{root}/Assets/Scripts/Source/Utilities.cs",
+                "language": "C#",
+                "imports": ["UnityEngine", "System"],
+            }
+        )
+
+        frameworks = detector._detect_frameworks(tmp_path, files)
+
+        assert "Unity" in frameworks, f"Expected Unity, got {frameworks}"
+        assert "Unreal" not in frameworks, f"Unreal falsely detected: {frameworks}"
+
+    def test_unreal_project_still_detected(self, detector, tmp_path):
+        """Genuine Unreal projects are still identified correctly."""
+        (tmp_path / "Source").mkdir()
+        (tmp_path / "Binaries").mkdir()
+        (tmp_path / "Content").mkdir()
+        (tmp_path / "Config").mkdir()
+        (tmp_path / "MyGame.uproject").write_text('{"FileVersion": 3}')
+
+        files = [
+            {
+                "file": f"{tmp_path}/Source/MyGame/MyGameCharacter.cpp",
+                "language": "C++",
+                "imports": [],
+            },
+            {
+                "file": f"{tmp_path}/Source/MyGame/MyGameCharacter.h",
+                "language": "C++",
+                "imports": [],
+            },
+        ]
+
+        frameworks = detector._detect_frameworks(tmp_path, files)
+
+        assert "Unreal" in frameworks, f"Expected Unreal, got {frameworks}"
+        assert "Unity" not in frameworks, f"Unity should not be detected: {frameworks}"
+
+    def test_unity_detected_with_manifest_in_paths(self, detector, tmp_path):
+        """Unity project is detected via Packages/manifest.json in file paths."""
+        root = str(tmp_path)
+        _make_unity_dir(tmp_path)
+
+        files = [
+            {
+                "file": f"{root}/Packages/manifest.json",
+                "language": "JSON",
+                "imports": [],
+            },
+            {
+                "file": f"{root}/Assets/Scripts/Player.cs",
+                "language": "C#",
+                "imports": ["UnityEngine"],
+            },
+        ]
+
+        frameworks = detector._detect_frameworks(tmp_path, files)
+
+        assert "Unity" in frameworks, f"Expected Unity, got {frameworks}"


### PR DESCRIPTION
Fixes #365

## Problem

Unity C# projects were incorrectly detected as `Unreal` by `architectural_pattern_detector.py`. This happened because:

1. **Game engine detection did not check imports** — the `_detect_frameworks` method searched file paths and directory names for game engine markers, but never checked `import_content`. This meant that `using UnityEngine;` statements in C# scripts were completely ignored.

2. **Unity markers lacked import-based signals** — `UnityEngine` (the most reliable Unity indicator) and `Packages/manifest.json` (the Unity Package Manager manifest) were not in `FRAMEWORK_MARKERS["Unity"]`.

3. **Path-based matching triggered false Unreal positives** — if a Unity project had files under a `Source/` or `Content/` subdirectory (both valid Unreal markers), those paths matched Unreal's markers via substring search, pushing Unreal to 2+ matches while Unity stayed at 0–1.

## Solution

Two targeted changes to `architectural_pattern_detector.py`:

**1. New Unity markers:**
```python
"Unity": [
    ...existing markers...,
    "UnityEngine",          # Import: using UnityEngine; in C# scripts
    "Packages/manifest.json",  # Unity Package Manager manifest
],
```

**2. Import-based detection for game engines (consistent with other frameworks):**
```python
# Import-based detection is high confidence (single match sufficient)
# Path/directory-based detection requires 2+ matches to avoid false positives
if import_matches >= 1 or (file_matches + dir_matches) >= 2:
    detected.append(framework)
    return detected
```

This mirrors the logic already used for non-game-engine frameworks (Django, Spring, etc.) where a single import match is treated as high-confidence evidence.

## Testing

Added `tests/test_architectural_pattern_detector.py` with 4 regression tests:

- `test_unity_detected_via_imports` — Unity detected from `using UnityEngine;` imports alone
- `test_unity_not_misidentified_as_unreal_with_source_dir` — Unity project with a `Source/` subfolder is NOT flagged as Unreal (the exact scenario from #365)
- `test_unreal_project_still_detected` — genuine Unreal projects (with `.uproject`) still work
- `test_unity_detected_with_manifest_in_paths` — Unity detected via `Packages/manifest.json` in analyzed file paths

All 4 tests pass. Ruff lint and format checks pass.