### PR TITLE
Sync development → main (docker-compose v2 CI fix)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,11 @@ MCP_PORT=8765
 # DOCKER_CPU_LIMIT=2.0
 # DOCKER_MEMORY_LIMIT=4g
 
+# Pinecone API (Optional)
+# Required for Pinecone vector database upload
+# Get your key from: https://app.pinecone.io/
+PINECONE_API_KEY=
+
 # Vector Database Ports (Optional - change if needed)
 # WEAVIATE_PORT=8080
 # QDRANT_PORT=6333

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -135,5 +135,5 @@ jobs:
     - name: Test Docker Compose
       run: |
         echo "🧪 Testing Docker Compose..."
-        docker-compose config
+        docker compose config
         echo "✅ Docker Compose configuration valid"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to Skill Seeker will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.0] - 2026-05-03
+
+**Theme:** Quality-of-life release — packaging targets, GitHub issue workflow, codebase analysis fixes, and source detection hardening.
+
+### Added
+- **IBM Bob packaging target** — new `--target bob` adaptor and agent install support for IBM's Bob agent platform (#366)
+- **GitHub issue filtering** — `--github-issue-state`, `--github-issue-labels`, and `--github-issue-since` filters in the GitHub scraper for narrowing which issues are pulled (#367)
+- **Per-issue files** — GitHub scraper now writes one Markdown file per issue instead of a single bundle, improving navigation and downstream chunking (#367)
+- **Pinecone frontmatter** — Pinecone vector exports now include consistent YAML frontmatter for metadata round-tripping (#367)
+
+### Fixed
+- **Unified scraper now generates `codebase_analysis/` index** — local sources were producing C3.x outputs with broken SKILL.md links; the unified skill builder now wires up the index and resolves links correctly (#362, #376)
+- **Guides fallback fires correctly** — `unified_skill_builder` was emitting a truthy placeholder for empty guides which suppressed the fallback content; placeholder removed (#364, #375)
+- **HTML URLs no longer treated as local files** — `source_detector` now checks for `http(s)://` before falling through to the local-path branch, fixing false-positive routing (#373)
+- **PDF extracted images appear in markdown** — `pdf_scraper` now inserts `![](…)` references for images extracted from PDFs so they render in the generated SKILL.md (#369)
+- **C3.x output for local sources** — `unified` command was skipping the C3.x analysis pipeline for local codebase sources; now emits the full pattern/test/guide/config/router output (#363, #372)
+- **Language filter passed to C3.x clone analysis** — repos cloned for analysis now respect `--languages` instead of analyzing every file (fixes #361, #370)
+- **Unity vs Unreal detection** — Unity projects with C# imports were being misidentified as Unreal; detection now keys on C# import patterns (fixes #365, #368)
+
 ## [3.5.1] - 2026-04-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ skill-seekers package output/react --target claude      # → Claude AI Skill (Z
 skill-seekers package output/react --target langchain   # → LangChain Documents
 skill-seekers package output/react --target llama-index # → LlamaIndex TextNodes
 skill-seekers package output/react --target cursor      # → .cursorrules
+skill-seekers package output/react --target ibm-bob     # → IBM Bob skill directory
 ```
 
 ### What gets built
@@ -72,6 +73,7 @@ skill-seekers package output/react --target cursor      # → .cursorrules
 | **Haystack Documents** | `--target haystack` | Enterprise RAG pipelines |
 | **Pinecone-ready** (Markdown) | `--target markdown` | Vector upsert |
 | **ChromaDB / FAISS / Qdrant** | `--format chroma/faiss/qdrant` | Local vector DBs |
+| **IBM Bob Skill** (directory) | `--target ibm-bob` | IBM Bob project/global skills |
 | **Cursor** `.cursorrules` | `--target claude` → copy | Cursor IDE AI context |
 | **Windsurf / Cline / Continue** | `--target claude` → copy | VS Code, IntelliJ, Vim |
 
@@ -1006,11 +1008,14 @@ In Claude Code, just ask:
 
 ## 🤖 Installing to AI Agents
 
-Skill Seekers can automatically install skills to 18 AI coding agents.
+Skill Seekers can automatically install skills to 19 AI coding agents.
 
 ```bash
 # Install to specific agent
 skill-seekers install-agent output/react/ --agent cursor
+
+# Install to IBM Bob (project-local .bob/skills/)
+skill-seekers install-agent output/react/ --agent bob
 
 # Install to all agents at once
 skill-seekers install-agent output/react/ --agent all
@@ -1037,6 +1042,7 @@ skill-seekers install-agent output/react/ --agent cursor --dry-run
 | **Kilo Code** | `.kilo/skills/` | Project |
 | **Continue** | `~/.continue/skills/` | Global |
 | **Kimi Code** | `~/.kimi/skills/` | Global |
+| **IBM Bob** | `.bob/skills/` | Project |
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "skill-seekers"
-version = "3.5.1"
+version = "3.6.0"
 description = "Convert documentation websites, GitHub repositories, and PDFs into Claude AI skills. International support with Chinese (简体中文) documentation."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/skill_seekers/_version.py
+++ b/src/skill_seekers/_version.py
@@ -28,7 +28,7 @@ def get_version() -> str:
     """
     if tomllib is None:
         # Fallback if TOML library not available
-        return "3.5.1"  # Hardcoded fallback
+        return "3.6.0"  # Hardcoded fallback
 
     try:
         # Get path to pyproject.toml (3 levels up from this file)
@@ -37,7 +37,7 @@ def get_version() -> str:
 
         if not pyproject_path.exists():
             # Fallback for installed package
-            return "3.5.1"  # Hardcoded fallback
+            return "3.6.0"  # Hardcoded fallback
 
         with open(pyproject_path, "rb") as f:
             pyproject_data = tomllib.load(f)
@@ -46,7 +46,7 @@ def get_version() -> str:
 
     except Exception:
         # Fallback if anything goes wrong
-        return "3.5.1"  # Hardcoded fallback
+        return "3.6.0"  # Hardcoded fallback
 
 
 __version__ = get_version()

--- a/src/skill_seekers/cli/adaptors/__init__.py
+++ b/src/skill_seekers/cli/adaptors/__init__.py
@@ -111,6 +111,11 @@ try:
 except ImportError:
     FireworksAdaptor = None
 
+try:
+    from .ibm_bob import IBMBobAdaptor
+except ImportError:
+    IBMBobAdaptor = None
+
 
 # Registry of available adaptors
 ADAPTORS: dict[str, type[SkillAdaptor]] = {}
@@ -156,6 +161,8 @@ if TogetherAdaptor:
     ADAPTORS["together"] = TogetherAdaptor
 if FireworksAdaptor:
     ADAPTORS["fireworks"] = FireworksAdaptor
+if IBMBobAdaptor:
+    ADAPTORS["ibm-bob"] = IBMBobAdaptor
 
 
 def get_adaptor(platform: str, config: dict = None) -> SkillAdaptor:

--- a/src/skill_seekers/cli/adaptors/ibm_bob.py
+++ b/src/skill_seekers/cli/adaptors/ibm_bob.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""
+IBM Bob Adaptor
+
+Generates skills in IBM Bob-compatible format.
+Bob discovers skills in project or global `.bob/skills/` directories.
+"""
+
+import re
+import shutil
+from pathlib import Path
+from typing import Any
+
+from .base import SkillAdaptor, SkillMetadata
+from skill_seekers.cli.arguments.common import DEFAULT_CHUNK_OVERLAP_TOKENS, DEFAULT_CHUNK_TOKENS
+
+
+class IBMBobAdaptor(SkillAdaptor):
+    """
+    IBM Bob platform adaptor.
+
+    Packages a skill into a Bob-ready directory layout:
+    `.bob/skills/<skill-name>/SKILL.md`
+    """
+
+    PLATFORM = "ibm-bob"
+    PLATFORM_NAME = "IBM Bob"
+    DEFAULT_API_ENDPOINT = None  # Local file-based, no upload API
+
+    @staticmethod
+    def _to_skill_dir_name(name: str) -> str:
+        """Normalize a skill name to a filesystem-friendly Bob directory name."""
+        result = name.lower()
+        result = re.sub(r"[_\s.]+", "-", result)
+        result = re.sub(r"[^a-z0-9-]", "", result)
+        result = re.sub(r"-+", "-", result)
+        result = result.strip("-")
+        return result or "skill"
+
+    @staticmethod
+    def _quote_yaml(value: str) -> str:
+        """Quote a YAML string to safely preserve punctuation."""
+        escaped = value.replace('"', '\\"')
+        return f'"{escaped}"'
+
+    def format_skill_md(self, skill_dir: Path, metadata: SkillMetadata) -> str:
+        """
+        Format SKILL.md with Bob-compatible YAML frontmatter.
+
+        Bob requires `name` and `description` and accepts additional metadata.
+        """
+        existing_content = self._read_existing_content(skill_dir)
+        body = (
+            existing_content
+            if existing_content
+            else f"# {metadata.name}\n\n{metadata.description}\n"
+        )
+
+        tags = metadata.tags or [self._to_skill_dir_name(metadata.name)]
+        tag_lines = "\n".join(f"  - {tag}" for tag in tags)
+        author_line = f"\nauthor: {self._quote_yaml(metadata.author)}" if metadata.author else ""
+
+        frontmatter = (
+            f"---\n"
+            f"name: {self._quote_yaml(metadata.name)}\n"
+            f"description: {self._quote_yaml(metadata.description)}\n"
+            f"version: {self._quote_yaml(metadata.version)}\n"
+            f"tags:\n{tag_lines}"
+            f"{author_line}\n"
+            f"---"
+        )
+
+        return f"{frontmatter}\n\n{body.strip()}\n"
+
+    def package(
+        self,
+        skill_dir: Path,
+        output_path: Path,
+        enable_chunking: bool = False,
+        chunk_max_tokens: int = DEFAULT_CHUNK_TOKENS,
+        preserve_code_blocks: bool = True,
+        chunk_overlap_tokens: int = DEFAULT_CHUNK_OVERLAP_TOKENS,
+    ) -> Path:
+        """
+        Package a skill as a Bob-ready directory tree.
+
+        Creates:
+        `<output>/<name>-ibm-bob/.bob/skills/<normalized-name>/SKILL.md`
+        """
+        del enable_chunking, chunk_max_tokens, preserve_code_blocks, chunk_overlap_tokens
+
+        skill_dir = Path(skill_dir)
+        output_path = Path(output_path)
+        dir_name = f"{skill_dir.name}-ibm-bob"
+
+        if output_path.is_dir() or str(output_path).endswith("/"):
+            target_dir = output_path / dir_name
+        else:
+            target_dir = output_path
+
+        if target_dir.exists():
+            shutil.rmtree(target_dir)
+        target_dir.mkdir(parents=True, exist_ok=True)
+
+        metadata = self._build_skill_metadata(skill_dir)
+        skill_name = self._to_skill_dir_name(metadata.name or skill_dir.name)
+        bob_skill_dir = target_dir / ".bob" / "skills" / skill_name
+        bob_skill_dir.mkdir(parents=True, exist_ok=True)
+
+        (bob_skill_dir / "SKILL.md").write_text(
+            self.format_skill_md(skill_dir, metadata),
+            encoding="utf-8",
+        )
+
+        for subdir in ("references", "scripts", "assets"):
+            source_dir = skill_dir / subdir
+            if source_dir.exists():
+                shutil.copytree(
+                    source_dir,
+                    bob_skill_dir / subdir,
+                    ignore=shutil.ignore_patterns("*.backup", ".*"),
+                )
+
+        return target_dir
+
+    def upload(self, package_path: Path, api_key: str, **kwargs) -> dict[str, Any]:
+        """IBM Bob uses local project/global folders rather than an upload API."""
+        del api_key, kwargs
+        package_path = Path(package_path)
+        return {
+            "success": True,
+            "skill_id": None,
+            "url": None,
+            "message": f"IBM Bob skill packaged at: {package_path} (local install only)",
+        }
+
+    def validate_api_key(self, api_key: str) -> bool:
+        """No API key needed for IBM Bob."""
+        del api_key
+        return True
+
+    def get_env_var_name(self) -> str:
+        """IBM Bob packaging does not require an API key."""
+        return ""
+
+    def supports_enhancement(self) -> bool:
+        """IBM Bob does not expose a packaging-time enhancement API."""
+        return False

--- a/src/skill_seekers/cli/adaptors/pinecone_adaptor.py
+++ b/src/skill_seekers/cli/adaptors/pinecone_adaptor.py
@@ -38,6 +38,34 @@ class PineconeAdaptor(SkillAdaptor):
         """Generate deterministic ID from content and metadata."""
         return self._generate_deterministic_id(content, metadata, format="hex")
 
+    @staticmethod
+    def _parse_ref_frontmatter(content: str) -> tuple[dict[str, Any], str]:
+        """Parse YAML frontmatter from reference file content.
+
+        Args:
+            content: File content potentially starting with ``---`` frontmatter
+
+        Returns:
+            Tuple of (frontmatter dict, content with frontmatter stripped).
+            If no frontmatter, returns ({}, original content).
+        """
+        if not content.startswith("---"):
+            return {}, content
+
+        parts = content.split("---", 2)
+        if len(parts) < 3:
+            return {}, content
+
+        try:
+            import yaml
+
+            fm = yaml.safe_load(parts[1])
+            if not isinstance(fm, dict):
+                return {}, content
+            return fm, parts[2].lstrip("\n")
+        except Exception:
+            return {}, content
+
     def _truncate_text_for_metadata(
         self, text: str, max_bytes: int = PINECONE_METADATA_BYTES_LIMIT
     ) -> str:
@@ -143,6 +171,9 @@ class PineconeAdaptor(SkillAdaptor):
             if ref_content.strip():
                 category = ref_file.stem.replace("_", " ").lower()
 
+                # Parse YAML frontmatter from per-issue files
+                frontmatter_fields, stripped_content = self._parse_ref_frontmatter(ref_content)
+
                 doc_metadata = {
                     "source": metadata.name,
                     "category": category,
@@ -151,6 +182,23 @@ class PineconeAdaptor(SkillAdaptor):
                     "version": metadata.version,
                     "doc_version": metadata.doc_version,
                 }
+
+                # Merge frontmatter fields into metadata for issue files
+                if frontmatter_fields.get("type") == "github_issue":
+                    doc_metadata["type"] = "github_issue"
+                    doc_metadata["category"] = f"{ref_file.stem}"
+                    for key in (
+                        "issue_number",
+                        "title",
+                        "state",
+                        "labels",
+                        "created_at",
+                        "updated_at",
+                        "url",
+                    ):
+                        if key in frontmatter_fields:
+                            doc_metadata[key] = frontmatter_fields[key]
+                    ref_content = stripped_content
 
                 chunks = self._maybe_chunk_content(
                     ref_content,

--- a/src/skill_seekers/cli/architectural_pattern_detector.py
+++ b/src/skill_seekers/cli/architectural_pattern_detector.py
@@ -95,6 +95,8 @@ class ArchitecturalPatternDetector:
             "ProjectSettings/ProjectVersion.txt",
             ".unity",
             "Library/",
+            "UnityEngine",  # Import: using UnityEngine; in C# scripts
+            "Packages/manifest.json",  # Unity Package Manager manifest
         ],
         "Unreal": ["Source/", ".uproject", "Config/DefaultEngine.ini", "Binaries/", "Content/"],
         "Godot": ["project.godot", ".godot", ".tscn", ".tres", ".gd"],
@@ -261,14 +263,21 @@ class ArchitecturalPatternDetector:
         for framework in ["Unity", "Unreal", "Godot"]:
             if framework in self.FRAMEWORK_MARKERS:
                 markers = self.FRAMEWORK_MARKERS[framework]
-                # Check both analyzed files AND directory structure
+                # Check analyzed file paths, directory structure, AND imports
                 file_matches = sum(1 for marker in markers if marker.lower() in all_content.lower())
                 dir_matches = sum(1 for marker in markers if marker.lower() in dir_content.lower())
-                total_matches = file_matches + dir_matches
+                import_matches = sum(
+                    1 for marker in markers if marker.lower() in import_content.lower()
+                )
 
-                if total_matches >= 2:
+                # Import-based detection is high confidence (single match sufficient)
+                # Path/directory-based detection requires 2+ matches to avoid false positives
+                if import_matches >= 1 or (file_matches + dir_matches) >= 2:
                     detected.append(framework)
-                    logger.info(f"  📦 Detected framework: {framework}")
+                    logger.info(
+                        f"  📦 Detected framework: {framework} "
+                        f"(imports:{import_matches} path:{file_matches} dir:{dir_matches})"
+                    )
                     # Return early to prevent web framework false positives
                     return detected
 

--- a/src/skill_seekers/cli/arguments/create.py
+++ b/src/skill_seekers/cli/arguments/create.py
@@ -325,6 +325,49 @@ GITHUB_ARGUMENTS: dict[str, dict[str, Any]] = {
             "help": "Max issues to fetch (default: 100)",
         },
     },
+    "since": {
+        "flags": ("--since",),
+        "kwargs": {
+            "type": str,
+            "default": None,
+            "help": "Only fetch issues updated after this date (ISO8601, UTC 'Z' suffix accepted, or YYYY-MM-DD)",
+            "metavar": "DATE",
+        },
+    },
+    "issue_labels": {
+        "flags": ("--issue-labels",),
+        "kwargs": {
+            "type": str,
+            "default": None,
+            "help": "Filter issues by labels (comma-separated)",
+            "metavar": "LABELS",
+        },
+    },
+    "issue_state": {
+        "flags": ("--issue-state",),
+        "kwargs": {
+            "type": str,
+            "default": None,
+            "choices": ["open", "closed", "all"],
+            "help": "Filter issues by state (default: all)",
+        },
+    },
+    "max_comments": {
+        "flags": ("--max-comments",),
+        "kwargs": {
+            "type": int,
+            "default": 0,
+            "help": "Fetch up to N comments per issue (default: 0, disabled; costs 1+ extra API call per issue, paginated)",
+            "metavar": "N",
+        },
+    },
+    "per_issue_files": {
+        "flags": ("--per-issue-files",),
+        "kwargs": {
+            "action": "store_true",
+            "help": "Write individual markdown files per issue (with YAML frontmatter)",
+        },
+    },
     "scrape_only": {
         "flags": ("--scrape-only",),
         "kwargs": {

--- a/src/skill_seekers/cli/arguments/github.py
+++ b/src/skill_seekers/cli/arguments/github.py
@@ -76,6 +76,49 @@ GITHUB_ARGUMENTS: dict[str, dict[str, Any]] = {
             "metavar": "N",
         },
     },
+    "since": {
+        "flags": ("--since",),
+        "kwargs": {
+            "type": str,
+            "default": None,
+            "help": "Only fetch issues updated after this date (ISO8601, UTC 'Z' suffix accepted, or YYYY-MM-DD; e.g. 2026-01-01T00:00:00Z)",
+            "metavar": "DATE",
+        },
+    },
+    "issue_labels": {
+        "flags": ("--issue-labels",),
+        "kwargs": {
+            "type": str,
+            "default": None,
+            "help": "Filter issues by labels (comma-separated, e.g. bug,enhancement)",
+            "metavar": "LABELS",
+        },
+    },
+    "issue_state": {
+        "flags": ("--issue-state",),
+        "kwargs": {
+            "type": str,
+            "default": None,
+            "choices": ["open", "closed", "all"],
+            "help": "Filter issues by state (default: all)",
+        },
+    },
+    "max_comments": {
+        "flags": ("--max-comments",),
+        "kwargs": {
+            "type": int,
+            "default": 0,
+            "help": "Fetch up to N comments per issue (default: 0, disabled; costs 1+ extra API call per issue, paginated)",
+            "metavar": "N",
+        },
+    },
+    "per_issue_files": {
+        "flags": ("--per-issue-files",),
+        "kwargs": {
+            "action": "store_true",
+            "help": "Write individual markdown files per issue (with YAML frontmatter)",
+        },
+    },
     # Control options
     "scrape_only": {
         "flags": ("--scrape-only",),

--- a/src/skill_seekers/cli/arguments/package.py
+++ b/src/skill_seekers/cli/arguments/package.py
@@ -51,6 +51,7 @@ PACKAGE_ARGUMENTS: dict[str, dict[str, Any]] = {
                 "openrouter",
                 "together",
                 "fireworks",
+                "ibm-bob",
                 "markdown",
                 "langchain",
                 "llama-index",

--- a/src/skill_seekers/cli/config_validator.py
+++ b/src/skill_seekers/cli/config_validator.py
@@ -275,6 +275,42 @@ class UniSkillConfigValidator:
         if "max_issues" in source and not isinstance(source["max_issues"], int):
             raise ValueError(f"Source {index} (github): 'max_issues' must be an integer")
 
+        # Validate issue_since if specified (ISO8601 date string)
+        if "issue_since" in source:
+            issue_since = source["issue_since"]
+            if not isinstance(issue_since, str):
+                raise ValueError(
+                    f"Source {index} (github): 'issue_since' must be an ISO8601 date string"
+                )
+            from datetime import datetime
+
+            since_str = issue_since[:-1] + "+00:00" if issue_since.endswith("Z") else issue_since
+            try:
+                datetime.fromisoformat(since_str)
+            except ValueError as err:
+                raise ValueError(
+                    f"Source {index} (github): 'issue_since' is not a valid ISO8601 date: '{issue_since}'"
+                ) from err
+
+        # Validate issue_labels if specified
+        if "issue_labels" in source:
+            issue_labels = source["issue_labels"]
+            if not isinstance(issue_labels, list) or not all(
+                isinstance(label, str) for label in issue_labels
+            ):
+                raise ValueError(
+                    f"Source {index} (github): 'issue_labels' must be a list of strings"
+                )
+
+        # Validate issue_state if specified
+        if "issue_state" in source:
+            valid_issue_states = {"open", "closed", "all"}
+            if source["issue_state"] not in valid_issue_states:
+                raise ValueError(
+                    f"Source {index} (github): Invalid issue_state '{source['issue_state']}'. "
+                    f"Must be one of {valid_issue_states}"
+                )
+
         # Validate enable_codebase_analysis if specified (C3.5)
         if "enable_codebase_analysis" in source and not isinstance(
             source["enable_codebase_analysis"], bool

--- a/src/skill_seekers/cli/create_command.py
+++ b/src/skill_seekers/cli/create_command.py
@@ -229,6 +229,15 @@ class CreateCommand:
                     "local_repo_path": getattr(self.args, "local_repo_path", None),
                     "include_issues": getattr(self.args, "include_issues", True),
                     "max_issues": getattr(self.args, "max_issues", 100),
+                    "max_comments": getattr(self.args, "max_comments", 0),
+                    "per_issue_files": getattr(self.args, "per_issue_files", False),
+                    "issue_labels": (
+                        [lab.strip() for lab in self.args.issue_labels.split(",") if lab.strip()]
+                        if getattr(self.args, "issue_labels", None)
+                        else []
+                    ),
+                    "issue_state": getattr(self.args, "issue_state", None) or "all",
+                    "issue_since": getattr(self.args, "since", None),
                     "include_changelog": getattr(self.args, "include_changelog", True),
                     "include_releases": getattr(self.args, "include_releases", True),
                     "include_code": getattr(self.args, "include_code", True),

--- a/src/skill_seekers/cli/github_fetcher.py
+++ b/src/skill_seekers/cli/github_fetcher.py
@@ -82,6 +82,9 @@ class GitHubThreeStreamFetcher:
         github_token: str | None = None,
         interactive: bool = True,
         profile_name: str | None = None,
+        issue_since: str | None = None,
+        issue_labels: list[str] | None = None,
+        issue_state: str | None = None,
     ):
         """
         Initialize fetcher.
@@ -91,11 +94,17 @@ class GitHubThreeStreamFetcher:
             github_token: Optional GitHub API token for higher rate limits
             interactive: Whether to show interactive prompts (False for CI/CD)
             profile_name: Name of the GitHub profile being used
+            issue_since: Only fetch issues updated after this ISO8601 date
+            issue_labels: Filter issues by these label names
+            issue_state: Filter issues by state ("open", "closed", or "all")
         """
         self.repo_url = repo_url
         self.github_token = github_token or os.getenv("GITHUB_TOKEN")
         self.owner, self.repo = self.parse_repo_url(repo_url)
         self.interactive = interactive
+        self.issue_since = issue_since
+        self.issue_labels = issue_labels or []
+        self.issue_state = issue_state or "all"
 
         # Initialize rate limit handler
         config = get_config_manager()
@@ -267,7 +276,7 @@ class GitHubThreeStreamFetcher:
 
     def fetch_issues(self, max_issues: int = 100) -> list[dict]:
         """
-        Fetch GitHub issues (open + closed).
+        Fetch GitHub issues with optional state/label/since filters.
 
         Args:
             max_issues: Maximum number of issues to fetch
@@ -277,11 +286,13 @@ class GitHubThreeStreamFetcher:
         """
         all_issues = []
 
-        # Fetch open issues
-        all_issues.extend(self._fetch_issues_page(state="open", max_count=max_issues // 2))
-
-        # Fetch closed issues
-        all_issues.extend(self._fetch_issues_page(state="closed", max_count=max_issues // 2))
+        if self.issue_state in ("open", "closed"):
+            # Single-state fetch: use full quota
+            all_issues.extend(self._fetch_issues_page(state=self.issue_state, max_count=max_issues))
+        else:
+            # Default "all": split quota between open and closed
+            all_issues.extend(self._fetch_issues_page(state="open", max_count=max_issues // 2))
+            all_issues.extend(self._fetch_issues_page(state="closed", max_count=max_issues // 2))
 
         return all_issues
 
@@ -308,6 +319,10 @@ class GitHubThreeStreamFetcher:
             "sort": "comments",
             "direction": "desc",
         }
+        if self.issue_since:
+            params["since"] = self.issue_since
+        if self.issue_labels:
+            params["labels"] = ",".join(self.issue_labels)
 
         try:
             response = requests.get(url, headers=headers, params=params, timeout=10)

--- a/src/skill_seekers/cli/github_scraper.py
+++ b/src/skill_seekers/cli/github_scraper.py
@@ -256,6 +256,11 @@ class GitHubScraper(SkillConverter):
         # Options
         self.include_issues = config.get("include_issues", True)
         self.max_issues = config.get("max_issues", 100)
+        self.max_comments = config.get("max_comments", 0)
+        self.issue_since = config.get("issue_since")
+        self.issue_labels = config.get("issue_labels", [])
+        self.issue_state = config.get("issue_state", "all")
+        self.per_issue_files = config.get("per_issue_files", False)
         self.include_changelog = config.get("include_changelog", True)
         self.include_releases = config.get("include_releases", True)
         self.include_code = config.get("include_code", True)
@@ -831,8 +836,26 @@ class GitHubScraper(SkillConverter):
         logger.info(f"Extracting GitHub Issues (max {self.max_issues})...")
 
         try:
-            # Fetch recent issues (open + closed)
-            issues = self.repo.get_issues(state="all", sort="updated", direction="desc")
+            # Build kwargs for get_issues
+            kwargs: dict[str, Any] = {
+                "state": self.issue_state or "all",
+                "sort": "updated",
+                "direction": "desc",
+            }
+            if self.issue_labels:
+                kwargs["labels"] = self.issue_labels
+            if self.issue_since:
+                from datetime import datetime
+
+                since_str = (
+                    self.issue_since[:-1] + "+00:00"
+                    if self.issue_since.endswith("Z")
+                    else self.issue_since
+                )
+                kwargs["since"] = datetime.fromisoformat(since_str)
+
+            # Fetch issues with filters
+            issues = self.repo.get_issues(**kwargs)
 
             issue_list = []
             for issue in itertools.islice(issues, self.max_issues):
@@ -840,6 +863,29 @@ class GitHubScraper(SkillConverter):
                 if issue.pull_request:
                     continue
 
+                # Fetch comments only when explicitly requested
+                comments_list = []
+                if self.max_comments > 0:
+                    try:
+                        for comment in issue.get_comments()[: self.max_comments]:
+                            comments_list.append(
+                                {
+                                    "author": comment.user.login if comment.user else "unknown",
+                                    "created_at": (
+                                        comment.created_at.isoformat()
+                                        if comment.created_at
+                                        else None
+                                    ),
+                                    "body": comment.body,
+                                }
+                            )
+                    except Exception as e:
+                        logger.debug(f"Could not fetch comments for issue #{issue.number}: {e}")
+
+                # data.json body field: with per_issue_files=True the full body is
+                # mirrored here AND in references/issues/*.md. With per_issue_files=False
+                # we keep only a 500-char preview to keep data.json small. Downstream
+                # packagers needing the full text should fetch the live issue.
                 issue_data = {
                     "number": issue.number,
                     "title": issue.title,
@@ -850,7 +896,12 @@ class GitHubScraper(SkillConverter):
                     "updated_at": issue.updated_at.isoformat() if issue.updated_at else None,
                     "closed_at": issue.closed_at.isoformat() if issue.closed_at else None,
                     "url": issue.html_url,
-                    "body": issue.body[:500] if issue.body else None,  # First 500 chars
+                    "body": (
+                        issue.body or None
+                        if self.per_issue_files
+                        else (issue.body[:500] if issue.body else None)
+                    ),
+                    "comments": comments_list,
                 }
                 issue_list.append(issue_data)
 
@@ -935,6 +986,9 @@ class GitHubToSkillConverter:
         """Initialize converter with configuration."""
         self.config = config
         self.name = config.get("name", config["repo"].split("/")[-1])
+        self.repo_owner = config["repo"].split("/")[0]
+        self.repo_short_name = config["repo"].split("/")[-1]
+        self.per_issue_files = config.get("per_issue_files", False)
 
         # Paths
         self.data_file = f"output/{self.name}_github_data.json"
@@ -1069,6 +1123,10 @@ Use this skill when you need to:
         skill_content += "- `references/README.md` - Complete README documentation\n"
         skill_content += "- `references/CHANGELOG.md` - Version history and changes\n"
         skill_content += "- `references/issues.md` - Recent GitHub issues\n"
+        if self.per_issue_files:
+            skill_content += (
+                "- `references/issues/` - Per-issue markdown files with YAML frontmatter\n"
+            )
         skill_content += "- `references/releases.md` - Release notes\n"
         skill_content += "- `references/file_structure.md` - Repository structure\n"
 
@@ -1315,9 +1373,10 @@ Use this skill when you need to:
             self._generate_file_structure_reference()
 
     def _generate_issues_reference(self):
-        """Generate issues.md reference file."""
+        """Generate issues.md summary and per-issue reference files."""
         issues = self.data["issues"]
 
+        # --- Summary file (issues.md) ---
         content = f"# GitHub Issues\n\nRecent issues from the repository ({len(issues)} total).\n\n"
 
         # Group by state
@@ -1344,6 +1403,68 @@ Use this skill when you need to:
         with open(issues_path, "w", encoding="utf-8") as f:
             f.write(content)
         logger.info(f"Generated: {issues_path}")
+
+        # --- Per-issue files (opt-in) ---
+        if self.per_issue_files:
+            os.makedirs(f"{self.skill_dir}/references/issues", exist_ok=True)
+            for issue in issues:
+                self._write_per_issue_file(issue)
+            logger.info(f"Generated {len(issues)} per-issue files")
+
+    def _write_per_issue_file(self, issue: dict):
+        """Write a single per-issue markdown file with YAML frontmatter.
+
+        Args:
+            issue: Issue data dict with number, title, body, comments, etc.
+        """
+        number = issue["number"]
+        title = issue["title"]
+        state = issue["state"]
+        labels = issue.get("labels", [])
+        created_at = issue.get("created_at") or "N/A"
+        updated_at = issue.get("updated_at") or "N/A"
+        url = issue.get("url", "")
+        body = issue.get("body") or ""
+        comments = issue.get("comments", [])
+
+        # Escape title for YAML (wrap in quotes)
+        yaml_title = title.replace('"', '\\"')
+        labels_yaml = json.dumps(labels)
+
+        file_content = f"""---
+type: github_issue
+issue_number: {number}
+title: "{yaml_title}"
+state: {state}
+labels: {labels_yaml}
+created_at: "{created_at}"
+updated_at: "{updated_at}"
+url: "{url}"
+---
+
+# Issue #{number}: {title}
+
+**State:** {state} | **Labels:** {", ".join(labels) if labels else "None"} | **Created:** {created_at[:10]}
+**URL:** {url}
+
+## Description
+
+{body}
+"""
+
+        if comments:
+            file_content += f"\n## Comments ({len(comments)})\n"
+            for comment in comments:
+                author = comment.get("author", "unknown")
+                comment_date = comment.get("created_at", "N/A")
+                comment_body = comment.get("body", "")
+                file_content += f"\n### {author} — {comment_date}\n{comment_body}\n\n---\n"
+
+        filename = f"{self.repo_owner}-{self.repo_short_name}-{number}.md"
+        filepath = f"{self.skill_dir}/references/issues/{filename}"
+        with open(filepath, "w", encoding="utf-8") as f:
+            f.write(file_content)
+        logger.debug(f"Generated per-issue file: {filepath}")
 
     def _generate_releases_reference(self):
         """Generate releases.md reference file."""

--- a/src/skill_seekers/cli/install_agent.py
+++ b/src/skill_seekers/cli/install_agent.py
@@ -51,6 +51,7 @@ AGENT_PATHS = {
     "kilo": ".kilo/skills/",  # Project-relative (Kilo Code, Cline fork)
     "continue": "~/.continue/skills/",  # Global (Continue.dev)
     "kimi-code": "~/.kimi/skills/",  # Global (Kimi Code)
+    "bob": ".bob/skills/",  # Project-relative (IBM Bob)
 }
 
 
@@ -370,7 +371,7 @@ Examples:
 
 Supported agents:
   claude, cursor, vscode, copilot, amp, goose, opencode, letta, aide, windsurf,
-  neovate, roo, cline, aider, bolt, kilo, continue, kimi-code, all
+  neovate, roo, cline, aider, bolt, kilo, continue, kimi-code, bob, all
         """,
     )
 

--- a/src/skill_seekers/cli/package_skill.py
+++ b/src/skill_seekers/cli/package_skill.py
@@ -187,8 +187,13 @@ def package_skill(
         print(f"\n📂 Opening folder: {package_path.parent}")
         open_folder(package_path.parent)
 
-    # Print upload instructions
-    print_upload_instructions(package_path)
+    # Print next-step instructions
+    if adaptor.DEFAULT_API_ENDPOINT:
+        print_upload_instructions(package_path)
+    else:
+        print()
+        print("ℹ️  Local target packaged successfully.")
+        print(f"   Install or copy from: {package_path}")
 
     return True, package_path
 

--- a/src/skill_seekers/cli/parsers/install_agent_parser.py
+++ b/src/skill_seekers/cli/parsers/install_agent_parser.py
@@ -24,7 +24,7 @@ class InstallAgentParser(SubcommandParser):
         parser.add_argument(
             "--agent",
             required=True,
-            help="Agent name (claude, cursor, vscode, amp, goose, opencode, kimi-code, all)",
+            help="Agent name (claude, cursor, vscode, amp, goose, opencode, kimi-code, bob, all)",
         )
         parser.add_argument(
             "--force", action="store_true", help="Overwrite existing installation without asking"

--- a/src/skill_seekers/cli/pdf_scraper.py
+++ b/src/skill_seekers/cli/pdf_scraper.py
@@ -328,8 +328,17 @@ class PDFToSkillConverter(SkillConverter):
                         lang = code.get("language", "")
                         f.write(f"```{lang}\n{code['code']}\n```\n\n")
 
-                # Add images
-                if page.get("images"):
+                # Add images extracted by pdf_extractor_poc (already saved to disk)
+                if page.get("extracted_images"):
+                    f.write("### Images\n\n")
+                    for img in page["extracted_images"]:
+                        img_filename = img["filename"]
+                        page_num = img.get("page_number", page.get("page_number", ""))
+                        alt_text = f"Image from page {page_num}" if page_num else "Image"
+                        f.write(f"![{alt_text}](../assets/images/{img_filename})\n\n")
+
+                # Add images in legacy format (with raw data, not yet saved)
+                elif page.get("images"):
                     # Create assets directory if needed
                     assets_dir = os.path.join(self.skill_dir, "assets")
                     os.makedirs(assets_dir, exist_ok=True)

--- a/src/skill_seekers/cli/source_detector.py
+++ b/src/skill_seekers/cli/source_detector.py
@@ -200,7 +200,15 @@ class SourceDetector:
 
     @classmethod
     def _detect_html(cls, source: str) -> SourceInfo:
-        """Detect local HTML file source."""
+        """Detect HTML source — URL or local file.
+
+        Routes ``http(s)://...`` inputs to the web scraper so URLs ending in
+        ``.html`` (e.g. Flutter API docs) are fetched instead of being treated
+        as missing local files. All other inputs route to the html_scraper.
+        """
+        if source.startswith(("http://", "https://")):
+            return cls._detect_web(source)
+
         name = os.path.splitext(os.path.basename(source))[0]
         return SourceInfo(
             type="html", parsed={"file_path": source}, suggested_name=name, raw_input=source

--- a/src/skill_seekers/cli/unified_scraper.py
+++ b/src/skill_seekers/cli/unified_scraper.py
@@ -1649,7 +1649,7 @@ class UnifiedScraper(SkillConverter):
                 directory=Path(local_repo_path),
                 output_dir=temp_output,
                 depth="deep",
-                languages=None,  # Analyze all languages
+                languages=source.get("languages"),  # Respect language filter from source config
                 file_patterns=source.get("file_patterns"),
                 build_api_reference=True,  # C2.5: API Reference
                 extract_comments=False,  # Not needed

--- a/src/skill_seekers/cli/unified_scraper.py
+++ b/src/skill_seekers/cli/unified_scraper.py
@@ -1564,15 +1564,21 @@ class UnifiedScraper(SkillConverter):
         """
         Load how-to guide collection from tutorials directory.
 
+        Returns an empty dict (falsy) when the directory or any guide files
+        are missing, so callers can chain ``primary or fallback`` to fall
+        through to a secondary path. Returning a non-empty placeholder here
+        would short-circuit those chains and silently drop real guide data
+        in the fallback location (issue #364).
+
         Args:
             tutorials_dir: Path to tutorials directory
 
         Returns:
-            Dict with guide collection data
+            Dict with guide collection data, or ``{}`` when no guides found.
         """
         if not tutorials_dir.exists():
-            logger.warning(f"Tutorials directory not found: {tutorials_dir}")
-            return {"guides": []}
+            logger.debug(f"Tutorials directory not found: {tutorials_dir}")
+            return {}
 
         collection_file = tutorials_dir / "guide_collection.json"
         if collection_file.exists():
@@ -1585,6 +1591,8 @@ class UnifiedScraper(SkillConverter):
             if guide_data:
                 guides.append(guide_data)
 
+        if not guides:
+            return {}
         return {"guides": guides, "total_count": len(guides)}
 
     def _load_api_reference(self, api_dir: Path) -> dict[str, Any]:

--- a/src/skill_seekers/cli/unified_skill_builder.py
+++ b/src/skill_seekers/cli/unified_skill_builder.py
@@ -882,18 +882,9 @@ This skill combines knowledge from multiple sources:
                 content += f"  - {extra_label}: {source.get(extra_key, extra_default)}\n"
 
         # C3.x Architecture & Code Analysis section (if available)
-        github_data = self.scraped_data.get("github", {})
-        # Handle both dict and list cases
-        if isinstance(github_data, dict):
-            github_data = github_data.get("data", {})
-        elif isinstance(github_data, list) and len(github_data) > 0:
-            first_item = github_data[0]
-            github_data = first_item.get("data", {}) if isinstance(first_item, dict) else {}
-        else:
-            github_data = {}
-
-        if github_data.get("c3_analysis"):
-            content += self._format_c3_summary_section(github_data["c3_analysis"])
+        c3_payloads = self._collect_c3_payloads()
+        if c3_payloads:
+            content += self._format_c3_summary_section(c3_payloads)
 
         # Data quality section
         if self.conflicts:
@@ -1099,6 +1090,9 @@ This skill combines knowledge from multiple sources:
             if github_data.get("c3_analysis"):
                 repo_id = github_source.get("repo_id", "unknown")
                 self._generate_c3_analysis_references(repo_id=repo_id)
+
+        # Local sources also carry C3.x output — fixes #363
+        self._generate_local_codebase_analysis_references()
 
     def _generate_docs_references(self, docs_list: list[dict]):
         """Generate references from multiple documentation sources."""
@@ -1388,14 +1382,59 @@ This skill combines knowledge from multiple sources:
         if not c3_data:
             return
 
-        # Create unique directory per repo for multi-source support
-        c3_dir = os.path.join(self.skill_dir, "references", "codebase_analysis", repo_id)
+        self._write_codebase_analysis_references(
+            c3_data=c3_data, source_id=repo_id, github_data=github_data
+        )
+
+    def _generate_local_codebase_analysis_references(self):
+        """Generate codebase analysis references for each local source (#363).
+
+        Local sources store C3.x output (patterns, test_examples, how_to_guides,
+        config_patterns, architecture, ...) directly on the source dict. They were
+        previously dropped by the builder, which only consumed GitHub sources.
+        """
+        local_list = self.scraped_data.get("local", [])
+        if not local_list:
+            return
+
+        c3_keys = (
+            "patterns",
+            "test_examples",
+            "how_to_guides",
+            "config_patterns",
+            "architecture",
+        )
+        for local_source in local_list:
+            if not any(local_source.get(k) for k in c3_keys):
+                continue
+
+            source_id = self._sanitize_source_id(
+                local_source.get("source_id") or local_source.get("name") or "local"
+            )
+            self._write_codebase_analysis_references(
+                c3_data=local_source, source_id=source_id, github_data=None
+            )
+
+    @staticmethod
+    def _sanitize_source_id(raw: str) -> str:
+        """Normalize a source identifier to a filesystem-safe directory name."""
+        cleaned = re.sub(r"[^\w\-]", "_", raw or "").strip("_")
+        return cleaned or "local"
+
+    def _write_codebase_analysis_references(
+        self,
+        c3_data: dict,
+        source_id: str,
+        github_data: dict | None = None,
+    ):
+        """Shared C3.x reference writer used by both GitHub and local sources."""
+        c3_dir = os.path.join(self.skill_dir, "references", "codebase_analysis", source_id)
         os.makedirs(c3_dir, exist_ok=True)
 
-        logger.info("Generating C3.x codebase analysis references...")
+        logger.info(f"Generating C3.x codebase analysis references for '{source_id}'...")
 
         # Generate ARCHITECTURE.md (main deliverable)
-        self._generate_architecture_overview(c3_dir, c3_data, github_data)
+        self._generate_architecture_overview(c3_dir, c3_data, github_data or {})
 
         # Generate subdirectories for each C3.x component
         self._generate_pattern_references(c3_dir, c3_data.get("patterns"))
@@ -1854,69 +1893,131 @@ This skill combines knowledge from multiple sources:
 
         logger.info(f"   ✓ Architectural details: {len(patterns)} patterns")
 
-    def _format_c3_summary_section(self, c3_data: dict) -> str:
-        """Format C3.x analysis summary for SKILL.md."""
+    def _collect_c3_payloads(self) -> list[dict]:
+        """Gather C3.x analysis payloads across GitHub and local sources (#363).
+
+        Returns:
+            List of c3_data dicts, one per source that produced analysis.
+        """
+        payloads: list[dict] = []
+
+        github_data = self.scraped_data.get("github", {})
+        # Handle both dict and list cases
+        if isinstance(github_data, list):
+            for item in github_data:
+                if not isinstance(item, dict):
+                    continue
+                inner = item.get("data", {})
+                if isinstance(inner, dict) and inner.get("c3_analysis"):
+                    payloads.append(inner["c3_analysis"])
+        elif isinstance(github_data, dict):
+            inner = github_data.get("data", {})
+            if isinstance(inner, dict) and inner.get("c3_analysis"):
+                payloads.append(inner["c3_analysis"])
+
+        for local_source in self.scraped_data.get("local", []) or []:
+            if not isinstance(local_source, dict):
+                continue
+            if any(
+                local_source.get(k)
+                for k in (
+                    "patterns",
+                    "test_examples",
+                    "how_to_guides",
+                    "config_patterns",
+                    "architecture",
+                )
+            ):
+                payloads.append(local_source)
+
+        return payloads
+
+    def _format_c3_summary_section(self, c3_payloads) -> str:
+        """Format C3.x analysis summary for SKILL.md.
+
+        Accepts either a single c3_data dict (legacy) or a list of payloads
+        (post #363, when GitHub + local sources both contribute).
+        """
+        # Backward-compatible: allow callers passing a single dict
+        payloads = [c3_payloads] if isinstance(c3_payloads, dict) else list(c3_payloads or [])
+
+        if not payloads:
+            return ""
+
         content = "\n## 🏗️ Architecture & Code Analysis\n\n"
         content += "*This skill includes comprehensive codebase analysis*\n\n"
 
-        # Add architectural pattern summary
-        if c3_data.get("architecture"):
-            patterns = c3_data["architecture"].get("patterns", [])
-            if patterns:
-                top_pattern = patterns[0]
+        # Primary architecture: take from the first payload that has one
+        for payload in payloads:
+            arch = payload.get("architecture") or {}
+            arch_patterns = arch.get("patterns", []) if isinstance(arch, dict) else []
+            if arch_patterns:
+                top_pattern = arch_patterns[0]
                 content += f"**Primary Architecture**: {top_pattern['pattern_name']}"
                 if top_pattern.get("framework"):
                     content += f" ({top_pattern['framework']})"
                 content += f" - Confidence: {top_pattern['confidence']:.0%}\n\n"
+                break
 
-        # Add design patterns summary
-        if c3_data.get("patterns"):
-            total_patterns = sum(len(f.get("patterns", [])) for f in c3_data["patterns"])
-            if total_patterns > 0:
-                content += f"**Design Patterns**: {total_patterns} detected\n"
+        # Design patterns: aggregate across payloads
+        total_patterns = 0
+        pattern_summary: dict[str, int] = {}
+        for payload in payloads:
+            for file_data in payload.get("patterns") or []:
+                for pattern in file_data.get("patterns", []):
+                    total_patterns += 1
+                    ptype = pattern.get("pattern_type", "Unknown")
+                    pattern_summary[ptype] = pattern_summary.get(ptype, 0) + 1
+        if total_patterns > 0:
+            content += f"**Design Patterns**: {total_patterns} detected\n"
+            top_patterns = sorted(pattern_summary.items(), key=lambda x: x[1], reverse=True)[:3]
+            if top_patterns:
+                content += (
+                    f"- Top patterns: {', '.join([f'{p[0]} ({p[1]})' for p in top_patterns])}\n"
+                )
+            content += "\n"
 
-                # Show top 3 pattern types
-                pattern_summary = {}
-                for file_data in c3_data["patterns"]:
-                    for pattern in file_data.get("patterns", []):
-                        ptype = pattern["pattern_type"]
-                        pattern_summary[ptype] = pattern_summary.get(ptype, 0) + 1
+        # Test examples: sum totals across payloads
+        total_examples = 0
+        total_high_value = 0
+        for payload in payloads:
+            examples = payload.get("test_examples") or {}
+            if isinstance(examples, dict):
+                total_examples += examples.get("total_examples", 0) or 0
+                total_high_value += examples.get("high_value_count", 0) or 0
+        if total_examples > 0:
+            content += (
+                f"**Usage Examples**: {total_examples} extracted from tests "
+                f"({total_high_value} high-value)\n\n"
+            )
 
-                top_patterns = sorted(pattern_summary.items(), key=lambda x: x[1], reverse=True)[:3]
-                if top_patterns:
-                    content += (
-                        f"- Top patterns: {', '.join([f'{p[0]} ({p[1]})' for p in top_patterns])}\n"
-                    )
-                content += "\n"
+        # How-to guides: sum guide counts
+        total_guides = 0
+        for payload in payloads:
+            guides = payload.get("how_to_guides") or {}
+            if isinstance(guides, dict):
+                total_guides += len(guides.get("guides", []) or [])
+        if total_guides > 0:
+            content += f"**How-To Guides**: {total_guides} workflow tutorials\n\n"
 
-        # Add test examples summary
-        if c3_data.get("test_examples"):
-            total = c3_data["test_examples"].get("total_examples", 0)
-            high_value = c3_data["test_examples"].get("high_value_count", 0)
-            if total > 0:
-                content += f"**Usage Examples**: {total} extracted from tests ({high_value} high-value)\n\n"
-
-        # Add how-to guides summary
-        if c3_data.get("how_to_guides"):
-            guide_count = len(c3_data["how_to_guides"].get("guides", []))
-            if guide_count > 0:
-                content += f"**How-To Guides**: {guide_count} workflow tutorials\n\n"
-
-        # Add configuration summary
-        if c3_data.get("config_patterns"):
-            config_files = c3_data["config_patterns"].get("config_files", [])
-            if config_files:
-                content += f"**Configuration Files**: {len(config_files)} analyzed\n"
-
-                # Add security warning if present
-                if c3_data["config_patterns"].get("ai_enhancements"):
-                    insights = c3_data["config_patterns"]["ai_enhancements"].get(
-                        "overall_insights", {}
-                    )
-                    security_issues = insights.get("security_issues_found", 0)
-                    if security_issues > 0:
-                        content += f"- 🔐 **Security Alert**: {security_issues} issue(s) detected\n"
-                content += "\n"
+        # Configuration: sum config files + propagate any security alerts
+        total_config_files = 0
+        total_security_issues = 0
+        for payload in payloads:
+            config = payload.get("config_patterns") or {}
+            if not isinstance(config, dict):
+                continue
+            total_config_files += len(config.get("config_files", []) or [])
+            ai_block = config.get("ai_enhancements") or {}
+            if isinstance(ai_block, dict):
+                insights = ai_block.get("overall_insights") or {}
+                if isinstance(insights, dict):
+                    total_security_issues += insights.get("security_issues_found", 0) or 0
+        if total_config_files > 0:
+            content += f"**Configuration Files**: {total_config_files} analyzed\n"
+            if total_security_issues > 0:
+                content += f"- 🔐 **Security Alert**: {total_security_issues} issue(s) detected\n"
+            content += "\n"
 
         # Add link to ARCHITECTURE.md
         content += "📖 **See** `references/codebase_analysis/ARCHITECTURE.md` for complete architectural overview.\n\n"

--- a/src/skill_seekers/cli/unified_skill_builder.py
+++ b/src/skill_seekers/cli/unified_skill_builder.py
@@ -384,7 +384,7 @@ This skill synthesizes knowledge from multiple sources:
         content += "Organized by source:\n\n"
         content += "- [Documentation](references/documentation/)\n"
         content += "- [GitHub](references/github/)\n"
-        content += "- [Codebase Analysis](references/codebase_analysis/ARCHITECTURE.md)\n\n"
+        content += "- [Codebase Analysis](references/codebase_analysis/index.md)\n\n"
 
         # Footer
         content += "---\n\n"
@@ -461,8 +461,8 @@ This skill synthesizes knowledge from multiple sources:
         # Update reference documentation to include PDF
         final_content = "\n".join(lines)
         final_content = final_content.replace(
-            "- [Codebase Analysis](references/codebase_analysis/ARCHITECTURE.md)\n",
-            "- [Codebase Analysis](references/codebase_analysis/ARCHITECTURE.md)\n- [PDF Documentation](references/pdf/)\n",
+            "- [Codebase Analysis](references/codebase_analysis/index.md)\n",
+            "- [Codebase Analysis](references/codebase_analysis/index.md)\n- [PDF Documentation](references/pdf/)\n",
         )
 
         return final_content
@@ -1094,6 +1094,12 @@ This skill combines knowledge from multiple sources:
         # Local sources also carry C3.x output — fixes #363
         self._generate_local_codebase_analysis_references()
 
+        # Top-level index linking each per-source ARCHITECTURE.md (#362).
+        # SKILL.md links into `references/codebase_analysis/index.md` instead of
+        # the historical `references/codebase_analysis/ARCHITECTURE.md`, which
+        # never existed once outputs became per-source-namespaced.
+        self._generate_codebase_analysis_index()
+
     def _generate_docs_references(self, docs_list: list[dict]):
         """Generate references from multiple documentation sources."""
         # Skip if no documentation sources
@@ -1420,6 +1426,57 @@ This skill combines knowledge from multiple sources:
         """Normalize a source identifier to a filesystem-safe directory name."""
         cleaned = re.sub(r"[^\w\-]", "_", raw or "").strip("_")
         return cleaned or "local"
+
+    def _generate_codebase_analysis_index(self):
+        """Write `references/codebase_analysis/index.md` (#362).
+
+        Scans the codebase_analysis directory after per-source references have
+        been written and produces a single landing page that links to each
+        source's ARCHITECTURE.md and any populated subsections (patterns,
+        examples, guides, configuration). SKILL.md uses this as a stable link
+        target so the path resolves whether the build has one source or many.
+        """
+        base = os.path.join(self.skill_dir, "references", "codebase_analysis")
+        if not os.path.isdir(base):
+            return
+
+        sources = []
+        for entry in sorted(os.listdir(base)):
+            entry_path = os.path.join(base, entry)
+            if not os.path.isdir(entry_path):
+                continue
+            if not os.path.isfile(os.path.join(entry_path, "ARCHITECTURE.md")):
+                continue
+            sources.append(entry)
+
+        if not sources:
+            return
+
+        index_path = os.path.join(base, "index.md")
+        subsections = (
+            ("patterns", "Design patterns"),
+            ("examples", "Usage examples"),
+            ("guides", "How-to guides"),
+            ("configuration", "Configuration"),
+        )
+
+        with open(index_path, "w", encoding="utf-8") as f:
+            f.write("# Codebase Analysis\n\n")
+            f.write(
+                "Architecture and code-analysis output from the C3.x pipeline, "
+                "organized by source. Each entry links to the per-source "
+                "ARCHITECTURE.md and any populated subsections.\n\n"
+            )
+
+            for source in sources:
+                f.write(f"## {source}\n\n")
+                f.write(f"- [Architecture overview]({source}/ARCHITECTURE.md)\n")
+                for sub_dir, label in subsections:
+                    if os.path.isdir(os.path.join(base, source, sub_dir)):
+                        f.write(f"- [{label}]({source}/{sub_dir}/)\n")
+                f.write("\n")
+
+        logger.info(f"📚 Created codebase analysis index: {index_path}")
 
     def _write_codebase_analysis_references(
         self,
@@ -2019,8 +2076,12 @@ This skill combines knowledge from multiple sources:
                 content += f"- 🔐 **Security Alert**: {total_security_issues} issue(s) detected\n"
             content += "\n"
 
-        # Add link to ARCHITECTURE.md
-        content += "📖 **See** `references/codebase_analysis/ARCHITECTURE.md` for complete architectural overview.\n\n"
+        # Add link to the codebase-analysis landing page (#362)
+        content += (
+            "📖 **See** `references/codebase_analysis/index.md` for the per-source "
+            "architecture overviews and detailed pattern, example, guide, and "
+            "configuration references.\n\n"
+        )
 
         return content
 

--- a/tests/test_adaptors/test_base.py
+++ b/tests/test_adaptors/test_base.py
@@ -54,6 +54,7 @@ class TestAdaptorRegistry(unittest.TestCase):
         self.assertIsInstance(platforms, list)
         # Claude should always be available
         self.assertIn("claude", platforms)
+        self.assertIn("ibm-bob", platforms)
 
     def test_is_platform_available(self):
         """Test checking platform availability"""

--- a/tests/test_adaptors/test_ibm_bob_adaptor.py
+++ b/tests/test_adaptors/test_ibm_bob_adaptor.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+Tests for IBM Bob adaptor.
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from skill_seekers.cli.adaptors import get_adaptor, is_platform_available
+from skill_seekers.cli.adaptors.base import SkillMetadata
+from skill_seekers.cli.adaptors.ibm_bob import IBMBobAdaptor
+
+
+class TestIBMBobAdaptor(unittest.TestCase):
+    """Test IBM Bob adaptor functionality."""
+
+    def setUp(self):
+        self.adaptor = get_adaptor("ibm-bob")
+
+    def test_platform_info(self):
+        self.assertEqual(self.adaptor.PLATFORM, "ibm-bob")
+        self.assertEqual(self.adaptor.PLATFORM_NAME, "IBM Bob")
+        self.assertIsNone(self.adaptor.DEFAULT_API_ENDPOINT)
+
+    def test_platform_available(self):
+        self.assertTrue(is_platform_available("ibm-bob"))
+
+    def test_validate_api_key_always_true(self):
+        self.assertTrue(self.adaptor.validate_api_key(""))
+        self.assertTrue(self.adaptor.validate_api_key("anything"))
+
+    def test_no_enhancement_support(self):
+        self.assertFalse(self.adaptor.supports_enhancement())
+
+    def test_upload_returns_local_path(self):
+        result = self.adaptor.upload(Path("/some/path"), "")
+        self.assertTrue(result["success"])
+        self.assertIn("local", result["message"].lower())
+
+    def test_skill_dir_name_normalization(self):
+        self.assertEqual(IBMBobAdaptor._to_skill_dir_name("My Cool Skill"), "my-cool-skill")
+        self.assertEqual(IBMBobAdaptor._to_skill_dir_name("Bob_skill.v2"), "bob-skill-v2")
+        self.assertEqual(IBMBobAdaptor._to_skill_dir_name("!!!"), "skill")
+
+    def test_format_skill_md_has_frontmatter(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            skill_dir = Path(temp_dir)
+            (skill_dir / "references").mkdir()
+            (skill_dir / "references" / "test.md").write_text("# Test content")
+
+            metadata = SkillMetadata(
+                name="django-orm",
+                description="Guide to Django ORM patterns and queries",
+                version="1.2.0",
+                tags=["django", "orm"],
+            )
+            formatted = self.adaptor.format_skill_md(skill_dir, metadata)
+
+            self.assertTrue(formatted.startswith("---"))
+            self.assertIn('name: "django-orm"', formatted)
+            self.assertIn('description: "Guide to Django ORM patterns and queries"', formatted)
+            self.assertIn('version: "1.2.0"', formatted)
+            self.assertIn("tags:", formatted)
+            self.assertIn("- django", formatted)
+
+    def test_format_with_existing_content(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            skill_dir = Path(temp_dir)
+            existing = (
+                "---\nname: test\ndescription: desc\n---\n\n# Existing Content\n\n" + "x" * 200
+            )
+            (skill_dir / "SKILL.md").write_text(existing)
+
+            metadata = SkillMetadata(name="test", description="Test")
+            formatted = self.adaptor.format_skill_md(skill_dir, metadata)
+
+            self.assertTrue(formatted.startswith("---"))
+            self.assertIn("Existing Content", formatted)
+
+    def test_package_creates_bob_layout(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            skill_dir = Path(temp_dir) / "test-skill"
+            skill_dir.mkdir()
+            (skill_dir / "SKILL.md").write_text(
+                "---\nname: Test Skill\ndescription: Test skill for Bob\nversion: 1.0.0\n---\n\n# Test"
+            )
+            refs = skill_dir / "references"
+            refs.mkdir()
+            (refs / "guide.md").write_text("# Guide")
+
+            output_dir = Path(temp_dir) / "output"
+            output_dir.mkdir()
+
+            result_path = self.adaptor.package(skill_dir, output_dir)
+            bob_skill_dir = result_path / ".bob" / "skills" / "test-skill"
+
+            self.assertTrue(result_path.exists())
+            self.assertTrue(result_path.is_dir())
+            self.assertTrue(bob_skill_dir.exists())
+            self.assertTrue((bob_skill_dir / "SKILL.md").exists())
+            self.assertTrue((bob_skill_dir / "references" / "guide.md").exists())
+
+    def test_package_excludes_backup_files(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            skill_dir = Path(temp_dir) / "test-skill"
+            skill_dir.mkdir()
+            (skill_dir / "SKILL.md").write_text("# Test")
+            refs = skill_dir / "references"
+            refs.mkdir()
+            (refs / "guide.md").write_text("# Guide")
+            (refs / "guide.md.backup").write_text("# Old")
+
+            output_dir = Path(temp_dir) / "output"
+            output_dir.mkdir()
+
+            result_path = self.adaptor.package(skill_dir, output_dir)
+            bob_skill_dir = result_path / ".bob" / "skills" / "test-skill"
+
+            self.assertTrue((bob_skill_dir / "references" / "guide.md").exists())
+            self.assertFalse((bob_skill_dir / "references" / "guide.md.backup").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_architectural_pattern_detector.py
+++ b/tests/test_architectural_pattern_detector.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""
+Tests for architectural_pattern_detector.py - Framework detection.
+
+Regression tests for:
+- Issue #365: Unity C# projects misidentified as Unreal
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from skill_seekers.cli.architectural_pattern_detector import ArchitecturalPatternDetector
+
+
+@pytest.fixture
+def detector():
+    return ArchitecturalPatternDetector(enhance_with_ai=False)
+
+
+def _unity_files(root: str) -> list[dict]:
+    """Simulate files_analysis for a Unity C# project."""
+    return [
+        {
+            "file": f"{root}/Assets/Scripts/Player.cs",
+            "language": "C#",
+            "imports": ["UnityEngine", "UnityEngine.UI", "System.Collections"],
+        },
+        {
+            "file": f"{root}/Assets/Scripts/GameManager.cs",
+            "language": "C#",
+            "imports": ["UnityEngine", "Zenject"],
+        },
+        {
+            "file": f"{root}/Assets/Scripts/Enemy.cs",
+            "language": "C#",
+            "imports": ["UnityEngine", "System.Collections.Generic"],
+        },
+    ]
+
+
+def _make_unity_dir(tmp_path: Path) -> Path:
+    """Create a minimal Unity project directory structure."""
+    (tmp_path / "Assets").mkdir()
+    (tmp_path / "Library").mkdir()
+    (tmp_path / "Packages").mkdir()
+    (tmp_path / "ProjectSettings").mkdir()
+    (tmp_path / "Packages" / "manifest.json").write_text(
+        '{"dependencies": {"com.unity.2d.sprite": "1.0.0"}}'
+    )
+    (tmp_path / "ProjectSettings" / "ProjectVersion.txt").write_text("m_EditorVersion: 2022.3.10f1")
+    return tmp_path
+
+
+class TestUnityFrameworkDetection:
+    """Regression tests for Unity vs Unreal framework detection (Issue #365)."""
+
+    def test_unity_detected_via_imports(self, detector, tmp_path):
+        """Unity project is detected correctly when C# files import UnityEngine."""
+        root = str(tmp_path)
+        _make_unity_dir(tmp_path)
+        files = _unity_files(root)
+
+        frameworks = detector._detect_frameworks(tmp_path, files)
+
+        assert "Unity" in frameworks, f"Expected Unity, got {frameworks}"
+        assert "Unreal" not in frameworks, f"Unreal should not be detected: {frameworks}"
+
+    def test_unity_not_misidentified_as_unreal_with_source_dir(self, detector, tmp_path):
+        """Unity project with a 'Source' subfolder must NOT be identified as Unreal (Issue #365)."""
+        root = str(tmp_path)
+        _make_unity_dir(tmp_path)
+        # Simulate the common pattern: Assets/Scripts/Source/... exists
+        source_dir = tmp_path / "Assets" / "Scripts" / "Source"
+        source_dir.mkdir(parents=True)
+
+        files = _unity_files(root)
+        # Add a file whose path contains 'Source/' (the false-positive trigger for Unreal)
+        files.append(
+            {
+                "file": f"{root}/Assets/Scripts/Source/Utilities.cs",
+                "language": "C#",
+                "imports": ["UnityEngine", "System"],
+            }
+        )
+
+        frameworks = detector._detect_frameworks(tmp_path, files)
+
+        assert "Unity" in frameworks, f"Expected Unity, got {frameworks}"
+        assert "Unreal" not in frameworks, f"Unreal falsely detected: {frameworks}"
+
+    def test_unreal_project_still_detected(self, detector, tmp_path):
+        """Genuine Unreal projects are still identified correctly."""
+        (tmp_path / "Source").mkdir()
+        (tmp_path / "Binaries").mkdir()
+        (tmp_path / "Content").mkdir()
+        (tmp_path / "Config").mkdir()
+        (tmp_path / "MyGame.uproject").write_text('{"FileVersion": 3}')
+
+        files = [
+            {
+                "file": f"{tmp_path}/Source/MyGame/MyGameCharacter.cpp",
+                "language": "C++",
+                "imports": [],
+            },
+            {
+                "file": f"{tmp_path}/Source/MyGame/MyGameCharacter.h",
+                "language": "C++",
+                "imports": [],
+            },
+        ]
+
+        frameworks = detector._detect_frameworks(tmp_path, files)
+
+        assert "Unreal" in frameworks, f"Expected Unreal, got {frameworks}"
+        assert "Unity" not in frameworks, f"Unity should not be detected: {frameworks}"
+
+    def test_unity_detected_with_manifest_in_paths(self, detector, tmp_path):
+        """Unity project is detected via Packages/manifest.json in file paths."""
+        root = str(tmp_path)
+        _make_unity_dir(tmp_path)
+
+        files = [
+            {
+                "file": f"{root}/Packages/manifest.json",
+                "language": "JSON",
+                "imports": [],
+            },
+            {
+                "file": f"{root}/Assets/Scripts/Player.cs",
+                "language": "C#",
+                "imports": ["UnityEngine"],
+            },
+        ]
+
+        frameworks = detector._detect_frameworks(tmp_path, files)
+
+        assert "Unity" in frameworks, f"Expected Unity, got {frameworks}"

--- a/tests/test_c3_integration.py
+++ b/tests/test_c3_integration.py
@@ -355,7 +355,10 @@ class TestC3Integration:
         assert "MVC" in content
         assert "Design Patterns" in content
         assert "Factory" in content
-        assert "references/codebase_analysis/ARCHITECTURE.md" in content
+        # SKILL.md links to the per-source index (#362), not the historical
+        # top-level ARCHITECTURE.md which never existed once outputs became
+        # per-source-namespaced.
+        assert "references/codebase_analysis/index.md" in content
 
 
 class TestC3AnalyzeCodebaseSignature:

--- a/tests/test_cli_parsers.py
+++ b/tests/test_cli_parsers.py
@@ -117,6 +117,9 @@ class TestSpecificParsers:
         args = main_parser.parse_args(["package", "output/test/", "--target", "gemini"])
         assert args.target == "gemini"
 
+        args = main_parser.parse_args(["package", "output/test/", "--target", "ibm-bob"])
+        assert args.target == "ibm-bob"
+
         args = main_parser.parse_args(["package", "output/test/", "--no-open"])
         assert args.no_open is True
 

--- a/tests/test_cli_paths.py
+++ b/tests/test_cli_paths.py
@@ -138,7 +138,7 @@ class TestUnifiedCLIEntryPoints(unittest.TestCase):
 
             # Should show version
             output = result.stdout + result.stderr
-            self.assertIn("3.5.1", output)
+            self.assertIn("3.6.0", output)
 
         except FileNotFoundError:
             # If skill-seekers is not installed, skip this test

--- a/tests/test_github_fetcher.py
+++ b/tests/test_github_fetcher.py
@@ -438,3 +438,136 @@ class TestIntegration:
         # Verify insights stream
         assert three_streams.insights_stream.metadata["stars"] == 1234
         assert len(three_streams.insights_stream.common_problems) > 0
+
+
+class TestIssueFiltering:
+    """Test issue filtering parameters (since, labels, state)."""
+
+    @patch("requests.get")
+    def test_fetch_issues_page_sends_since_param(self, mock_get):
+        """Test that _fetch_issues_page sends 'since' when set."""
+        mock_response = Mock()
+        mock_response.json.return_value = []
+        mock_response.raise_for_status = Mock()
+        mock_get.return_value = mock_response
+
+        fetcher = GitHubThreeStreamFetcher(
+            "https://github.com/test/repo", issue_since="2026-01-01T00:00:00"
+        )
+        fetcher._fetch_issues_page(state="open", max_count=50)
+
+        call_kwargs = mock_get.call_args
+        params = (
+            call_kwargs[1]["params"] if "params" in call_kwargs[1] else call_kwargs.kwargs["params"]
+        )
+        assert params["since"] == "2026-01-01T00:00:00"
+
+    @patch("requests.get")
+    def test_fetch_issues_page_sends_labels_param(self, mock_get):
+        """Test that _fetch_issues_page sends 'labels' when set."""
+        mock_response = Mock()
+        mock_response.json.return_value = []
+        mock_response.raise_for_status = Mock()
+        mock_get.return_value = mock_response
+
+        fetcher = GitHubThreeStreamFetcher(
+            "https://github.com/test/repo", issue_labels=["bug", "enhancement"]
+        )
+        fetcher._fetch_issues_page(state="open", max_count=50)
+
+        call_kwargs = mock_get.call_args
+        params = (
+            call_kwargs[1]["params"] if "params" in call_kwargs[1] else call_kwargs.kwargs["params"]
+        )
+        assert params["labels"] == "bug,enhancement"
+
+    @patch("requests.get")
+    def test_fetch_issues_page_no_extra_params_by_default(self, mock_get):
+        """Test that since/labels are NOT sent when not set."""
+        mock_response = Mock()
+        mock_response.json.return_value = []
+        mock_response.raise_for_status = Mock()
+        mock_get.return_value = mock_response
+
+        fetcher = GitHubThreeStreamFetcher("https://github.com/test/repo")
+        fetcher._fetch_issues_page(state="open", max_count=50)
+
+        call_kwargs = mock_get.call_args
+        params = (
+            call_kwargs[1]["params"] if "params" in call_kwargs[1] else call_kwargs.kwargs["params"]
+        )
+        assert "since" not in params
+        assert "labels" not in params
+
+    @patch("requests.get")
+    def test_fetch_issues_single_state_open(self, mock_get):
+        """Test fetch_issues with issue_state='open' makes one call."""
+        mock_response = Mock()
+        mock_response.json.return_value = [
+            {"title": "Bug", "number": 1, "state": "open", "comments": 5, "labels": []}
+        ]
+        mock_response.raise_for_status = Mock()
+        mock_get.return_value = mock_response
+
+        fetcher = GitHubThreeStreamFetcher("https://github.com/test/repo", issue_state="open")
+        fetcher.fetch_issues(max_issues=100)
+
+        # Should only call once (not 50/50 split)
+        assert mock_get.call_count == 1
+        # Verify it requested "open" state
+        call_kwargs = mock_get.call_args
+        params = (
+            call_kwargs[1]["params"] if "params" in call_kwargs[1] else call_kwargs.kwargs["params"]
+        )
+        assert params["state"] == "open"
+        assert params["per_page"] == 100
+
+    @patch("requests.get")
+    def test_fetch_issues_single_state_closed(self, mock_get):
+        """Test fetch_issues with issue_state='closed' makes one call."""
+        mock_response = Mock()
+        mock_response.json.return_value = []
+        mock_response.raise_for_status = Mock()
+        mock_get.return_value = mock_response
+
+        fetcher = GitHubThreeStreamFetcher("https://github.com/test/repo", issue_state="closed")
+        fetcher.fetch_issues(max_issues=100)
+
+        assert mock_get.call_count == 1
+        call_kwargs = mock_get.call_args
+        params = (
+            call_kwargs[1]["params"] if "params" in call_kwargs[1] else call_kwargs.kwargs["params"]
+        )
+        assert params["state"] == "closed"
+
+    @patch("requests.get")
+    def test_fetch_issues_all_state_makes_two_calls(self, mock_get):
+        """Test fetch_issues with issue_state='all' makes two calls (50/50 split)."""
+        mock_response = Mock()
+        mock_response.json.return_value = []
+        mock_response.raise_for_status = Mock()
+        mock_get.return_value = mock_response
+
+        fetcher = GitHubThreeStreamFetcher("https://github.com/test/repo", issue_state="all")
+        fetcher.fetch_issues(max_issues=100)
+
+        assert mock_get.call_count == 2
+
+    def test_init_stores_issue_filters(self):
+        """Test that __init__ stores issue filter parameters."""
+        fetcher = GitHubThreeStreamFetcher(
+            "https://github.com/test/repo",
+            issue_since="2026-01-01",
+            issue_labels=["bug"],
+            issue_state="open",
+        )
+        assert fetcher.issue_since == "2026-01-01"
+        assert fetcher.issue_labels == ["bug"]
+        assert fetcher.issue_state == "open"
+
+    def test_init_defaults_for_issue_filters(self):
+        """Test default values for issue filter parameters."""
+        fetcher = GitHubThreeStreamFetcher("https://github.com/test/repo")
+        assert fetcher.issue_since is None
+        assert fetcher.issue_labels == []
+        assert fetcher.issue_state == "all"

--- a/tests/test_github_scraper.py
+++ b/tests/test_github_scraper.py
@@ -296,6 +296,7 @@ class TestIssuesExtraction(unittest.TestCase):
         mock_issue1.html_url = "https://github.com/facebook/react/issues/123"
         mock_issue1.body = "Issue description"
         mock_issue1.pull_request = None
+        mock_issue1.get_comments.return_value = []
 
         mock_label3 = Mock()
         mock_label3.name = "enhancement"
@@ -312,6 +313,7 @@ class TestIssuesExtraction(unittest.TestCase):
         mock_issue2.html_url = "https://github.com/facebook/react/issues/124"
         mock_issue2.body = "Feature description"
         mock_issue2.pull_request = None
+        mock_issue2.get_comments.return_value = []
 
         with patch("skill_seekers.cli.github_scraper.Github"):
             scraper = self.GitHubScraper(config)
@@ -358,6 +360,7 @@ class TestIssuesExtraction(unittest.TestCase):
         mock_issue.html_url = "https://github.com/test/repo/issues/123"
         mock_issue.body = "Issue body"
         mock_issue.pull_request = None
+        mock_issue.get_comments.return_value = []
 
         mock_pr = Mock()
         mock_pr.number = 124
@@ -400,6 +403,7 @@ class TestIssuesExtraction(unittest.TestCase):
             mock_issue.html_url = f"https://github.com/test/repo/issues/{i}"
             mock_issue.body = None
             mock_issue.pull_request = None
+            mock_issue.get_comments.return_value = []
             mock_issues.append(mock_issue)
 
         with patch("skill_seekers.cli.github_scraper.Github"):
@@ -1039,6 +1043,491 @@ class TestErrorHandling(unittest.TestCase):
             # Should handle gracefully and log warning
             scraper._extract_issues()
             # Should not crash, just log warning
+
+    def test_extract_issues_passes_state_filter(self):
+        """Test that _extract_issues passes issue_state to get_issues."""
+        config = {
+            "repo": "facebook/react",
+            "name": "react",
+            "github_token": None,
+            "max_issues": 10,
+            "issue_state": "open",
+        }
+
+        with patch("skill_seekers.cli.github_scraper.Github"):
+            scraper = self.GitHubScraper(config)
+            scraper.repo = Mock()
+            scraper.repo.get_issues.return_value = []
+
+            scraper._extract_issues()
+
+            call_kwargs = scraper.repo.get_issues.call_args[1]
+            self.assertEqual(call_kwargs["state"], "open")
+
+    def test_extract_issues_passes_labels_filter(self):
+        """Test that _extract_issues passes issue_labels as plain strings to get_issues."""
+        config = {
+            "repo": "facebook/react",
+            "name": "react",
+            "github_token": None,
+            "max_issues": 10,
+            "issue_labels": ["bug", "enhancement"],
+        }
+
+        with patch("skill_seekers.cli.github_scraper.Github"):
+            scraper = self.GitHubScraper(config)
+            scraper.repo = Mock()
+            scraper.repo.get_issues.return_value = []
+
+            scraper._extract_issues()
+
+            # PyGithub's get_issues(labels=...) accepts plain strings; we should
+            # NEVER call get_label (which costs an extra API call per label and
+            # 404s if the label doesn't exist).
+            scraper.repo.get_label.assert_not_called()
+            call_kwargs = scraper.repo.get_issues.call_args[1]
+            self.assertEqual(call_kwargs["labels"], ["bug", "enhancement"])
+
+    def test_extract_issues_since_z_suffix(self):
+        """Test that _extract_issues accepts ISO8601 'Z' (UTC) suffix on Python 3.10."""
+        config = {
+            "repo": "facebook/react",
+            "name": "react",
+            "github_token": None,
+            "max_issues": 10,
+            "issue_since": "2024-01-01T00:00:00Z",
+        }
+
+        with patch("skill_seekers.cli.github_scraper.Github"):
+            scraper = self.GitHubScraper(config)
+            scraper.repo = Mock()
+            scraper.repo.get_issues.return_value = []
+
+            # Must not raise — Python 3.10's fromisoformat rejects raw 'Z'.
+            scraper._extract_issues()
+
+            call_kwargs = scraper.repo.get_issues.call_args[1]
+            self.assertIn("since", call_kwargs)
+            since = call_kwargs["since"]
+            self.assertEqual(since.year, 2024)
+            self.assertEqual(since.month, 1)
+            self.assertEqual(since.day, 1)
+            self.assertIsNotNone(since.tzinfo)
+
+    def test_extract_issues_passes_since_filter(self):
+        """Test that _extract_issues passes issue_since to get_issues."""
+        config = {
+            "repo": "facebook/react",
+            "name": "react",
+            "github_token": None,
+            "max_issues": 10,
+            "issue_since": "2026-01-01",
+        }
+
+        with patch("skill_seekers.cli.github_scraper.Github"):
+            scraper = self.GitHubScraper(config)
+            scraper.repo = Mock()
+            scraper.repo.get_issues.return_value = []
+
+            scraper._extract_issues()
+
+            call_kwargs = scraper.repo.get_issues.call_args[1]
+            self.assertIn("since", call_kwargs)
+            self.assertEqual(call_kwargs["since"], datetime.fromisoformat("2026-01-01"))
+
+    def test_extract_issues_no_filters_by_default(self):
+        """Test that _extract_issues uses defaults when no filters set."""
+        config = {
+            "repo": "facebook/react",
+            "name": "react",
+            "github_token": None,
+            "max_issues": 10,
+        }
+
+        with patch("skill_seekers.cli.github_scraper.Github"):
+            scraper = self.GitHubScraper(config)
+            scraper.repo = Mock()
+            scraper.repo.get_issues.return_value = []
+
+            scraper._extract_issues()
+
+            call_kwargs = scraper.repo.get_issues.call_args[1]
+            self.assertEqual(call_kwargs["state"], "all")
+            self.assertNotIn("labels", call_kwargs)
+            self.assertNotIn("since", call_kwargs)
+
+    def test_issue_filter_args_in_config(self):
+        """Test that issue filter config keys are read in __init__."""
+        config = {
+            "repo": "facebook/react",
+            "name": "react",
+            "github_token": None,
+            "issue_since": "2026-03-01",
+            "issue_labels": ["bug"],
+            "issue_state": "closed",
+        }
+
+        with patch("skill_seekers.cli.github_scraper.Github"):
+            scraper = self.GitHubScraper(config)
+            self.assertEqual(scraper.issue_since, "2026-03-01")
+            self.assertEqual(scraper.issue_labels, ["bug"])
+            self.assertEqual(scraper.issue_state, "closed")
+
+
+class TestExtractIssuesFullBodyAndComments(unittest.TestCase):
+    """Test full issue body and comment fetching."""
+
+    def setUp(self):
+        if not PYGITHUB_AVAILABLE:
+            self.skipTest("PyGithub not installed")
+        from skill_seekers.cli.github_scraper import GitHubScraper
+
+        self.GitHubScraper = GitHubScraper
+
+    def _make_mock_issue(self, number=1, body="Full body text here", comments=None):
+        """Helper to create a mock issue with comments."""
+        mock_issue = Mock()
+        mock_issue.number = number
+        mock_issue.title = f"Issue {number}"
+        mock_issue.state = "open"
+        mock_issue.labels = []
+        mock_issue.milestone = None
+        mock_issue.created_at = datetime(2023, 1, 1)
+        mock_issue.updated_at = datetime(2023, 1, 2)
+        mock_issue.closed_at = None
+        mock_issue.html_url = f"https://github.com/test/repo/issues/{number}"
+        mock_issue.body = body
+        mock_issue.pull_request = None
+        mock_issue.get_comments.return_value = comments or []
+        return mock_issue
+
+    def _make_mock_comment(self, author="alice", body="Comment body", date=None):
+        """Helper to create a mock comment."""
+        comment = Mock()
+        comment.user = Mock()
+        comment.user.login = author
+        comment.created_at = date or datetime(2023, 2, 1)
+        comment.body = body
+        return comment
+
+    def test_body_truncated_by_default(self):
+        """Issue body is truncated to 500 chars by default."""
+        long_body = "x" * 2000
+        mock_issue = self._make_mock_issue(body=long_body)
+
+        config = {"repo": "test/repo", "name": "repo", "github_token": None, "max_issues": 10}
+        with patch("skill_seekers.cli.github_scraper.Github"):
+            scraper = self.GitHubScraper(config)
+            scraper.repo = Mock()
+            scraper.repo.get_issues.return_value = [mock_issue]
+
+            scraper._extract_issues()
+
+            issues = scraper.extracted_data["issues"]
+            self.assertEqual(len(issues[0]["body"]), 500)
+
+    def test_full_body_with_per_issue_files(self):
+        """Issue body is stored in full when per_issue_files is enabled."""
+        long_body = "x" * 2000
+        mock_issue = self._make_mock_issue(body=long_body)
+
+        config = {
+            "repo": "test/repo",
+            "name": "repo",
+            "github_token": None,
+            "max_issues": 10,
+            "per_issue_files": True,
+        }
+        with patch("skill_seekers.cli.github_scraper.Github"):
+            scraper = self.GitHubScraper(config)
+            scraper.repo = Mock()
+            scraper.repo.get_issues.return_value = [mock_issue]
+
+            scraper._extract_issues()
+
+            issues = scraper.extracted_data["issues"]
+            self.assertEqual(len(issues[0]["body"]), 2000)
+
+    def test_comments_not_fetched_by_default(self):
+        """Comments are NOT fetched when max_comments is 0 (default)."""
+        comment1 = self._make_mock_comment(author="alice", body="First comment")
+        mock_issue = self._make_mock_issue(comments=[comment1])
+
+        config = {"repo": "test/repo", "name": "repo", "github_token": None, "max_issues": 10}
+        with patch("skill_seekers.cli.github_scraper.Github"):
+            scraper = self.GitHubScraper(config)
+            scraper.repo = Mock()
+            scraper.repo.get_issues.return_value = [mock_issue]
+
+            scraper._extract_issues()
+
+            issues = scraper.extracted_data["issues"]
+            self.assertEqual(len(issues[0]["comments"]), 0)
+
+    def test_comments_fetched(self):
+        """Comments are fetched when max_comments > 0."""
+        comment1 = self._make_mock_comment(author="alice", body="First comment")
+        comment2 = self._make_mock_comment(author="bob", body="Second comment")
+        mock_issue = self._make_mock_issue(comments=[comment1, comment2])
+
+        config = {
+            "repo": "test/repo",
+            "name": "repo",
+            "github_token": None,
+            "max_issues": 10,
+            "max_comments": 50,
+        }
+        with patch("skill_seekers.cli.github_scraper.Github"):
+            scraper = self.GitHubScraper(config)
+            scraper.repo = Mock()
+            scraper.repo.get_issues.return_value = [mock_issue]
+
+            scraper._extract_issues()
+
+            issues = scraper.extracted_data["issues"]
+            self.assertEqual(len(issues[0]["comments"]), 2)
+            self.assertEqual(issues[0]["comments"][0]["author"], "alice")
+            self.assertEqual(issues[0]["comments"][0]["body"], "First comment")
+            self.assertEqual(issues[0]["comments"][1]["author"], "bob")
+
+    def test_max_comments_respected(self):
+        """Only max_comments comments are stored per issue."""
+        comments = [self._make_mock_comment(author=f"user{i}") for i in range(10)]
+        mock_issue = self._make_mock_issue(comments=comments)
+
+        config = {
+            "repo": "test/repo",
+            "name": "repo",
+            "github_token": None,
+            "max_issues": 10,
+            "max_comments": 3,
+        }
+        with patch("skill_seekers.cli.github_scraper.Github"):
+            scraper = self.GitHubScraper(config)
+            scraper.repo = Mock()
+            scraper.repo.get_issues.return_value = [mock_issue]
+
+            scraper._extract_issues()
+
+            issues = scraper.extracted_data["issues"]
+            self.assertEqual(len(issues[0]["comments"]), 3)
+
+    def test_max_comments_config_default(self):
+        """max_comments defaults to 0 (disabled) in config."""
+        config = {"repo": "test/repo", "name": "repo", "github_token": None}
+        with patch("skill_seekers.cli.github_scraper.Github"):
+            scraper = self.GitHubScraper(config)
+            self.assertEqual(scraper.max_comments, 0)
+
+
+class TestPerIssueFileGeneration(unittest.TestCase):
+    """Test per-issue markdown file generation."""
+
+    def setUp(self):
+        if not PYGITHUB_AVAILABLE:
+            self.skipTest("PyGithub not installed")
+        from skill_seekers.cli.github_scraper import GitHubToSkillConverter
+
+        self.GitHubToSkillConverter = GitHubToSkillConverter
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        if hasattr(self, "temp_dir"):
+            shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _setup_converter(self, issues):
+        """Create a converter with pre-built data."""
+        name = "test-repo"
+        data_dir = os.path.join(self.temp_dir, "output")
+        os.makedirs(data_dir, exist_ok=True)
+
+        # Write extracted data
+        data = {
+            "readme": "# Test Repo",
+            "issues": issues,
+            "releases": [],
+            "file_tree": [],
+        }
+        data_file = os.path.join(data_dir, f"{name}_github_data.json")
+        with open(data_file, "w") as f:
+            json.dump(data, f)
+
+        config = {"repo": "test/test-repo", "name": name, "per_issue_files": True}
+
+        # Patch the data file path
+        with patch.object(
+            self.GitHubToSkillConverter,
+            "_load_data",
+            return_value=data,
+        ):
+            converter = self.GitHubToSkillConverter(config)
+
+        converter.data = data
+        converter.skill_dir = os.path.join(data_dir, name)
+        os.makedirs(os.path.join(converter.skill_dir, "references"), exist_ok=True)
+        return converter
+
+    def test_per_issue_files_created(self):
+        """Per-issue files live in references/issues/ with {owner}-{repo}-{n}.md naming."""
+        issues = [
+            {
+                "number": 42,
+                "title": "Bug report",
+                "state": "open",
+                "labels": ["bug"],
+                "created_at": "2023-01-01T00:00:00",
+                "updated_at": "2023-01-02T00:00:00",
+                "closed_at": None,
+                "url": "https://github.com/test/test-repo/issues/42",
+                "body": "Full bug description here",
+                "comments": [],
+            },
+        ]
+        converter = self._setup_converter(issues)
+        converter._generate_issues_reference()
+
+        expected_file = os.path.join(
+            converter.skill_dir, "references", "issues", "test-test-repo-42.md"
+        )
+        self.assertTrue(os.path.exists(expected_file))
+
+        # Old flat path must NOT exist (regression guard for the rename).
+        old_file = os.path.join(converter.skill_dir, "references", "test-repo_42.md")
+        self.assertFalse(os.path.exists(old_file))
+
+    def test_per_issue_files_no_collision_across_repos(self):
+        """Two repos sharing a skill_dir + issue number write distinct files."""
+        issues = [
+            {
+                "number": 1,
+                "title": "Same number",
+                "state": "open",
+                "labels": [],
+                "created_at": "2023-01-01T00:00:00",
+                "updated_at": "2023-01-02T00:00:00",
+                "closed_at": None,
+                "url": "https://github.com/alpha/proj/issues/1",
+                "body": "Issue from alpha/proj",
+                "comments": [],
+            },
+        ]
+
+        # First repo: alpha/proj
+        skill_dir = os.path.join(self.temp_dir, "shared-skill")
+        os.makedirs(os.path.join(skill_dir, "references"), exist_ok=True)
+
+        config_a = {"repo": "alpha/proj", "name": "shared-skill", "per_issue_files": True}
+        with patch.object(self.GitHubToSkillConverter, "_load_data", return_value={}):
+            converter_a = self.GitHubToSkillConverter(config_a)
+        converter_a.data = {"issues": issues}
+        converter_a.skill_dir = skill_dir
+        converter_a._generate_issues_reference()
+
+        # Second repo: beta/proj — same issue number, same skill_dir.
+        issues_b = [{**issues[0], "url": "https://github.com/beta/proj/issues/1"}]
+        config_b = {"repo": "beta/proj", "name": "shared-skill", "per_issue_files": True}
+        with patch.object(self.GitHubToSkillConverter, "_load_data", return_value={}):
+            converter_b = self.GitHubToSkillConverter(config_b)
+        converter_b.data = {"issues": issues_b}
+        converter_b.skill_dir = skill_dir
+        converter_b._generate_issues_reference()
+
+        alpha_file = os.path.join(skill_dir, "references", "issues", "alpha-proj-1.md")
+        beta_file = os.path.join(skill_dir, "references", "issues", "beta-proj-1.md")
+        self.assertTrue(os.path.exists(alpha_file))
+        self.assertTrue(os.path.exists(beta_file))
+
+    def test_per_issue_file_content(self):
+        """Per-issue file contains full body and YAML frontmatter."""
+        issues = [
+            {
+                "number": 99,
+                "title": "Feature request",
+                "state": "open",
+                "labels": ["enhancement"],
+                "created_at": "2023-01-01T00:00:00",
+                "updated_at": "2023-01-02T00:00:00",
+                "closed_at": None,
+                "url": "https://github.com/test/repo/issues/99",
+                "body": "Please add dark mode support",
+                "comments": [],
+            },
+        ]
+        converter = self._setup_converter(issues)
+        converter._generate_issues_reference()
+
+        filepath = os.path.join(converter.skill_dir, "references", "issues", "test-test-repo-99.md")
+        content = Path(filepath).read_text()
+
+        # Check YAML frontmatter
+        self.assertTrue(content.startswith("---"))
+        self.assertIn("type: github_issue", content)
+        self.assertIn("issue_number: 99", content)
+        self.assertIn("state: open", content)
+
+        # Check body
+        self.assertIn("Please add dark mode support", content)
+
+    def test_per_issue_file_with_comments(self):
+        """Per-issue file includes comments section."""
+        issues = [
+            {
+                "number": 7,
+                "title": "Question",
+                "state": "open",
+                "labels": [],
+                "created_at": "2023-01-01T00:00:00",
+                "updated_at": "2023-01-02T00:00:00",
+                "closed_at": None,
+                "url": "https://github.com/test/repo/issues/7",
+                "body": "How do I configure X?",
+                "comments": [
+                    {
+                        "author": "maintainer",
+                        "created_at": "2023-01-03T00:00:00",
+                        "body": "You can configure X by editing config.yaml",
+                    },
+                    {
+                        "author": "user123",
+                        "created_at": "2023-01-04T00:00:00",
+                        "body": "Thanks, that worked!",
+                    },
+                ],
+            },
+        ]
+        converter = self._setup_converter(issues)
+        converter._generate_issues_reference()
+
+        filepath = os.path.join(converter.skill_dir, "references", "issues", "test-test-repo-7.md")
+        content = Path(filepath).read_text()
+
+        self.assertIn("## Comments (2)", content)
+        self.assertIn("### maintainer", content)
+        self.assertIn("You can configure X by editing config.yaml", content)
+        self.assertIn("### user123", content)
+        self.assertIn("Thanks, that worked!", content)
+
+    def test_summary_file_still_generated(self):
+        """issues.md summary file is still generated alongside per-issue files."""
+        issues = [
+            {
+                "number": 1,
+                "title": "Test",
+                "state": "open",
+                "labels": [],
+                "created_at": "2023-01-01T00:00:00",
+                "updated_at": "2023-01-02T00:00:00",
+                "closed_at": None,
+                "url": "https://github.com/test/repo/issues/1",
+                "body": "Test body",
+                "comments": [],
+            },
+        ]
+        converter = self._setup_converter(issues)
+        converter._generate_issues_reference()
+
+        summary_file = os.path.join(converter.skill_dir, "references", "issues.md")
+        self.assertTrue(os.path.exists(summary_file))
 
 
 if __name__ == "__main__":

--- a/tests/test_install_agent.py
+++ b/tests/test_install_agent.py
@@ -66,9 +66,9 @@ class TestAgentPathMapping:
             get_agent_path("invalid_agent")
 
     def test_get_available_agents(self):
-        """Test that all 18 agents are listed."""
+        """Test that all 19 agents are listed."""
         agents = get_available_agents()
-        assert len(agents) == 18
+        assert len(agents) == 19
         assert "claude" in agents
         assert "cursor" in agents
         assert "vscode" in agents
@@ -82,6 +82,7 @@ class TestAgentPathMapping:
         assert "kilo" in agents
         assert "continue" in agents
         assert "kimi-code" in agents
+        assert "bob" in agents
         assert sorted(agents) == agents  # Should be sorted
 
     def test_new_agents_project_relative(self):
@@ -361,7 +362,7 @@ class TestInstallToAllAgents:
         shutil.rmtree(self.tmpdir, ignore_errors=True)
 
     def test_install_to_all_success(self):
-        """Test that install_to_all_agents attempts all 18 agents."""
+        """Test that install_to_all_agents attempts all 19 agents."""
         with tempfile.TemporaryDirectory() as agent_tmpdir:
 
             def mock_get_agent_path(agent_name, _project_root=None):
@@ -373,9 +374,10 @@ class TestInstallToAllAgents:
             ):
                 results = install_to_all_agents(self.skill_dir, force=True)
 
-                assert len(results) == 18
+                assert len(results) == 19
                 assert "claude" in results
                 assert "cursor" in results
+                assert "bob" in results
 
     def test_install_to_all_partial_success(self):
         """Test that install_to_all collects both successes and failures."""
@@ -383,7 +385,7 @@ class TestInstallToAllAgents:
         results = install_to_all_agents(self.skill_dir, dry_run=True)
 
         # All should succeed in dry-run mode
-        assert len(results) == 18
+        assert len(results) == 19
         for _agent_name, (success, message) in results.items():
             assert success is True
             assert "DRY RUN" in message
@@ -420,7 +422,7 @@ class TestInstallToAllAgents:
         results = install_to_all_agents(self.skill_dir, dry_run=True)
 
         assert isinstance(results, dict)
-        assert len(results) == 18
+        assert len(results) == 19
 
         for agent_name, (success, message) in results.items():
             assert isinstance(success, bool)

--- a/tests/test_multi_source.py
+++ b/tests/test_multi_source.py
@@ -503,5 +503,118 @@ class TestUnifiedSkillBuilderPdfReferences(unittest.TestCase):
             self.assertIn("3 PDF document", content)
 
 
+class TestCodebaseAnalysisIndex(unittest.TestCase):
+    """Issue #362: SKILL.md must link to a real codebase_analysis target.
+
+    Per-source ARCHITECTURE.md files live at
+    ``references/codebase_analysis/{source_id}/ARCHITECTURE.md``, but four
+    call sites historically linked to ``references/codebase_analysis/
+    ARCHITECTURE.md`` (no source_id). That link was always broken once the
+    layout became per-source-namespaced.
+
+    The fix: generate a top-level ``references/codebase_analysis/index.md``
+    aggregating all sources, and route every SKILL.md link through it.
+    """
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.original_dir = os.getcwd()
+        os.chdir(self.temp_dir)
+
+    def tearDown(self):
+        os.chdir(self.original_dir)
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _run_build(self, sources_local):
+        from skill_seekers.cli.unified_skill_builder import UnifiedSkillBuilder
+
+        config = {"name": "issue-362", "description": "Test"}
+        scraped_data = {
+            "documentation": [],
+            "github": [],
+            "pdf": [],
+            "local": sources_local,
+        }
+        builder = UnifiedSkillBuilder(config, scraped_data)
+        builder.build()
+        return builder
+
+    def test_index_md_lists_each_local_source(self):
+        sample_patterns = [
+            {
+                "file_path": "/x/foo.py",
+                "patterns": [
+                    {"pattern_type": "Singleton", "confidence": 0.88, "indicators": ["__instance"]}
+                ],
+            }
+        ]
+        builder = self._run_build(
+            [
+                {
+                    "source_id": "issue-362_local_0_repo_a",
+                    "name": "repo_a",
+                    "patterns": sample_patterns,
+                },
+                {
+                    "source_id": "issue-362_local_1_repo_b",
+                    "name": "repo_b",
+                    "patterns": sample_patterns,
+                },
+            ]
+        )
+
+        index_path = os.path.join(builder.skill_dir, "references", "codebase_analysis", "index.md")
+        self.assertTrue(os.path.isfile(index_path), "codebase_analysis/index.md must be created")
+
+        with open(index_path) as f:
+            content = f.read()
+        self.assertIn("issue-362_local_0_repo_a", content)
+        self.assertIn("issue-362_local_1_repo_b", content)
+        self.assertIn("issue-362_local_0_repo_a/ARCHITECTURE.md", content)
+        self.assertIn("issue-362_local_0_repo_a/patterns/", content)
+
+    def test_skill_md_link_resolves_to_real_file(self):
+        """The SKILL.md link to codebase_analysis must resolve on disk."""
+        sample_patterns = [
+            {
+                "file_path": "/x/foo.py",
+                "patterns": [
+                    {"pattern_type": "Singleton", "confidence": 0.88, "indicators": ["__instance"]}
+                ],
+            }
+        ]
+        builder = self._run_build(
+            [
+                {
+                    "source_id": "issue-362_local_0_repo",
+                    "name": "repo",
+                    "patterns": sample_patterns,
+                },
+            ]
+        )
+
+        skill_md = os.path.join(builder.skill_dir, "SKILL.md")
+        with open(skill_md) as f:
+            content = f.read()
+
+        import re
+
+        targets = re.findall(r"references/codebase_analysis/[^\s`)]+", content)
+        self.assertTrue(targets, "SKILL.md must mention a codebase_analysis link")
+
+        for target in targets:
+            full = os.path.join(builder.skill_dir, target)
+            self.assertTrue(
+                os.path.exists(full),
+                f"SKILL.md links to {target!r} but file does not exist on disk",
+            )
+
+    def test_no_index_when_no_codebase_data(self):
+        """No C3.x output → no index file written."""
+        builder = self._run_build([])  # no local sources at all
+        index_path = os.path.join(builder.skill_dir, "references", "codebase_analysis", "index.md")
+        self.assertFalse(os.path.exists(index_path))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_new_source_types.py
+++ b/tests/test_new_source_types.py
@@ -379,6 +379,32 @@ class TestConfigValidatorNewTypes:
         validator = ConfigValidator(config)
         assert validator.validate() is True
 
+    def test_github_issue_since_accepts_z_suffix(self):
+        """github source: issue_since with UTC 'Z' suffix passes on Python 3.10."""
+        config = self._make_config(
+            {
+                "type": "github",
+                "repo": "octocat/Hello-World",
+                "issue_since": "2024-01-01T00:00:00Z",
+            }
+        )
+        validator = ConfigValidator(config)
+        # Must not raise — Python 3.10's fromisoformat rejects raw 'Z'.
+        assert validator.validate() is True
+
+    def test_github_issue_since_rejects_garbage(self):
+        """github source: malformed issue_since still raises ValueError."""
+        config = self._make_config(
+            {
+                "type": "github",
+                "repo": "octocat/Hello-World",
+                "issue_since": "not-a-date",
+            }
+        )
+        validator = ConfigValidator(config)
+        with pytest.raises(ValueError, match="not a valid ISO8601 date"):
+            validator.validate()
+
 
 # ---------------------------------------------------------------------------
 # 3. UnifiedSkillBuilder — generic merge system

--- a/tests/test_new_source_types.py
+++ b/tests/test_new_source_types.py
@@ -46,6 +46,20 @@ class TestSourceDetectorNewTypes:
         assert info.type == "html"
         assert info.parsed["file_path"] == "index.HTM"
 
+    def test_detect_html_url_routes_to_web(self):
+        """Regression: URLs ending in .html must route to web, not local html scraper."""
+        url = "https://api.flutter.dev/flutter/rendering/RenderObject-class.html"
+        info = SourceDetector.detect(url)
+        assert info.type == "web"
+        assert info.parsed["url"] == url
+
+    def test_detect_http_html_url_routes_to_web(self):
+        """Regression: http:// URLs ending in .html route to web."""
+        url = "http://example.com/page.html"
+        info = SourceDetector.detect(url)
+        assert info.type == "web"
+        assert info.parsed["url"] == url
+
     # -- PowerPoint --
     def test_detect_pptx(self):
         """Test .pptx → pptx detection."""

--- a/tests/test_package_skill.py
+++ b/tests/test_package_skill.py
@@ -154,6 +154,23 @@ class TestPackageSkill(unittest.TestCase):
             self.assertTrue(success)
             self.assertEqual(zip_path.name, "my-awesome-skill.zip")
 
+    def test_package_ibm_bob_creates_bob_directory(self):
+        """Test IBM Bob packaging creates a Bob-ready directory layout."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = self.create_test_skill_directory(tmpdir)
+
+            success, package_path = package_skill(
+                skill_dir,
+                open_folder_after=False,
+                skip_quality_check=True,
+                target="ibm-bob",
+            )
+
+            self.assertTrue(success)
+            self.assertIsNotNone(package_path)
+            self.assertTrue(package_path.is_dir())
+            self.assertTrue((package_path / ".bob" / "skills" / "test-skill" / "SKILL.md").exists())
+
 
 class TestPackageSkillCLI(unittest.TestCase):
     """Test package_skill.py command-line interface"""

--- a/tests/test_package_structure.py
+++ b/tests/test_package_structure.py
@@ -24,7 +24,7 @@ class TestCliPackage:
         import skill_seekers.cli
 
         assert hasattr(skill_seekers.cli, "__version__")
-        assert skill_seekers.cli.__version__ == "3.5.1"
+        assert skill_seekers.cli.__version__ == "3.6.0"
 
     def test_cli_has_all(self):
         """Test that skill_seekers.cli package has __all__ export list."""
@@ -88,7 +88,7 @@ class TestMcpPackage:
         import skill_seekers.mcp
 
         assert hasattr(skill_seekers.mcp, "__version__")
-        assert skill_seekers.mcp.__version__ == "3.5.1"
+        assert skill_seekers.mcp.__version__ == "3.6.0"
 
     def test_mcp_has_all(self):
         """Test that skill_seekers.mcp package has __all__ export list."""
@@ -108,7 +108,7 @@ class TestMcpPackage:
         import skill_seekers.mcp.tools
 
         assert hasattr(skill_seekers.mcp.tools, "__version__")
-        assert skill_seekers.mcp.tools.__version__ == "3.5.1"
+        assert skill_seekers.mcp.tools.__version__ == "3.6.0"
 
 
 class TestPackageStructure:
@@ -212,7 +212,7 @@ class TestRootPackage:
         import skill_seekers
 
         assert hasattr(skill_seekers, "__version__")
-        assert skill_seekers.__version__ == "3.5.1"
+        assert skill_seekers.__version__ == "3.6.0"
 
     def test_root_has_metadata(self):
         """Test that skill_seekers root package has metadata."""

--- a/tests/test_pdf_scraper.py
+++ b/tests/test_pdf_scraper.py
@@ -428,6 +428,44 @@ class TestImageHandling(unittest.TestCase):
         self.assertIn("![", content)  # Markdown image syntax
         self.assertIn("../assets/", content)  # Relative path to assets
 
+    def test_extracted_images_references_in_markdown(self):
+        """Test that extracted_images (pdf_extractor_poc format) are referenced in markdown"""
+        config = {"name": "test_skill", "pdf_path": "test.pdf"}
+        converter = self.PDFToSkillConverter(config)
+
+        converter.skill_dir = str(Path(self.temp_dir) / "test_skill")
+
+        converter.extracted_data = {
+            "pages": [
+                {
+                    "page_number": 18,
+                    "text": "Architecture diagram",
+                    "code_blocks": [],
+                    "extracted_images": [
+                        {
+                            "filename": "test_page18_img1.png",
+                            "path": "/tmp/test_page18_img1.png",
+                            "page_number": 18,
+                            "width": 200,
+                            "height": 150,
+                            "format": "png",
+                            "size_bytes": 3,
+                        }
+                    ],
+                }
+            ],
+            "total_pages": 1,
+        }
+
+        converter.build_skill()
+
+        # Check reference file has image markdown reference
+        ref_file = Path(self.temp_dir) / "test_skill" / "references" / "test.md"
+        content = ref_file.read_text()
+
+        self.assertIn("![Image from page 18]", content)
+        self.assertIn("../assets/images/test_page18_img1.png", content)
+
 
 class TestErrorHandling(unittest.TestCase):
     """Test error handling for invalid inputs"""

--- a/tests/test_pinecone_adaptor.py
+++ b/tests/test_pinecone_adaptor.py
@@ -448,6 +448,93 @@ class TestPineconeAdaptor:
         call_kwargs = mock_pc.create_index.call_args
         assert call_kwargs.kwargs["dimension"] == 768
 
+    def test_frontmatter_parsed_into_metadata(self, tmp_path):
+        """YAML frontmatter from per-issue files is parsed and merged into vector metadata."""
+        from skill_seekers.cli.adaptors.pinecone_adaptor import PineconeAdaptor
+
+        skill_dir = tmp_path / "issue-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: issue-skill\ndescription: test\n---\n\n# Skill\n\nContent.\n"
+        )
+        refs = skill_dir / "references"
+        refs.mkdir()
+        (refs / "myrepo_42.md").write_text(
+            '---\ntype: github_issue\nissue_number: 42\ntitle: "Bug"\n'
+            'state: open\nlabels: ["bug"]\ncreated_at: "2023-01-01"\n'
+            'updated_at: "2023-01-02"\nurl: "https://github.com/test/repo/issues/42"\n'
+            "---\n\n# Issue #42: Bug\n\nFull body here.\n"
+        )
+
+        adaptor = PineconeAdaptor()
+        metadata = SkillMetadata(name="issue-skill", description="test")
+        result = adaptor.format_skill_md(skill_dir, metadata)
+        data = json.loads(result)
+
+        # Find the vector for the issue file
+        issue_vecs = [v for v in data["vectors"] if v["metadata"]["file"] == "myrepo_42.md"]
+        assert len(issue_vecs) == 1
+
+        meta = issue_vecs[0]["metadata"]
+        assert meta["type"] == "github_issue"
+        assert meta["issue_number"] == 42
+        assert meta["state"] == "open"
+        assert meta["labels"] == ["bug"]
+        assert meta["url"] == "https://github.com/test/repo/issues/42"
+
+    def test_frontmatter_stripped_from_text(self, tmp_path):
+        """Frontmatter is stripped from the text content of the vector."""
+        from skill_seekers.cli.adaptors.pinecone_adaptor import PineconeAdaptor
+
+        skill_dir = tmp_path / "strip-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: strip-skill\ndescription: test\n---\n\n# Skill\n\nContent.\n"
+        )
+        refs = skill_dir / "references"
+        refs.mkdir()
+        (refs / "repo_1.md").write_text(
+            '---\ntype: github_issue\nissue_number: 1\ntitle: "Test"\n'
+            'state: open\nlabels: []\ncreated_at: "2023-01-01"\n'
+            'updated_at: "2023-01-02"\nurl: "https://example.com"\n---\n\n'
+            "# Issue #1: Test\n\nActual content.\n"
+        )
+
+        adaptor = PineconeAdaptor()
+        metadata = SkillMetadata(name="strip-skill", description="test")
+        result = adaptor.format_skill_md(skill_dir, metadata)
+        data = json.loads(result)
+
+        issue_vecs = [v for v in data["vectors"] if v["metadata"]["file"] == "repo_1.md"]
+        text = issue_vecs[0]["metadata"]["text"]
+        assert "---" not in text.split("\n")[0]  # No frontmatter markers
+        assert "type: github_issue" not in text
+        assert "# Issue #1: Test" in text
+        assert "Actual content." in text
+
+    def test_non_frontmatter_files_unaffected(self, tmp_path):
+        """Reference files without frontmatter are processed normally."""
+        from skill_seekers.cli.adaptors.pinecone_adaptor import PineconeAdaptor
+
+        skill_dir = tmp_path / "normal-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: normal-skill\ndescription: test\n---\n\n# Skill\n\nContent.\n"
+        )
+        refs = skill_dir / "references"
+        refs.mkdir()
+        (refs / "api_reference.md").write_text("# API Reference\n\nSome API docs.\n")
+
+        adaptor = PineconeAdaptor()
+        metadata = SkillMetadata(name="normal-skill", description="test")
+        result = adaptor.format_skill_md(skill_dir, metadata)
+        data = json.loads(result)
+
+        ref_vecs = [v for v in data["vectors"] if v["metadata"]["file"] == "api_reference.md"]
+        assert len(ref_vecs) == 1
+        assert ref_vecs[0]["metadata"]["type"] == "reference"
+        assert "# API Reference" in ref_vecs[0]["metadata"]["text"]
+
     def test_deterministic_ids(self, sample_skill_dir):
         """IDs are deterministic — same input produces same ID."""
         from skill_seekers.cli.adaptors.pinecone_adaptor import PineconeAdaptor
@@ -464,6 +551,57 @@ class TestPineconeAdaptor:
         ids1 = [v["id"] for v in data1["vectors"]]
         ids2 = [v["id"] for v in data2["vectors"]]
         assert ids1 == ids2
+
+
+# ---------------------------------------------------------------------------
+# _parse_ref_frontmatter — malformed YAML resilience
+# ---------------------------------------------------------------------------
+
+
+class TestParseRefFrontmatter:
+    """_parse_ref_frontmatter must never raise on malformed YAML."""
+
+    def test_parse_valid_frontmatter(self):
+        """Valid YAML frontmatter parses to dict + content."""
+        from skill_seekers.cli.adaptors.pinecone_adaptor import PineconeAdaptor
+
+        content = "---\nfoo: bar\nnum: 42\n---\nbody text\n"
+        fm, body = PineconeAdaptor._parse_ref_frontmatter(content)
+        assert fm == {"foo": "bar", "num": 42}
+        assert body == "body text\n"
+
+    def test_parse_no_frontmatter(self):
+        """Content without leading --- returns empty dict + original content."""
+        from skill_seekers.cli.adaptors.pinecone_adaptor import PineconeAdaptor
+
+        content = "no frontmatter here"
+        fm, body = PineconeAdaptor._parse_ref_frontmatter(content)
+        assert fm == {}
+        assert body == content
+
+    def test_parse_malformed_yaml_does_not_raise(self):
+        """Malformed YAML returns ({}, original content) instead of raising."""
+        from skill_seekers.cli.adaptors.pinecone_adaptor import PineconeAdaptor
+
+        # Two flavors of broken YAML — both must fall through to the except.
+        broken_colons = "---\n: : :\n---\nbody"
+        fm, body = PineconeAdaptor._parse_ref_frontmatter(broken_colons)
+        assert fm == {}
+        assert body == broken_colons
+
+        unbalanced = "---\n[unbalanced\n---\nbody"
+        fm, body = PineconeAdaptor._parse_ref_frontmatter(unbalanced)
+        assert fm == {}
+        assert body == unbalanced
+
+    def test_parse_non_dict_yaml_returns_empty(self):
+        """Frontmatter that parses to a non-dict (e.g. a list) returns empty dict."""
+        from skill_seekers.cli.adaptors.pinecone_adaptor import PineconeAdaptor
+
+        content = "---\n- just\n- a list\n---\nbody"
+        fm, body = PineconeAdaptor._parse_ref_frontmatter(content)
+        assert fm == {}
+        assert body == content
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_unified.py
+++ b/tests/test_unified.py
@@ -527,6 +527,191 @@ def test_skill_builder_merged_apis():
 
 
 # ===========================
+# Issue #363: Local C3.x output
+# ===========================
+
+
+def _make_local_source(
+    *,
+    name: str = "my-codebase",
+    path: str = "/tmp/my-codebase",
+    test_examples: dict | None = None,
+    patterns: list | None = None,
+    how_to_guides: dict | None = None,
+    config_patterns: dict | None = None,
+    architecture: dict | None = None,
+) -> dict:
+    """Build a local-source dict shaped like UnifiedScraper._run_local_codebase_analysis output."""
+    return {
+        "source_id": f"unified_local_0_{name}",
+        "path": path,
+        "name": name,
+        "description": f"Local analysis of {name}",
+        "weight": 1.0,
+        "patterns": patterns,
+        "test_examples": test_examples,
+        "how_to_guides": how_to_guides,
+        "config_patterns": config_patterns,
+        "architecture": architecture,
+        "api_reference": None,
+        "dependency_graph": None,
+    }
+
+
+def test_local_source_test_examples_become_references_363():
+    """Issue #363: test_examples from local sources should land in references/."""
+    config = {
+        "name": "skill_363",
+        "description": "Local C3.x output should not be dropped",
+        "sources": [{"type": "local", "path": "/tmp/my-codebase"}],
+    }
+
+    test_examples = {
+        "total_examples": 292,
+        "high_value_count": 47,
+        "examples_by_category": {"DI": 100, "Setup": 80, "Mocks": 112},
+        "examples": [],
+    }
+    local_source = _make_local_source(test_examples=test_examples)
+
+    scraped_data = {"local": [local_source]}
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        builder = UnifiedSkillBuilder(config, scraped_data)
+        builder.skill_dir = tmpdir
+        os.makedirs(os.path.join(tmpdir, "references"), exist_ok=True)
+
+        builder._generate_local_codebase_analysis_references()
+
+        analysis_root = Path(tmpdir) / "references" / "codebase_analysis"
+        # Source-id is sanitized; should produce a single subdir
+        subdirs = [p for p in analysis_root.iterdir() if p.is_dir()]
+        assert len(subdirs) == 1, f"expected 1 source dir, got {subdirs}"
+        source_dir = subdirs[0]
+
+        examples_json = source_dir / "examples" / "test_examples.json"
+        assert examples_json.exists(), "test_examples.json not generated"
+
+        data = json.loads(examples_json.read_text())
+        assert data["total_examples"] == 292
+        assert data["high_value_count"] == 47
+
+        # ARCHITECTURE.md should also be created with the test-examples summary
+        arch_md = source_dir / "ARCHITECTURE.md"
+        assert arch_md.exists()
+        arch_content = arch_md.read_text()
+        assert "292 usage example" in arch_content
+
+
+def test_local_source_skill_md_includes_summary_363():
+    """SKILL.md should reflect counts from local-source C3.x output (#363)."""
+    config = {
+        "name": "skill_363",
+        "description": "Test",
+        "sources": [{"type": "local", "path": "/tmp/my-codebase"}],
+    }
+
+    local_source = _make_local_source(
+        test_examples={"total_examples": 50, "high_value_count": 12},
+        how_to_guides={"guides": [{"title": "A"}, {"title": "B"}]},
+    )
+    scraped_data = {"local": [local_source]}
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        builder = UnifiedSkillBuilder(config, scraped_data)
+        builder.skill_dir = tmpdir
+
+        builder._generate_skill_md()
+
+        skill_md = Path(tmpdir) / "SKILL.md"
+        content = skill_md.read_text()
+
+        assert "Architecture & Code Analysis" in content
+        assert "50 extracted from tests" in content
+        assert "12 high-value" in content
+        assert "2 workflow tutorials" in content
+
+
+def test_format_c3_summary_aggregates_across_sources_363():
+    """_format_c3_summary_section should sum counts across multiple payloads."""
+    config = {"name": "agg", "description": "Test", "sources": []}
+    builder = UnifiedSkillBuilder(config, {})
+
+    payloads = [
+        {"test_examples": {"total_examples": 100, "high_value_count": 20}},
+        {"test_examples": {"total_examples": 50, "high_value_count": 5}},
+    ]
+
+    out = builder._format_c3_summary_section(payloads)
+    assert "150 extracted from tests" in out
+    assert "25 high-value" in out
+
+
+def test_format_c3_summary_backward_compat_dict_arg_363():
+    """Single-dict arg (legacy) must still produce the summary."""
+    config = {"name": "compat", "description": "Test", "sources": []}
+    builder = UnifiedSkillBuilder(config, {})
+
+    payload = {"test_examples": {"total_examples": 7, "high_value_count": 3}}
+    out = builder._format_c3_summary_section(payload)
+    assert "7 extracted from tests" in out
+
+
+def test_collect_c3_payloads_combines_github_and_local_363():
+    """_collect_c3_payloads should pull from both github and local sources."""
+    config = {"name": "combo", "description": "Test", "sources": []}
+
+    github_c3 = {"test_examples": {"total_examples": 10, "high_value_count": 2}}
+    local_source = _make_local_source(test_examples={"total_examples": 5, "high_value_count": 1})
+    scraped_data = {
+        "github": [{"repo_id": "owner_repo", "data": {"c3_analysis": github_c3}}],
+        "local": [local_source],
+    }
+    builder = UnifiedSkillBuilder(config, scraped_data)
+
+    payloads = builder._collect_c3_payloads()
+    assert len(payloads) == 2
+
+    # Aggregated summary should reflect both
+    out = builder._format_c3_summary_section(payloads)
+    assert "15 extracted from tests" in out
+    assert "3 high-value" in out
+
+
+def test_local_source_without_c3_data_skipped_363():
+    """Local sources with no C3 fields should not create empty reference dirs."""
+    config = {
+        "name": "empty_local",
+        "description": "Test",
+        "sources": [{"type": "local", "path": "/tmp/my-codebase"}],
+    }
+    # All C3 fields None / empty
+    local_source = _make_local_source()
+    scraped_data = {"local": [local_source]}
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        builder = UnifiedSkillBuilder(config, scraped_data)
+        builder.skill_dir = tmpdir
+        os.makedirs(os.path.join(tmpdir, "references"), exist_ok=True)
+
+        builder._generate_local_codebase_analysis_references()
+
+        analysis_root = Path(tmpdir) / "references" / "codebase_analysis"
+        assert not analysis_root.exists() or not any(analysis_root.iterdir())
+
+
+def test_sanitize_source_id_363():
+    """Source IDs must be filesystem-safe."""
+    sanitize = UnifiedSkillBuilder._sanitize_source_id
+    assert sanitize("my-skill_local_0_repo") == "my-skill_local_0_repo"
+    assert sanitize("path/with/slashes") == "path_with_slashes"
+    assert sanitize("name with spaces") == "name_with_spaces"
+    assert sanitize("!!!") == "local"
+    assert sanitize("") == "local"
+    assert sanitize(None) == "local"
+
+
+# ===========================
 # Integration Tests
 # ===========================
 

--- a/tests/test_unified_scraper_orchestration.py
+++ b/tests/test_unified_scraper_orchestration.py
@@ -594,3 +594,80 @@ class TestRunOrchestration:
                 wr_mod.run_workflows = orig_wr
 
         assert "minimal" in (captured.get("workflows") or [])
+
+
+# ===========================================================================
+# Regression: issue #364 — guides loaded from fallback location
+# ===========================================================================
+
+
+class TestLoadGuideCollectionFallback:
+    """_load_guide_collection must return a falsy value when nothing is loadable.
+
+    Otherwise the ``primary or fallback`` chain in _scrape_local /
+    _run_c3_analysis short-circuits on the truthy placeholder and the real
+    guide data in the fallback location is silently dropped (issue #364:
+    output references contain an empty guide_collection.json even though
+    the cache holds 3 generated guides).
+    """
+
+    def _scraper(self):
+        return UnifiedScraper.__new__(UnifiedScraper)
+
+    def test_returns_empty_dict_when_directory_missing(self, tmp_path):
+        scraper = self._scraper()
+        result = scraper._load_guide_collection(tmp_path / "nope")
+        assert result == {}
+        assert not result  # falsy, so `or` fallback fires
+
+    def test_returns_empty_dict_when_directory_has_no_guide_files(self, tmp_path):
+        tutorials = tmp_path / "tutorials"
+        tutorials.mkdir()
+        (tutorials / "index.md").write_text("# Empty\n")
+        scraper = self._scraper()
+        result = scraper._load_guide_collection(tutorials)
+        assert result == {}
+        assert not result
+
+    def test_loads_guide_collection_when_present(self, tmp_path):
+        tutorials = tmp_path / "tutorials"
+        tutorials.mkdir()
+        payload = {
+            "total_guides": 2,
+            "guides_by_complexity": {},
+            "guides_by_use_case": {},
+            "guides": [{"id": "g1", "title": "One"}, {"id": "g2", "title": "Two"}],
+        }
+        (tutorials / "guide_collection.json").write_text(json.dumps(payload))
+        scraper = self._scraper()
+        result = scraper._load_guide_collection(tutorials)
+        assert result["total_guides"] == 2
+        assert len(result["guides"]) == 2
+
+    def test_or_fallback_picks_up_guides_from_secondary_path(self, tmp_path):
+        """Issue #364: when references/tutorials/ is missing but the original
+        tutorials/ still has the JSON, the fallback path must win."""
+        temp_output = tmp_path / "local_analysis_0_repo"
+        refs = temp_output / "references"  # not created — simulates skipped move
+        tutorials = temp_output / "tutorials"
+        tutorials.mkdir(parents=True)
+        payload = {
+            "total_guides": 3,
+            "guides_by_complexity": {},
+            "guides_by_use_case": {},
+            "guides": [
+                {"id": "g1", "title": "One"},
+                {"id": "g2", "title": "Two"},
+                {"id": "g3", "title": "Three"},
+            ],
+        }
+        (tutorials / "guide_collection.json").write_text(json.dumps(payload))
+
+        scraper = self._scraper()
+        primary = scraper._load_guide_collection(refs / "tutorials")
+        fallback = scraper._load_guide_collection(temp_output / "tutorials")
+        result = primary or fallback
+
+        assert not primary  # primary missing, must be falsy
+        assert result["total_guides"] == 3
+        assert len(result["guides"]) == 3

--- a/uv.lock
+++ b/uv.lock
@@ -5733,7 +5733,7 @@ wheels = [
 
 [[package]]
 name = "skill-seekers"
-version = "3.5.0"
+version = "3.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Why

PR #377 (Release v3.6.0) was squash-merged to \`main\`, so the 10 individual commits from \`development\` collapsed into one. \`development\` then merged PR #378 on top (a one-line CI fix), creating a small divergence.

This PR brings \`development\` and \`main\` back in sync.

## Diff

Only one substantive change vs main:

\`\`\`
.github/workflows/docker-publish.yml | 2 +-
\`\`\`

\`docker-compose config\` → \`docker compose config\` (Compose v2 plugin form, since \`docker-compose\` v1 is no longer on \`ubuntu-latest\` runners). Already verified green on PR #378's checks against \`development\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)