### PR TITLE
fix: insert markdown image refs for extracted_images in PDF output

### DIFF
--- a/src/skill_seekers/cli/pdf_scraper.py
+++ b/src/skill_seekers/cli/pdf_scraper.py
@@ -333,7 +333,9 @@ class PDFToSkillConverter(SkillConverter):
                     f.write("### Images\n\n")
                     for img in page["extracted_images"]:
                         img_filename = img["filename"]
-                        f.write(f"![{img_filename}](../assets/images/{img_filename})\n\n")
+                        page_num = img.get("page_number", page.get("page_number", ""))
+                        alt_text = f"Image from page {page_num}" if page_num else "Image"
+                        f.write(f"![{alt_text}](../assets/images/{img_filename})\n\n")
 
                 # Add images in legacy format (with raw data, not yet saved)
                 elif page.get("images"):

--- a/src/skill_seekers/cli/pdf_scraper.py
+++ b/src/skill_seekers/cli/pdf_scraper.py
@@ -328,8 +328,15 @@ class PDFToSkillConverter(SkillConverter):
                         lang = code.get("language", "")
                         f.write(f"```{lang}\n{code['code']}\n```\n\n")
 
-                # Add images
-                if page.get("images"):
+                # Add images extracted by pdf_extractor_poc (already saved to disk)
+                if page.get("extracted_images"):
+                    f.write("### Images\n\n")
+                    for img in page["extracted_images"]:
+                        img_filename = img["filename"]
+                        f.write(f"![{img_filename}](../assets/images/{img_filename})\n\n")
+
+                # Add images in legacy format (with raw data, not yet saved)
+                elif page.get("images"):
                     # Create assets directory if needed
                     assets_dir = os.path.join(self.skill_dir, "assets")
                     os.makedirs(assets_dir, exist_ok=True)

--- a/tests/test_pdf_scraper.py
+++ b/tests/test_pdf_scraper.py
@@ -435,12 +435,6 @@ class TestImageHandling(unittest.TestCase):
 
         converter.skill_dir = str(Path(self.temp_dir) / "test_skill")
 
-        # Pre-create the images directory with a dummy image file
-        images_dir = Path(self.temp_dir) / "test_skill" / "assets" / "images"
-        images_dir.mkdir(parents=True, exist_ok=True)
-        dummy_image = images_dir / "test_page18_img1.png"
-        dummy_image.write_bytes(b"PNG")
-
         converter.extracted_data = {
             "pages": [
                 {
@@ -450,7 +444,7 @@ class TestImageHandling(unittest.TestCase):
                     "extracted_images": [
                         {
                             "filename": "test_page18_img1.png",
-                            "path": str(dummy_image),
+                            "path": "/tmp/test_page18_img1.png",
                             "page_number": 18,
                             "width": 200,
                             "height": 150,
@@ -469,11 +463,11 @@ class TestImageHandling(unittest.TestCase):
         ref_file = Path(self.temp_dir) / "test_skill" / "references" / "test.md"
         content = ref_file.read_text()
 
-        self.assertIn("![test_page18_img1.png]", content)
+        self.assertIn("![Image from page 18]", content)
         self.assertIn("../assets/images/test_page18_img1.png", content)
 
 
-
+class TestErrorHandling(unittest.TestCase):
     """Test error handling for invalid inputs"""
 
     def setUp(self):

--- a/tests/test_pdf_scraper.py
+++ b/tests/test_pdf_scraper.py
@@ -428,8 +428,52 @@ class TestImageHandling(unittest.TestCase):
         self.assertIn("![", content)  # Markdown image syntax
         self.assertIn("../assets/", content)  # Relative path to assets
 
+    def test_extracted_images_references_in_markdown(self):
+        """Test that extracted_images (pdf_extractor_poc format) are referenced in markdown"""
+        config = {"name": "test_skill", "pdf_path": "test.pdf"}
+        converter = self.PDFToSkillConverter(config)
 
-class TestErrorHandling(unittest.TestCase):
+        converter.skill_dir = str(Path(self.temp_dir) / "test_skill")
+
+        # Pre-create the images directory with a dummy image file
+        images_dir = Path(self.temp_dir) / "test_skill" / "assets" / "images"
+        images_dir.mkdir(parents=True, exist_ok=True)
+        dummy_image = images_dir / "test_page18_img1.png"
+        dummy_image.write_bytes(b"PNG")
+
+        converter.extracted_data = {
+            "pages": [
+                {
+                    "page_number": 18,
+                    "text": "Architecture diagram",
+                    "code_blocks": [],
+                    "extracted_images": [
+                        {
+                            "filename": "test_page18_img1.png",
+                            "path": str(dummy_image),
+                            "page_number": 18,
+                            "width": 200,
+                            "height": 150,
+                            "format": "png",
+                            "size_bytes": 3,
+                        }
+                    ],
+                }
+            ],
+            "total_pages": 1,
+        }
+
+        converter.build_skill()
+
+        # Check reference file has image markdown reference
+        ref_file = Path(self.temp_dir) / "test_skill" / "references" / "test.md"
+        content = ref_file.read_text()
+
+        self.assertIn("![test_page18_img1.png]", content)
+        self.assertIn("../assets/images/test_page18_img1.png", content)
+
+
+
     """Test error handling for invalid inputs"""
 
     def setUp(self):


### PR DESCRIPTION
Fixes #338

## Problem

Images extracted from PDFs by `pdf_extractor_poc.py` were saved to
`assets/images/` correctly, but never referenced in the generated
markdown files. The `_generate_reference_file` method in `pdf_scraper.py`
checked for `page["images"]` (a legacy format expecting raw `data` bytes),
while the extractor stores images as `page["extracted_images"]` with
`filename` and `path` keys — images already written to disk.

## Solution

Added a new block in `_generate_reference_file` that handles the
`extracted_images` format: it writes `![filename](../assets/images/filename)`
markdown references for each image. The legacy `images` format (with raw
binary data) is preserved as a fallback via `elif` for backward compatibility.

## Testing

- Added `test_extracted_images_references_in_markdown` to `TestImageHandling`
  which verifies the new format produces correct `![...]()` references
- All 6 existing `TestImageHandling` tests continue to pass