### PR TITLE
feat(converters): fail fast on missing optional dependency in get_converter

### DIFF
--- a/src/skill_seekers/cli/skill_converter.py
+++ b/src/skill_seekers/cli/skill_converter.py
@@ -83,6 +83,30 @@ CONVERTER_REGISTRY: dict[str, tuple[str, str]] = {
 }
 
 
+# Source types backed by an optional dependency. Maps the source type to the
+# name of the module-level dependency-check function in its registered scraper
+# module (see CONVERTER_REGISTRY). Each such function is the single source of
+# truth for its install hint: it raises RuntimeError when the dependency is
+# missing and is a no-op otherwise. get_converter() calls it so a missing
+# optional dependency fails fast — at converter lookup — instead of partway
+# through extraction.
+#
+# 'chat' is intentionally excluded: its requirement (slack_sdk vs discord.py)
+# depends on the configured platform, so it is checked at runtime from config.
+OPTIONAL_DEP_CHECKS: dict[str, str] = {
+    "word": "_check_word_deps",
+    "epub": "_check_epub_deps",
+    "video": "check_video_dependencies",
+    "jupyter": "_check_jupyter_deps",
+    "openapi": "_check_yaml_deps",
+    "asciidoc": "_check_asciidoc_deps",
+    "pptx": "_check_pptx_deps",
+    "rss": "_check_feedparser_deps",
+    "confluence": "_check_atlassian_deps",
+    "notion": "_check_notion_deps",
+}
+
+
 def get_converter(source_type: str, config: dict[str, Any]) -> SkillConverter:
     """Get the appropriate converter for a source type.
 
@@ -95,6 +119,8 @@ def get_converter(source_type: str, config: dict[str, Any]) -> SkillConverter:
 
     Raises:
         ValueError: If source type is not supported.
+        RuntimeError: If the source type's optional dependency is not installed
+            (raised by the scraper's own dependency check, with an install hint).
     """
     import importlib
 
@@ -106,6 +132,15 @@ def get_converter(source_type: str, config: dict[str, Any]) -> SkillConverter:
 
     module_path, class_name = CONVERTER_REGISTRY[source_type]
     module = importlib.import_module(module_path)
+
+    # Fail fast on a missing optional dependency, delegating to the scraper's
+    # own dependency check so the install hint stays defined in one place.
+    dep_check_name = OPTIONAL_DEP_CHECKS.get(source_type)
+    if dep_check_name is not None:
+        dep_check = getattr(module, dep_check_name, None)
+        if callable(dep_check):
+            dep_check()
+
     converter_class = getattr(module, class_name, None)
     if converter_class is None:
         raise ValueError(

--- a/tests/test_new_source_types.py
+++ b/tests/test_new_source_types.py
@@ -859,14 +859,60 @@ class TestCreateCommandRouting:
         from skill_seekers.cli.skill_converter import get_converter
 
         for source_type in self.NEW_SOURCE_TYPES:
-            # get_converter should not raise for known types
-            # (it may raise ImportError for missing optional deps, which is OK)
+            # get_converter should not raise for known types.
+            # ImportError/RuntimeError are acceptable: the source type's optional
+            # dependency simply isn't installed in this environment.
             try:
                 converter_cls = get_converter(source_type, {"name": "test"})
                 assert converter_cls is not None, f"get_converter returned None for '{source_type}'"
-            except ImportError:
+            except (ImportError, RuntimeError):
                 # Optional dependency not installed - that's fine
                 pass
+
+    def test_optional_dep_checks_are_wired_correctly(self):
+        """Every OPTIONAL_DEP_CHECKS entry must resolve to a real callable.
+
+        Structural guard against drift: each mapped source type must exist in
+        CONVERTER_REGISTRY, and the named dependency-check function must exist
+        and be callable in that source type's registered module.
+        """
+        import importlib
+
+        from skill_seekers.cli.skill_converter import (
+            CONVERTER_REGISTRY,
+            OPTIONAL_DEP_CHECKS,
+        )
+
+        for source_type, func_name in OPTIONAL_DEP_CHECKS.items():
+            assert source_type in CONVERTER_REGISTRY, (
+                f"OPTIONAL_DEP_CHECKS references unknown source type '{source_type}'"
+            )
+            module_path, _ = CONVERTER_REGISTRY[source_type]
+            module = importlib.import_module(module_path)
+            fn = getattr(module, func_name, None)
+            assert callable(fn), f"{module_path}.{func_name} is missing or not callable"
+
+    def test_get_converter_fails_fast_when_optional_dep_missing(self):
+        """get_converter raises the scraper's RuntimeError when its dep is absent.
+
+        Exercises the real wiring end-to-end: flip the real jupyter_scraper
+        availability flag, then confirm get_converter() surfaces the same
+        RuntimeError (with install hint) that _check_jupyter_deps() raises —
+        before the converter is instantiated.
+        """
+        from unittest.mock import patch
+
+        from skill_seekers.cli.skill_converter import get_converter
+
+        with (
+            patch("skill_seekers.cli.jupyter_scraper.JUPYTER_AVAILABLE", False),
+            pytest.raises(RuntimeError) as exc_info,
+        ):
+            get_converter("jupyter", {"name": "test"})
+
+        message = str(exc_info.value)
+        assert "nbformat" in message
+        assert "pip install" in message
 
     def test_route_to_scraper_uses_get_converter(self):
         """Test _route_to_scraper delegates to get_converter (not per-type branches)."""


### PR DESCRIPTION
## Summary
Makes `get_converter()` fail fast when a source type's **optional dependency** is missing, with a clear install hint — instead of returning a converter that blows up partway through extraction.

This is the proper, codebase-wide version of the idea behind #386 (closed): that PR special-cased only `jupyter`, duplicated the install-hint string, and used an awkward `sys.modules` lookup. This delegates to each scraper's own dependency check so the message lives in exactly one place.

## Changes
**`src/skill_seekers/cli/skill_converter.py`**
- New `OPTIONAL_DEP_CHECKS` map: `source_type → dep-check function name` for the 10 optional-dep source types (word, epub, video, jupyter, openapi, asciidoc, pptx, rss, confluence, notion).
- `get_converter()` calls the scraper's existing `_check_*_deps()` right after import. Each such function is already the single source of truth for its install hint (raises `RuntimeError` when the dep is missing, no-op otherwise).
- `chat` is intentionally **excluded** — its `slack_sdk` vs `discord.py` requirement depends on the configured platform, so it's checked at runtime from config (documented inline).
- Uses the already-imported `module` (no `sys.modules` hack / no extra `import sys`).

**`tests/test_new_source_types.py`**
- `test_optional_dep_checks_are_wired_correctly` — structural guard: every map entry resolves to a real callable in its registered module (catches typos/drift).
- `test_get_converter_fails_fast_when_optional_dep_missing` — behavioral: flips the **real** `jupyter_scraper.JUPYTER_AVAILABLE` and asserts `get_converter` surfaces the real `RuntimeError` + install hint.
- `test_get_converter_handles_all_new_types` now also tolerates `RuntimeError` (a type's optional dep simply not being installed in the env).

## Why this is safe
- No behavior change when deps are present (the checks are no-ops).
- Other `get_converter` callers in tests use core types (web/github/pdf) or mock it.
- No new imports of the network/subprocess kind; the check only reads a module flag and may raise.

## Risk
LOW — additive guard + tests. `ruff check`/`ruff format` clean.
