### PR TITLE
fix(unified): emit C3.x output for local sources (#363)

### DIFF
--- a/src/skill_seekers/cli/unified_skill_builder.py
+++ b/src/skill_seekers/cli/unified_skill_builder.py
@@ -882,18 +882,9 @@ This skill combines knowledge from multiple sources:
                 content += f"  - {extra_label}: {source.get(extra_key, extra_default)}\n"
 
         # C3.x Architecture & Code Analysis section (if available)
-        github_data = self.scraped_data.get("github", {})
-        # Handle both dict and list cases
-        if isinstance(github_data, dict):
-            github_data = github_data.get("data", {})
-        elif isinstance(github_data, list) and len(github_data) > 0:
-            first_item = github_data[0]
-            github_data = first_item.get("data", {}) if isinstance(first_item, dict) else {}
-        else:
-            github_data = {}
-
-        if github_data.get("c3_analysis"):
-            content += self._format_c3_summary_section(github_data["c3_analysis"])
+        c3_payloads = self._collect_c3_payloads()
+        if c3_payloads:
+            content += self._format_c3_summary_section(c3_payloads)
 
         # Data quality section
         if self.conflicts:
@@ -1099,6 +1090,9 @@ This skill combines knowledge from multiple sources:
             if github_data.get("c3_analysis"):
                 repo_id = github_source.get("repo_id", "unknown")
                 self._generate_c3_analysis_references(repo_id=repo_id)
+
+        # Local sources also carry C3.x output — fixes #363
+        self._generate_local_codebase_analysis_references()
 
     def _generate_docs_references(self, docs_list: list[dict]):
         """Generate references from multiple documentation sources."""
@@ -1388,14 +1382,59 @@ This skill combines knowledge from multiple sources:
         if not c3_data:
             return
 
-        # Create unique directory per repo for multi-source support
-        c3_dir = os.path.join(self.skill_dir, "references", "codebase_analysis", repo_id)
+        self._write_codebase_analysis_references(
+            c3_data=c3_data, source_id=repo_id, github_data=github_data
+        )
+
+    def _generate_local_codebase_analysis_references(self):
+        """Generate codebase analysis references for each local source (#363).
+
+        Local sources store C3.x output (patterns, test_examples, how_to_guides,
+        config_patterns, architecture, ...) directly on the source dict. They were
+        previously dropped by the builder, which only consumed GitHub sources.
+        """
+        local_list = self.scraped_data.get("local", [])
+        if not local_list:
+            return
+
+        c3_keys = (
+            "patterns",
+            "test_examples",
+            "how_to_guides",
+            "config_patterns",
+            "architecture",
+        )
+        for local_source in local_list:
+            if not any(local_source.get(k) for k in c3_keys):
+                continue
+
+            source_id = self._sanitize_source_id(
+                local_source.get("source_id") or local_source.get("name") or "local"
+            )
+            self._write_codebase_analysis_references(
+                c3_data=local_source, source_id=source_id, github_data=None
+            )
+
+    @staticmethod
+    def _sanitize_source_id(raw: str) -> str:
+        """Normalize a source identifier to a filesystem-safe directory name."""
+        cleaned = re.sub(r"[^\w\-]", "_", raw or "").strip("_")
+        return cleaned or "local"
+
+    def _write_codebase_analysis_references(
+        self,
+        c3_data: dict,
+        source_id: str,
+        github_data: dict | None = None,
+    ):
+        """Shared C3.x reference writer used by both GitHub and local sources."""
+        c3_dir = os.path.join(self.skill_dir, "references", "codebase_analysis", source_id)
         os.makedirs(c3_dir, exist_ok=True)
 
-        logger.info("Generating C3.x codebase analysis references...")
+        logger.info(f"Generating C3.x codebase analysis references for '{source_id}'...")
 
         # Generate ARCHITECTURE.md (main deliverable)
-        self._generate_architecture_overview(c3_dir, c3_data, github_data)
+        self._generate_architecture_overview(c3_dir, c3_data, github_data or {})
 
         # Generate subdirectories for each C3.x component
         self._generate_pattern_references(c3_dir, c3_data.get("patterns"))
@@ -1854,69 +1893,131 @@ This skill combines knowledge from multiple sources:
 
         logger.info(f"   ✓ Architectural details: {len(patterns)} patterns")
 
-    def _format_c3_summary_section(self, c3_data: dict) -> str:
-        """Format C3.x analysis summary for SKILL.md."""
+    def _collect_c3_payloads(self) -> list[dict]:
+        """Gather C3.x analysis payloads across GitHub and local sources (#363).
+
+        Returns:
+            List of c3_data dicts, one per source that produced analysis.
+        """
+        payloads: list[dict] = []
+
+        github_data = self.scraped_data.get("github", {})
+        # Handle both dict and list cases
+        if isinstance(github_data, list):
+            for item in github_data:
+                if not isinstance(item, dict):
+                    continue
+                inner = item.get("data", {})
+                if isinstance(inner, dict) and inner.get("c3_analysis"):
+                    payloads.append(inner["c3_analysis"])
+        elif isinstance(github_data, dict):
+            inner = github_data.get("data", {})
+            if isinstance(inner, dict) and inner.get("c3_analysis"):
+                payloads.append(inner["c3_analysis"])
+
+        for local_source in self.scraped_data.get("local", []) or []:
+            if not isinstance(local_source, dict):
+                continue
+            if any(
+                local_source.get(k)
+                for k in (
+                    "patterns",
+                    "test_examples",
+                    "how_to_guides",
+                    "config_patterns",
+                    "architecture",
+                )
+            ):
+                payloads.append(local_source)
+
+        return payloads
+
+    def _format_c3_summary_section(self, c3_payloads) -> str:
+        """Format C3.x analysis summary for SKILL.md.
+
+        Accepts either a single c3_data dict (legacy) or a list of payloads
+        (post #363, when GitHub + local sources both contribute).
+        """
+        # Backward-compatible: allow callers passing a single dict
+        payloads = [c3_payloads] if isinstance(c3_payloads, dict) else list(c3_payloads or [])
+
+        if not payloads:
+            return ""
+
         content = "\n## 🏗️ Architecture & Code Analysis\n\n"
         content += "*This skill includes comprehensive codebase analysis*\n\n"
 
-        # Add architectural pattern summary
-        if c3_data.get("architecture"):
-            patterns = c3_data["architecture"].get("patterns", [])
-            if patterns:
-                top_pattern = patterns[0]
+        # Primary architecture: take from the first payload that has one
+        for payload in payloads:
+            arch = payload.get("architecture") or {}
+            arch_patterns = arch.get("patterns", []) if isinstance(arch, dict) else []
+            if arch_patterns:
+                top_pattern = arch_patterns[0]
                 content += f"**Primary Architecture**: {top_pattern['pattern_name']}"
                 if top_pattern.get("framework"):
                     content += f" ({top_pattern['framework']})"
                 content += f" - Confidence: {top_pattern['confidence']:.0%}\n\n"
+                break
 
-        # Add design patterns summary
-        if c3_data.get("patterns"):
-            total_patterns = sum(len(f.get("patterns", [])) for f in c3_data["patterns"])
-            if total_patterns > 0:
-                content += f"**Design Patterns**: {total_patterns} detected\n"
+        # Design patterns: aggregate across payloads
+        total_patterns = 0
+        pattern_summary: dict[str, int] = {}
+        for payload in payloads:
+            for file_data in payload.get("patterns") or []:
+                for pattern in file_data.get("patterns", []):
+                    total_patterns += 1
+                    ptype = pattern.get("pattern_type", "Unknown")
+                    pattern_summary[ptype] = pattern_summary.get(ptype, 0) + 1
+        if total_patterns > 0:
+            content += f"**Design Patterns**: {total_patterns} detected\n"
+            top_patterns = sorted(pattern_summary.items(), key=lambda x: x[1], reverse=True)[:3]
+            if top_patterns:
+                content += (
+                    f"- Top patterns: {', '.join([f'{p[0]} ({p[1]})' for p in top_patterns])}\n"
+                )
+            content += "\n"
 
-                # Show top 3 pattern types
-                pattern_summary = {}
-                for file_data in c3_data["patterns"]:
-                    for pattern in file_data.get("patterns", []):
-                        ptype = pattern["pattern_type"]
-                        pattern_summary[ptype] = pattern_summary.get(ptype, 0) + 1
+        # Test examples: sum totals across payloads
+        total_examples = 0
+        total_high_value = 0
+        for payload in payloads:
+            examples = payload.get("test_examples") or {}
+            if isinstance(examples, dict):
+                total_examples += examples.get("total_examples", 0) or 0
+                total_high_value += examples.get("high_value_count", 0) or 0
+        if total_examples > 0:
+            content += (
+                f"**Usage Examples**: {total_examples} extracted from tests "
+                f"({total_high_value} high-value)\n\n"
+            )
 
-                top_patterns = sorted(pattern_summary.items(), key=lambda x: x[1], reverse=True)[:3]
-                if top_patterns:
-                    content += (
-                        f"- Top patterns: {', '.join([f'{p[0]} ({p[1]})' for p in top_patterns])}\n"
-                    )
-                content += "\n"
+        # How-to guides: sum guide counts
+        total_guides = 0
+        for payload in payloads:
+            guides = payload.get("how_to_guides") or {}
+            if isinstance(guides, dict):
+                total_guides += len(guides.get("guides", []) or [])
+        if total_guides > 0:
+            content += f"**How-To Guides**: {total_guides} workflow tutorials\n\n"
 
-        # Add test examples summary
-        if c3_data.get("test_examples"):
-            total = c3_data["test_examples"].get("total_examples", 0)
-            high_value = c3_data["test_examples"].get("high_value_count", 0)
-            if total > 0:
-                content += f"**Usage Examples**: {total} extracted from tests ({high_value} high-value)\n\n"
-
-        # Add how-to guides summary
-        if c3_data.get("how_to_guides"):
-            guide_count = len(c3_data["how_to_guides"].get("guides", []))
-            if guide_count > 0:
-                content += f"**How-To Guides**: {guide_count} workflow tutorials\n\n"
-
-        # Add configuration summary
-        if c3_data.get("config_patterns"):
-            config_files = c3_data["config_patterns"].get("config_files", [])
-            if config_files:
-                content += f"**Configuration Files**: {len(config_files)} analyzed\n"
-
-                # Add security warning if present
-                if c3_data["config_patterns"].get("ai_enhancements"):
-                    insights = c3_data["config_patterns"]["ai_enhancements"].get(
-                        "overall_insights", {}
-                    )
-                    security_issues = insights.get("security_issues_found", 0)
-                    if security_issues > 0:
-                        content += f"- 🔐 **Security Alert**: {security_issues} issue(s) detected\n"
-                content += "\n"
+        # Configuration: sum config files + propagate any security alerts
+        total_config_files = 0
+        total_security_issues = 0
+        for payload in payloads:
+            config = payload.get("config_patterns") or {}
+            if not isinstance(config, dict):
+                continue
+            total_config_files += len(config.get("config_files", []) or [])
+            ai_block = config.get("ai_enhancements") or {}
+            if isinstance(ai_block, dict):
+                insights = ai_block.get("overall_insights") or {}
+                if isinstance(insights, dict):
+                    total_security_issues += insights.get("security_issues_found", 0) or 0
+        if total_config_files > 0:
+            content += f"**Configuration Files**: {total_config_files} analyzed\n"
+            if total_security_issues > 0:
+                content += f"- 🔐 **Security Alert**: {total_security_issues} issue(s) detected\n"
+            content += "\n"
 
         # Add link to ARCHITECTURE.md
         content += "📖 **See** `references/codebase_analysis/ARCHITECTURE.md` for complete architectural overview.\n\n"

--- a/tests/test_unified.py
+++ b/tests/test_unified.py
@@ -527,6 +527,191 @@ def test_skill_builder_merged_apis():
 
 
 # ===========================
+# Issue #363: Local C3.x output
+# ===========================
+
+
+def _make_local_source(
+    *,
+    name: str = "my-codebase",
+    path: str = "/tmp/my-codebase",
+    test_examples: dict | None = None,
+    patterns: list | None = None,
+    how_to_guides: dict | None = None,
+    config_patterns: dict | None = None,
+    architecture: dict | None = None,
+) -> dict:
+    """Build a local-source dict shaped like UnifiedScraper._run_local_codebase_analysis output."""
+    return {
+        "source_id": f"unified_local_0_{name}",
+        "path": path,
+        "name": name,
+        "description": f"Local analysis of {name}",
+        "weight": 1.0,
+        "patterns": patterns,
+        "test_examples": test_examples,
+        "how_to_guides": how_to_guides,
+        "config_patterns": config_patterns,
+        "architecture": architecture,
+        "api_reference": None,
+        "dependency_graph": None,
+    }
+
+
+def test_local_source_test_examples_become_references_363():
+    """Issue #363: test_examples from local sources should land in references/."""
+    config = {
+        "name": "skill_363",
+        "description": "Local C3.x output should not be dropped",
+        "sources": [{"type": "local", "path": "/tmp/my-codebase"}],
+    }
+
+    test_examples = {
+        "total_examples": 292,
+        "high_value_count": 47,
+        "examples_by_category": {"DI": 100, "Setup": 80, "Mocks": 112},
+        "examples": [],
+    }
+    local_source = _make_local_source(test_examples=test_examples)
+
+    scraped_data = {"local": [local_source]}
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        builder = UnifiedSkillBuilder(config, scraped_data)
+        builder.skill_dir = tmpdir
+        os.makedirs(os.path.join(tmpdir, "references"), exist_ok=True)
+
+        builder._generate_local_codebase_analysis_references()
+
+        analysis_root = Path(tmpdir) / "references" / "codebase_analysis"
+        # Source-id is sanitized; should produce a single subdir
+        subdirs = [p for p in analysis_root.iterdir() if p.is_dir()]
+        assert len(subdirs) == 1, f"expected 1 source dir, got {subdirs}"
+        source_dir = subdirs[0]
+
+        examples_json = source_dir / "examples" / "test_examples.json"
+        assert examples_json.exists(), "test_examples.json not generated"
+
+        data = json.loads(examples_json.read_text())
+        assert data["total_examples"] == 292
+        assert data["high_value_count"] == 47
+
+        # ARCHITECTURE.md should also be created with the test-examples summary
+        arch_md = source_dir / "ARCHITECTURE.md"
+        assert arch_md.exists()
+        arch_content = arch_md.read_text()
+        assert "292 usage example" in arch_content
+
+
+def test_local_source_skill_md_includes_summary_363():
+    """SKILL.md should reflect counts from local-source C3.x output (#363)."""
+    config = {
+        "name": "skill_363",
+        "description": "Test",
+        "sources": [{"type": "local", "path": "/tmp/my-codebase"}],
+    }
+
+    local_source = _make_local_source(
+        test_examples={"total_examples": 50, "high_value_count": 12},
+        how_to_guides={"guides": [{"title": "A"}, {"title": "B"}]},
+    )
+    scraped_data = {"local": [local_source]}
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        builder = UnifiedSkillBuilder(config, scraped_data)
+        builder.skill_dir = tmpdir
+
+        builder._generate_skill_md()
+
+        skill_md = Path(tmpdir) / "SKILL.md"
+        content = skill_md.read_text()
+
+        assert "Architecture & Code Analysis" in content
+        assert "50 extracted from tests" in content
+        assert "12 high-value" in content
+        assert "2 workflow tutorials" in content
+
+
+def test_format_c3_summary_aggregates_across_sources_363():
+    """_format_c3_summary_section should sum counts across multiple payloads."""
+    config = {"name": "agg", "description": "Test", "sources": []}
+    builder = UnifiedSkillBuilder(config, {})
+
+    payloads = [
+        {"test_examples": {"total_examples": 100, "high_value_count": 20}},
+        {"test_examples": {"total_examples": 50, "high_value_count": 5}},
+    ]
+
+    out = builder._format_c3_summary_section(payloads)
+    assert "150 extracted from tests" in out
+    assert "25 high-value" in out
+
+
+def test_format_c3_summary_backward_compat_dict_arg_363():
+    """Single-dict arg (legacy) must still produce the summary."""
+    config = {"name": "compat", "description": "Test", "sources": []}
+    builder = UnifiedSkillBuilder(config, {})
+
+    payload = {"test_examples": {"total_examples": 7, "high_value_count": 3}}
+    out = builder._format_c3_summary_section(payload)
+    assert "7 extracted from tests" in out
+
+
+def test_collect_c3_payloads_combines_github_and_local_363():
+    """_collect_c3_payloads should pull from both github and local sources."""
+    config = {"name": "combo", "description": "Test", "sources": []}
+
+    github_c3 = {"test_examples": {"total_examples": 10, "high_value_count": 2}}
+    local_source = _make_local_source(test_examples={"total_examples": 5, "high_value_count": 1})
+    scraped_data = {
+        "github": [{"repo_id": "owner_repo", "data": {"c3_analysis": github_c3}}],
+        "local": [local_source],
+    }
+    builder = UnifiedSkillBuilder(config, scraped_data)
+
+    payloads = builder._collect_c3_payloads()
+    assert len(payloads) == 2
+
+    # Aggregated summary should reflect both
+    out = builder._format_c3_summary_section(payloads)
+    assert "15 extracted from tests" in out
+    assert "3 high-value" in out
+
+
+def test_local_source_without_c3_data_skipped_363():
+    """Local sources with no C3 fields should not create empty reference dirs."""
+    config = {
+        "name": "empty_local",
+        "description": "Test",
+        "sources": [{"type": "local", "path": "/tmp/my-codebase"}],
+    }
+    # All C3 fields None / empty
+    local_source = _make_local_source()
+    scraped_data = {"local": [local_source]}
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        builder = UnifiedSkillBuilder(config, scraped_data)
+        builder.skill_dir = tmpdir
+        os.makedirs(os.path.join(tmpdir, "references"), exist_ok=True)
+
+        builder._generate_local_codebase_analysis_references()
+
+        analysis_root = Path(tmpdir) / "references" / "codebase_analysis"
+        assert not analysis_root.exists() or not any(analysis_root.iterdir())
+
+
+def test_sanitize_source_id_363():
+    """Source IDs must be filesystem-safe."""
+    sanitize = UnifiedSkillBuilder._sanitize_source_id
+    assert sanitize("my-skill_local_0_repo") == "my-skill_local_0_repo"
+    assert sanitize("path/with/slashes") == "path_with_slashes"
+    assert sanitize("name with spaces") == "name_with_spaces"
+    assert sanitize("!!!") == "local"
+    assert sanitize("") == "local"
+    assert sanitize(None) == "local"
+
+
+# ===========================
 # Integration Tests
 # ===========================
 


### PR DESCRIPTION
Fixes #363

## Problem

The unified skill builder dropped all C3.x analysis output produced by local sources. `_run_local_codebase_analysis` correctly extracted `test_examples`, `patterns`, `how_to_guides`, `config_patterns`, `architecture`, etc., wrote them to cache (`local_analysis_{idx}_{name}/`), and stored them on `scraped_data["local"]` — but `unified_skill_builder.py` only consumed GitHub sources for C3.x reference generation and SKILL.md summarization.

Concretely, both code paths only looked at GitHub:

- `_generate_references()` at line 1095-1101 iterated `scraped_data.get("github", [])` and called `_generate_c3_analysis_references` per repo.
- `_generate_skill_md()` at line 884-896 read `scraped_data.get("github", {})` and passed only the first GitHub source's `c3_analysis` to `_format_c3_summary_section`.

So a unified config with a `local` source and `extract_tests=true` would happily run the test-example extractor (122 files / 292 examples in the issue), then quietly throw the result away.

The bug is broader than the issue title suggests — it's not just `test_examples`, it's the entire C3.x payload from local sources.

## Solution

Refactor and extend in `unified_skill_builder.py`:

1. **Refactor** `_generate_c3_analysis_references` to delegate to a new shared helper `_write_codebase_analysis_references(c3_data, source_id, github_data=None)` that does the actual work. The GitHub path is now a thin lookup wrapper.
2. **Add** `_generate_local_codebase_analysis_references` that walks `scraped_data["local"]`, skips sources with no C3 fields, and calls the shared writer with a sanitized source ID. Wired into `_generate_references` next to the GitHub loop.
3. **Add** `_sanitize_source_id` to make local IDs filesystem-safe (slashes, spaces, special chars → `_`; empty → `"local"`).
4. **Add** `_collect_c3_payloads` that gathers C3 data from both GitHub and local sources into a flat list.
5. **Rewrite** `_format_c3_summary_section` to accept either a single dict (legacy) or a list of payloads, aggregating counts (test examples, design patterns, how-to guides, config files, security alerts) across all sources.

## Testing

7 new regression tests in `tests/test_unified.py`:

- `test_local_source_test_examples_become_references_363` — the headline issue: local source with test_examples produces `references/codebase_analysis/<sanitized-id>/examples/test_examples.json` and an `ARCHITECTURE.md` mentioning the example count.
- `test_local_source_skill_md_includes_summary_363` — SKILL.md gets the C3 summary section when only local has data.
- `test_format_c3_summary_aggregates_across_sources_363` — counts sum across multiple payloads.
- `test_format_c3_summary_backward_compat_dict_arg_363` — single-dict input still works.
- `test_collect_c3_payloads_combines_github_and_local_363` — combined harvesting from both source types.
- `test_local_source_without_c3_data_skipped_363` — empty local sources don't create empty reference dirs.
- `test_sanitize_source_id_363` — ID normalization edge cases.

All 31 `tests/test_unified.py` tests pass; 93 unified-related tests across `test_unified.py + test_c3_integration.py + test_unified_scraper_orchestration.py + test_unified_analyzer.py` all pass. Lint + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)