### PR TITLE
test(conflict-detector): exercise real asdict() serialization path

### DIFF
--- a/tests/test_conflict_detector.py
+++ b/tests/test_conflict_detector.py
@@ -1,3 +1,5 @@
+from dataclasses import asdict
+
 from skill_seekers.cli.conflict_detector import ConflictDetector, Conflict
 
 
@@ -45,7 +47,12 @@ class TestConflictDetectorEdgeCases:
         assert conflict.suggestion is None
 
     def test_conflict_asdict_with_all_fields(self):
-        """Conflict.asdict() should work when all optional fields are populated."""
+        """dataclasses.asdict(conflict) should produce a full, deep-copied mapping.
+
+        Mirrors the production serialization path (see ConflictDetector, which
+        emits ``asdict(c)`` for each conflict), rather than the shallow
+        ``__dict__`` attribute view.
+        """
         conflict = Conflict(
             type="signature_mismatch",
             severity="medium",
@@ -55,9 +62,15 @@ class TestConflictDetectorEdgeCases:
             difference="code has extra param c",
             suggestion="add param c to docs",
         )
-        d = conflict.__dict__
+        d = asdict(conflict)
         assert d["type"] == "signature_mismatch"
         assert d["severity"] == "medium"
         assert d["api_name"] == "my_api"
         assert d["docs_info"] == {"params": ["a", "b"]}
         assert d["code_info"] == {"params": ["a", "b", "c"]}
+        assert d["difference"] == "code has extra param c"
+        assert d["suggestion"] == "add param c to docs"
+        # asdict() recursively copies nested containers (unlike __dict__), so
+        # mutating the result must not leak back into the original instance.
+        d["docs_info"]["params"].append("mutated")
+        assert conflict.docs_info == {"params": ["a", "b"]}


### PR DESCRIPTION
## Summary
Follow-up to #389. `test_conflict_asdict_with_all_fields` was named and documented as testing `asdict()`, but its body read `conflict.__dict__` — so it never exercised the serialization path actually used in production (`ConflictDetector` emits `asdict(c)` per conflict). For a flat dataclass the two happen to coincide, so the test passed while giving false coverage.

## Changes
- Call `dataclasses.asdict(conflict)` (the production path) instead of `__dict__`
- Assert the full field mapping, including `difference` and `suggestion`
- Add a deep-copy assertion: mutating a nested container in the result must not leak into the original instance. This fails under the old `__dict__` approach, so the test now genuinely distinguishes `asdict()` from `__dict__`.

## Tests
`pytest tests/test_conflict_detector.py -v` → 6 passed. `ruff check` + `ruff format --check` clean.

## Risk
LOW — test-only change.
