### PR TITLE
fix(unified): drop guides truthy placeholder so fallback can fire (#364)

### DIFF
--- a/src/skill_seekers/cli/unified_scraper.py
+++ b/src/skill_seekers/cli/unified_scraper.py
@@ -1564,15 +1564,21 @@ class UnifiedScraper(SkillConverter):
         """
         Load how-to guide collection from tutorials directory.
 
+        Returns an empty dict (falsy) when the directory or any guide files
+        are missing, so callers can chain ``primary or fallback`` to fall
+        through to a secondary path. Returning a non-empty placeholder here
+        would short-circuit those chains and silently drop real guide data
+        in the fallback location (issue #364).
+
         Args:
             tutorials_dir: Path to tutorials directory
 
         Returns:
-            Dict with guide collection data
+            Dict with guide collection data, or ``{}`` when no guides found.
         """
         if not tutorials_dir.exists():
-            logger.warning(f"Tutorials directory not found: {tutorials_dir}")
-            return {"guides": []}
+            logger.debug(f"Tutorials directory not found: {tutorials_dir}")
+            return {}
 
         collection_file = tutorials_dir / "guide_collection.json"
         if collection_file.exists():
@@ -1585,6 +1591,8 @@ class UnifiedScraper(SkillConverter):
             if guide_data:
                 guides.append(guide_data)
 
+        if not guides:
+            return {}
         return {"guides": guides, "total_count": len(guides)}
 
     def _load_api_reference(self, api_dir: Path) -> dict[str, Any]:

--- a/tests/test_unified_scraper_orchestration.py
+++ b/tests/test_unified_scraper_orchestration.py
@@ -594,3 +594,80 @@ class TestRunOrchestration:
                 wr_mod.run_workflows = orig_wr
 
         assert "minimal" in (captured.get("workflows") or [])
+
+
+# ===========================================================================
+# Regression: issue #364 — guides loaded from fallback location
+# ===========================================================================
+
+
+class TestLoadGuideCollectionFallback:
+    """_load_guide_collection must return a falsy value when nothing is loadable.
+
+    Otherwise the ``primary or fallback`` chain in _scrape_local /
+    _run_c3_analysis short-circuits on the truthy placeholder and the real
+    guide data in the fallback location is silently dropped (issue #364:
+    output references contain an empty guide_collection.json even though
+    the cache holds 3 generated guides).
+    """
+
+    def _scraper(self):
+        return UnifiedScraper.__new__(UnifiedScraper)
+
+    def test_returns_empty_dict_when_directory_missing(self, tmp_path):
+        scraper = self._scraper()
+        result = scraper._load_guide_collection(tmp_path / "nope")
+        assert result == {}
+        assert not result  # falsy, so `or` fallback fires
+
+    def test_returns_empty_dict_when_directory_has_no_guide_files(self, tmp_path):
+        tutorials = tmp_path / "tutorials"
+        tutorials.mkdir()
+        (tutorials / "index.md").write_text("# Empty\n")
+        scraper = self._scraper()
+        result = scraper._load_guide_collection(tutorials)
+        assert result == {}
+        assert not result
+
+    def test_loads_guide_collection_when_present(self, tmp_path):
+        tutorials = tmp_path / "tutorials"
+        tutorials.mkdir()
+        payload = {
+            "total_guides": 2,
+            "guides_by_complexity": {},
+            "guides_by_use_case": {},
+            "guides": [{"id": "g1", "title": "One"}, {"id": "g2", "title": "Two"}],
+        }
+        (tutorials / "guide_collection.json").write_text(json.dumps(payload))
+        scraper = self._scraper()
+        result = scraper._load_guide_collection(tutorials)
+        assert result["total_guides"] == 2
+        assert len(result["guides"]) == 2
+
+    def test_or_fallback_picks_up_guides_from_secondary_path(self, tmp_path):
+        """Issue #364: when references/tutorials/ is missing but the original
+        tutorials/ still has the JSON, the fallback path must win."""
+        temp_output = tmp_path / "local_analysis_0_repo"
+        refs = temp_output / "references"  # not created — simulates skipped move
+        tutorials = temp_output / "tutorials"
+        tutorials.mkdir(parents=True)
+        payload = {
+            "total_guides": 3,
+            "guides_by_complexity": {},
+            "guides_by_use_case": {},
+            "guides": [
+                {"id": "g1", "title": "One"},
+                {"id": "g2", "title": "Two"},
+                {"id": "g3", "title": "Three"},
+            ],
+        }
+        (tutorials / "guide_collection.json").write_text(json.dumps(payload))
+
+        scraper = self._scraper()
+        primary = scraper._load_guide_collection(refs / "tutorials")
+        fallback = scraper._load_guide_collection(temp_output / "tutorials")
+        result = primary or fallback
+
+        assert not primary  # primary missing, must be falsy
+        assert result["total_guides"] == 3
+        assert len(result["guides"]) == 3


### PR DESCRIPTION
Fixes #364

## Problem

When the unified scraper analyzes a local source, it loads C3.x outputs from two possible locations and falls back via Python's `or`:

```python
"how_to_guides": self._load_guide_collection(refs / "tutorials")
or self._load_guide_collection(temp_output / "tutorials"),
```

The same pattern is used in `_run_c3_analysis` for GitHub sources. The intent: if `analyze_codebase`'s `_generate_references()` step moved tutorials into `references/tutorials/`, load from there; otherwise fall back to the original `tutorials/` location.

In practice the fallback never fires because `_load_guide_collection` returns the **truthy** placeholder `{"guides": []}` whenever the directory doesn't exist (or exists but holds no guide JSON). The `or` short-circuits on that placeholder and the real `guide_collection.json` sitting in the fallback path is silently dropped.

The user-visible symptom (issue #364): `references/codebase_analysis/{repo}/guides/` ends up with an empty `guide_collection.json` and a minimal `index.md`, even though `.skillseeker-cache/{name}/data/local_analysis_0_{name}/tutorials/guide_collection.json` contains 3 generated guides.

## Reproduction

A small script confirms it:

| Scenario | Before fix | After fix |
| --- | --- | --- |
| Guides at `references/tutorials/` (normal) | 3 loaded | 3 loaded |
| Guides only at `temp_output/tutorials/` (fallback path) | **0 loaded — bug** | **3 loaded** |

## Fix

`_load_guide_collection` now returns `{}` (falsy) when the directory is missing or contains no guide JSON, matching the falsy-on-miss contract of `_load_api_reference` and `_load_json_fallback`. The existing `or` chains at the call sites work correctly without modification.

## Tests

Added `TestLoadGuideCollectionFallback` to `tests/test_unified_scraper_orchestration.py` with four cases:

1. Missing directory → `{}`
2. Directory exists but holds no guide JSON → `{}`
3. Directory has `guide_collection.json` → loaded payload
4. **Regression for #364**: primary missing, fallback has guides → fallback wins, all 3 guides come through

Targeted test runs (`test_unified_scraper_orchestration.py`, `test_unified.py`, `test_how_to_guide_builder.py`, `test_unified_analyzer.py`) — 122 passed. Lint + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)