### PR TITLE
ci(docker): use Compose v2 plugin (`docker compose`) in PR test job

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -135,5 +135,5 @@ jobs:
     - name: Test Docker Compose
       run: |
         echo "🧪 Testing Docker Compose..."
-        docker-compose config
+        docker compose config
         echo "✅ Docker Compose configuration valid"


### PR DESCRIPTION
## Problem

The `Test Docker Compose` step in `Test Docker Images` (Docker Publish workflow) has been failing on every PR with:

```
docker-compose: command not found
##[error]Process completed with exit code 127.
```

GitHub-hosted `ubuntu-latest` runners no longer ship the standalone `docker-compose` v1 binary — only the Docker CLI plugin (`docker compose`).

## Fix

Single-character change: `docker-compose config` → `docker compose config`.

## Scope

Only the PR-only `test-images` job was affected. The actual build/push job uses `docker/build-push-action` and was unaffected — that's why v3.5.0 / v3.5.1 / v3.6.0 image publishes succeeded despite this red check.

## Verification

Will be confirmed by the `Test Docker Compose` step on this PR turning green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)