### PR TITLE
fix(unified): generate codebase_analysis index, fix broken SKILL.md links (#362)

### DIFF
--- a/src/skill_seekers/cli/unified_skill_builder.py
+++ b/src/skill_seekers/cli/unified_skill_builder.py
@@ -384,7 +384,7 @@ This skill synthesizes knowledge from multiple sources:
         content += "Organized by source:\n\n"
         content += "- [Documentation](references/documentation/)\n"
         content += "- [GitHub](references/github/)\n"
-        content += "- [Codebase Analysis](references/codebase_analysis/ARCHITECTURE.md)\n\n"
+        content += "- [Codebase Analysis](references/codebase_analysis/index.md)\n\n"
 
         # Footer
         content += "---\n\n"
@@ -461,8 +461,8 @@ This skill synthesizes knowledge from multiple sources:
         # Update reference documentation to include PDF
         final_content = "\n".join(lines)
         final_content = final_content.replace(
-            "- [Codebase Analysis](references/codebase_analysis/ARCHITECTURE.md)\n",
-            "- [Codebase Analysis](references/codebase_analysis/ARCHITECTURE.md)\n- [PDF Documentation](references/pdf/)\n",
+            "- [Codebase Analysis](references/codebase_analysis/index.md)\n",
+            "- [Codebase Analysis](references/codebase_analysis/index.md)\n- [PDF Documentation](references/pdf/)\n",
         )
 
         return final_content
@@ -1094,6 +1094,12 @@ This skill combines knowledge from multiple sources:
         # Local sources also carry C3.x output — fixes #363
         self._generate_local_codebase_analysis_references()
 
+        # Top-level index linking each per-source ARCHITECTURE.md (#362).
+        # SKILL.md links into `references/codebase_analysis/index.md` instead of
+        # the historical `references/codebase_analysis/ARCHITECTURE.md`, which
+        # never existed once outputs became per-source-namespaced.
+        self._generate_codebase_analysis_index()
+
     def _generate_docs_references(self, docs_list: list[dict]):
         """Generate references from multiple documentation sources."""
         # Skip if no documentation sources
@@ -1420,6 +1426,57 @@ This skill combines knowledge from multiple sources:
         """Normalize a source identifier to a filesystem-safe directory name."""
         cleaned = re.sub(r"[^\w\-]", "_", raw or "").strip("_")
         return cleaned or "local"
+
+    def _generate_codebase_analysis_index(self):
+        """Write `references/codebase_analysis/index.md` (#362).
+
+        Scans the codebase_analysis directory after per-source references have
+        been written and produces a single landing page that links to each
+        source's ARCHITECTURE.md and any populated subsections (patterns,
+        examples, guides, configuration). SKILL.md uses this as a stable link
+        target so the path resolves whether the build has one source or many.
+        """
+        base = os.path.join(self.skill_dir, "references", "codebase_analysis")
+        if not os.path.isdir(base):
+            return
+
+        sources = []
+        for entry in sorted(os.listdir(base)):
+            entry_path = os.path.join(base, entry)
+            if not os.path.isdir(entry_path):
+                continue
+            if not os.path.isfile(os.path.join(entry_path, "ARCHITECTURE.md")):
+                continue
+            sources.append(entry)
+
+        if not sources:
+            return
+
+        index_path = os.path.join(base, "index.md")
+        subsections = (
+            ("patterns", "Design patterns"),
+            ("examples", "Usage examples"),
+            ("guides", "How-to guides"),
+            ("configuration", "Configuration"),
+        )
+
+        with open(index_path, "w", encoding="utf-8") as f:
+            f.write("# Codebase Analysis\n\n")
+            f.write(
+                "Architecture and code-analysis output from the C3.x pipeline, "
+                "organized by source. Each entry links to the per-source "
+                "ARCHITECTURE.md and any populated subsections.\n\n"
+            )
+
+            for source in sources:
+                f.write(f"## {source}\n\n")
+                f.write(f"- [Architecture overview]({source}/ARCHITECTURE.md)\n")
+                for sub_dir, label in subsections:
+                    if os.path.isdir(os.path.join(base, source, sub_dir)):
+                        f.write(f"- [{label}]({source}/{sub_dir}/)\n")
+                f.write("\n")
+
+        logger.info(f"📚 Created codebase analysis index: {index_path}")
 
     def _write_codebase_analysis_references(
         self,
@@ -2019,8 +2076,12 @@ This skill combines knowledge from multiple sources:
                 content += f"- 🔐 **Security Alert**: {total_security_issues} issue(s) detected\n"
             content += "\n"
 
-        # Add link to ARCHITECTURE.md
-        content += "📖 **See** `references/codebase_analysis/ARCHITECTURE.md` for complete architectural overview.\n\n"
+        # Add link to the codebase-analysis landing page (#362)
+        content += (
+            "📖 **See** `references/codebase_analysis/index.md` for the per-source "
+            "architecture overviews and detailed pattern, example, guide, and "
+            "configuration references.\n\n"
+        )
 
         return content
 

--- a/tests/test_c3_integration.py
+++ b/tests/test_c3_integration.py
@@ -355,7 +355,10 @@ class TestC3Integration:
         assert "MVC" in content
         assert "Design Patterns" in content
         assert "Factory" in content
-        assert "references/codebase_analysis/ARCHITECTURE.md" in content
+        # SKILL.md links to the per-source index (#362), not the historical
+        # top-level ARCHITECTURE.md which never existed once outputs became
+        # per-source-namespaced.
+        assert "references/codebase_analysis/index.md" in content
 
 
 class TestC3AnalyzeCodebaseSignature:

--- a/tests/test_multi_source.py
+++ b/tests/test_multi_source.py
@@ -503,5 +503,118 @@ class TestUnifiedSkillBuilderPdfReferences(unittest.TestCase):
             self.assertIn("3 PDF document", content)
 
 
+class TestCodebaseAnalysisIndex(unittest.TestCase):
+    """Issue #362: SKILL.md must link to a real codebase_analysis target.
+
+    Per-source ARCHITECTURE.md files live at
+    ``references/codebase_analysis/{source_id}/ARCHITECTURE.md``, but four
+    call sites historically linked to ``references/codebase_analysis/
+    ARCHITECTURE.md`` (no source_id). That link was always broken once the
+    layout became per-source-namespaced.
+
+    The fix: generate a top-level ``references/codebase_analysis/index.md``
+    aggregating all sources, and route every SKILL.md link through it.
+    """
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.original_dir = os.getcwd()
+        os.chdir(self.temp_dir)
+
+    def tearDown(self):
+        os.chdir(self.original_dir)
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _run_build(self, sources_local):
+        from skill_seekers.cli.unified_skill_builder import UnifiedSkillBuilder
+
+        config = {"name": "issue-362", "description": "Test"}
+        scraped_data = {
+            "documentation": [],
+            "github": [],
+            "pdf": [],
+            "local": sources_local,
+        }
+        builder = UnifiedSkillBuilder(config, scraped_data)
+        builder.build()
+        return builder
+
+    def test_index_md_lists_each_local_source(self):
+        sample_patterns = [
+            {
+                "file_path": "/x/foo.py",
+                "patterns": [
+                    {"pattern_type": "Singleton", "confidence": 0.88, "indicators": ["__instance"]}
+                ],
+            }
+        ]
+        builder = self._run_build(
+            [
+                {
+                    "source_id": "issue-362_local_0_repo_a",
+                    "name": "repo_a",
+                    "patterns": sample_patterns,
+                },
+                {
+                    "source_id": "issue-362_local_1_repo_b",
+                    "name": "repo_b",
+                    "patterns": sample_patterns,
+                },
+            ]
+        )
+
+        index_path = os.path.join(builder.skill_dir, "references", "codebase_analysis", "index.md")
+        self.assertTrue(os.path.isfile(index_path), "codebase_analysis/index.md must be created")
+
+        with open(index_path) as f:
+            content = f.read()
+        self.assertIn("issue-362_local_0_repo_a", content)
+        self.assertIn("issue-362_local_1_repo_b", content)
+        self.assertIn("issue-362_local_0_repo_a/ARCHITECTURE.md", content)
+        self.assertIn("issue-362_local_0_repo_a/patterns/", content)
+
+    def test_skill_md_link_resolves_to_real_file(self):
+        """The SKILL.md link to codebase_analysis must resolve on disk."""
+        sample_patterns = [
+            {
+                "file_path": "/x/foo.py",
+                "patterns": [
+                    {"pattern_type": "Singleton", "confidence": 0.88, "indicators": ["__instance"]}
+                ],
+            }
+        ]
+        builder = self._run_build(
+            [
+                {
+                    "source_id": "issue-362_local_0_repo",
+                    "name": "repo",
+                    "patterns": sample_patterns,
+                },
+            ]
+        )
+
+        skill_md = os.path.join(builder.skill_dir, "SKILL.md")
+        with open(skill_md) as f:
+            content = f.read()
+
+        import re
+
+        targets = re.findall(r"references/codebase_analysis/[^\s`)]+", content)
+        self.assertTrue(targets, "SKILL.md must mention a codebase_analysis link")
+
+        for target in targets:
+            full = os.path.join(builder.skill_dir, target)
+            self.assertTrue(
+                os.path.exists(full),
+                f"SKILL.md links to {target!r} but file does not exist on disk",
+            )
+
+    def test_no_index_when_no_codebase_data(self):
+        """No C3.x output → no index file written."""
+        builder = self._run_build([])  # no local sources at all
+        index_path = os.path.join(builder.skill_dir, "references", "codebase_analysis", "index.md")
+        self.assertFalse(os.path.exists(index_path))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #362

## Problem

When the unified scraper analyzes a local codebase, C3.x detection populates `references/codebase_analysis/{source_id}/ARCHITECTURE.md`, `patterns/`, `examples/`, etc. After PR #372 this part works for local sources too — patterns *are* surfaced into the references tree.

But the user reported the analysis still appeared missing. Root cause: SKILL.md's "see the architecture overview" pointers all hardcoded `references/codebase_analysis/ARCHITECTURE.md` — a path that never existed once outputs became per-source-namespaced. A reader following the link hit nothing.

Affected sites (all in `unified_skill_builder.py`):
- L387 — `_synthesize_docs_github` reference list
- L464–465 — `_synthesize_docs_github_pdf` reference list
- L2023 — `_format_c3_summary_section` "See ARCHITECTURE.md" CTA

## Fix

1. Generate `references/codebase_analysis/index.md` after all per-source references are written. The index scans the directory and lists each source's `ARCHITECTURE.md` plus any populated subsection (patterns, examples, guides, configuration).
2. Route the four SKILL.md links through this stable target so the path resolves whether the build has one source or many.
3. Skip the index when no codebase analysis ran, so skills built only from docs/PDF/etc. don't get a stray empty index.

## Verification

Before:

```
SKILL.md: "📖 See `references/codebase_analysis/ARCHITECTURE.md`"
On disk: references/codebase_analysis/word-block_local_0_word-block/ARCHITECTURE.md
        (the bare path is missing — link broken)
```

After:

```
SKILL.md: "📖 See `references/codebase_analysis/index.md`"
On disk: references/codebase_analysis/index.md  ← lists each source
         references/codebase_analysis/word-block_local_0_word-block/ARCHITECTURE.md
```

## Tests

- `TestCodebaseAnalysisIndex` (3 cases in `tests/test_multi_source.py`):
  - `test_index_md_lists_each_local_source` — multi-source index aggregates correctly
  - `test_skill_md_link_resolves_to_real_file` — every `references/codebase_analysis/...` link in SKILL.md exists on disk
  - `test_no_index_when_no_codebase_data` — no codebase analysis → no index file
- Updated `test_skill_md_includes_c3_summary` (in `tests/test_c3_integration.py`) to assert the new `index.md` link.

Targeted suite: `tests/test_multi_source.py tests/test_c3_integration.py tests/test_unified.py tests/test_unified_scraper_orchestration.py` — 88 passed. Lint + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)