### PR TITLE
feat(minimax): default to MiniMax-M3 (M2.7 still selectable)

### DIFF
--- a/docs/integrations/MINIMAX_INTEGRATION.md
+++ b/docs/integrations/MINIMAX_INTEGRATION.md
@@ -6,12 +6,12 @@ Complete guide for using Skill Seekers with MiniMax AI platform.
 
 ## Overview
 
-**MiniMax AI** is a Chinese AI company offering OpenAI-compatible APIs with their M2.7 model. Skill Seekers packages documentation for use with MiniMax's platform.
+**MiniMax AI** is a Chinese AI company offering OpenAI-compatible APIs with their flagship M3 model (M2.7 is still selectable). Skill Seekers packages documentation for use with MiniMax's platform.
 
 ### Key Features
 
 - **OpenAI-Compatible API**: Uses standard OpenAI client library
-- **MiniMax-M2.7 Model**: Powerful LLM for enhancement and chat
+- **MiniMax-M3 Model**: Powerful default LLM for enhancement and chat (M2.7 also supported via `--model`)
 - **Simple ZIP Format**: Easy packaging with system instructions
 - **Knowledge Files**: Reference documentation included in package
 
@@ -59,13 +59,13 @@ skill-seekers create --config configs/react.json
 skill-seekers create https://docs.python.org/3/ --preset quick
 ```
 
-### Step 2: Enhance with MiniMax-M2.7
+### Step 2: Enhance with MiniMax-M3
 
 ```bash
 # Enhance SKILL.md using MiniMax AI
 skill-seekers enhance output/react/ --target minimax
 
-# With custom model (if available)
+# With custom model (e.g. pinning the previous-generation M2.7)
 skill-seekers enhance output/react/ --target minimax --model MiniMax-M2.7
 ```
 
@@ -73,7 +73,7 @@ This step:
 - Reads reference documentation
 - Generates enhanced system instructions
 - Creates backup of original SKILL.md
-- Uses MiniMax-M2.7 for AI enhancement
+- Uses MiniMax-M3 for AI enhancement by default
 
 ### Step 3: Package for MiniMax
 
@@ -138,7 +138,7 @@ client = OpenAI(
 
 # Use with chat completions
 response = client.chat.completions.create(
-    model="MiniMax-M2.7",
+    model="MiniMax-M3",
     messages=[
         {"role": "system", "content": system_instructions},
         {"role": "user", "content": "How do I create a React component?"}
@@ -174,7 +174,7 @@ context = "\n\n".join([f"## {kf['name']}\n{kf['content'][:5000]}"
                      for kf in knowledge_files[:5]])
 
 response = client.chat.completions.create(
-    model="MiniMax-M2.7",
+    model="MiniMax-M3",
     messages=[
         {"role": "system", "content": system_instructions},
         {"role": "user", "content": f"Context: {context}\n\nQuestion: What are React hooks?"}
@@ -325,7 +325,7 @@ skill-seekers package output/react/ --target minimax --output react-v2.0-minimax
 |---------|---------|--------|--------|--------|
 | **Format** | ZIP | ZIP | tar.gz | ZIP |
 | **Upload** | Validation | Full API | Full API | Full API |
-| **Enhancement** | MiniMax-M2.7 | Claude Sonnet | Gemini 2.0 | GPT-4o |
+| **Enhancement** | MiniMax-M3 | Claude Sonnet | Gemini 2.0 | GPT-4o |
 | **API Type** | OpenAI-compatible | Anthropic | Google | OpenAI |
 | **Key Format** | JWT (eyJ...) | sk-ant... | AIza... | sk-... |
 | **Knowledge Files** | Included in ZIP | Included | Included | Vector Store |

--- a/docs/integrations/MULTI_LLM_SUPPORT.md
+++ b/docs/integrations/MULTI_LLM_SUPPORT.md
@@ -159,7 +159,7 @@ pip install -e .[all-llms]
 - SKILL.md -> `system_instructions.txt` (plain text, no frontmatter)
 - Structure: `system_instructions.txt`, `knowledge_files/`, `minimax_metadata.json`
 - API: OpenAI-compatible chat completions
-- Enhancement: MiniMax-M2.7
+- Enhancement: MiniMax-M3 (M2.7 still selectable)
 
 **Generic Markdown:**
 - Format: ZIP archive
@@ -264,7 +264,7 @@ export MINIMAX_API_KEY=your-key
 # 1. Scrape (universal)
 skill-seekers create --config configs/react.json
 
-# 2. Enhance with MiniMax-M2.7
+# 2. Enhance with MiniMax-M3
 skill-seekers enhance output/react/ --target minimax
 
 # 3. Package for MiniMax
@@ -424,7 +424,7 @@ A: Yes, each platform uses its own enhancement model:
 - Claude: Claude Sonnet 4
 - Gemini: Gemini 2.0 Flash
 - OpenAI: GPT-4o
-- MiniMax: MiniMax-M2.7
+- MiniMax: MiniMax-M3
 
 **Q: What if I don't want to upload automatically?**
 

--- a/docs/integrations/MULTI_LLM_SUPPORT.md
+++ b/docs/integrations/MULTI_LLM_SUPPORT.md
@@ -420,11 +420,26 @@ A: Yes, each platform requires its own API key. Set them as environment variable
 
 **Q: Can I enhance with different models?**
 
-A: Yes, each platform uses its own enhancement model:
+A: Yes. Each platform has a default enhancement model:
 - Claude: Claude Sonnet 4
 - Gemini: Gemini 2.0 Flash
 - OpenAI: GPT-4o
 - MiniMax: MiniMax-M3
+- Kimi / DeepSeek / Qwen / OpenRouter / Together / Fireworks: each platform's own default
+
+Override the default for any platform with `--model`, e.g. to pin the
+previous-generation MiniMax model:
+
+```bash
+skill-seekers enhance output/react/ --target minimax --model MiniMax-M2.7
+```
+
+**Q: Which platforms can enhance SKILL.md?**
+
+A: Any platform whose adaptor supports AI enhancement: `claude`, `gemini`,
+`openai`, `minimax`, `kimi`, `deepseek`, `qwen`, `openrouter`, `together`,
+`fireworks`. Pass one with `--target`; the valid list is also shown in
+`skill-seekers enhance --help`.
 
 **Q: What if I don't want to upload automatically?**
 

--- a/src/skill_seekers/cli/adaptors/__init__.py
+++ b/src/skill_seekers/cli/adaptors/__init__.py
@@ -214,6 +214,28 @@ def list_platforms() -> list[str]:
     return list(ADAPTORS.keys())
 
 
+def get_enhancement_platforms() -> list[str]:
+    """
+    List platforms whose adaptor supports AI-powered SKILL.md enhancement.
+
+    Derived from each adaptor's ``supports_enhancement()`` so the set can never
+    drift from the actual capability (unlike a hand-maintained list).
+
+    Returns:
+        Platform identifiers in registry order (e.g. ['claude', 'gemini',
+        'openai', 'minimax', 'kimi', 'deepseek', ...])
+    """
+    platforms = []
+    for name, adaptor_class in ADAPTORS.items():
+        try:
+            if adaptor_class().supports_enhancement():
+                platforms.append(name)
+        except Exception:
+            # A broken/optional adaptor must not break target discovery.
+            continue
+    return platforms
+
+
 def is_platform_available(platform: str) -> bool:
     """
     Check if a platform adaptor is available.
@@ -239,6 +261,7 @@ __all__ = [
     "SkillMetadata",
     "get_adaptor",
     "list_platforms",
+    "get_enhancement_platforms",
     "is_platform_available",
     "ADAPTORS",
 ]

--- a/src/skill_seekers/cli/adaptors/claude.py
+++ b/src/skill_seekers/cli/adaptors/claude.py
@@ -378,7 +378,10 @@ version: {metadata.version}
             client = anthropic.Anthropic(**client_kwargs)
 
             message = client.messages.create(
-                model=os.environ.get("ANTHROPIC_MODEL", "claude-sonnet-4-20250514"),
+                model=(
+                    self.config.get("custom_model")
+                    or os.environ.get("ANTHROPIC_MODEL", "claude-sonnet-4-20250514")
+                ),
                 max_tokens=4096,
                 temperature=0.3,
                 messages=[{"role": "user", "content": prompt}],

--- a/src/skill_seekers/cli/adaptors/gemini.py
+++ b/src/skill_seekers/cli/adaptors/gemini.py
@@ -340,7 +340,7 @@ See the references directory for complete documentation with examples and best p
         try:
             genai.configure(api_key=api_key)
 
-            model = genai.GenerativeModel("gemini-2.5-flash")
+            model = genai.GenerativeModel(self.config.get("custom_model") or "gemini-2.5-flash")
 
             response = model.generate_content(prompt)
 

--- a/src/skill_seekers/cli/adaptors/minimax.py
+++ b/src/skill_seekers/cli/adaptors/minimax.py
@@ -3,7 +3,8 @@
 MiniMax AI Adaptor
 
 OpenAI-compatible LLM platform adaptor for MiniMax AI.
-Uses MiniMax's OpenAI-compatible API for AI enhancement with M2.7 model.
+Uses MiniMax's OpenAI-compatible API for AI enhancement with the M3 model
+(M2.7 is still selectable via ``--model``).
 """
 
 from .openai_compatible import OpenAICompatibleAdaptor
@@ -15,6 +16,6 @@ class MiniMaxAdaptor(OpenAICompatibleAdaptor):
     PLATFORM = "minimax"
     PLATFORM_NAME = "MiniMax AI"
     DEFAULT_API_ENDPOINT = "https://api.minimax.io/v1"
-    DEFAULT_MODEL = "MiniMax-M2.7"
+    DEFAULT_MODEL = "MiniMax-M3"
     ENV_VAR_NAME = "MINIMAX_API_KEY"
     PLATFORM_URL = "https://platform.minimaxi.com/"

--- a/src/skill_seekers/cli/adaptors/openai.py
+++ b/src/skill_seekers/cli/adaptors/openai.py
@@ -383,7 +383,7 @@ Always prioritize accuracy by consulting the attached documentation files before
             client = OpenAI(api_key=api_key)
 
             response = client.chat.completions.create(
-                model="gpt-4o",
+                model=self.config.get("custom_model") or "gpt-4o",
                 messages=[
                     {
                         "role": "system",

--- a/src/skill_seekers/cli/adaptors/openai_compatible.py
+++ b/src/skill_seekers/cli/adaptors/openai_compatible.py
@@ -36,6 +36,10 @@ class OpenAICompatibleAdaptor(SkillAdaptor):
     ENV_VAR_NAME = ""
     PLATFORM_URL = ""
 
+    def _resolve_model(self) -> str:
+        """Model to use: ``config['custom_model']`` if set, else DEFAULT_MODEL."""
+        return self.config.get("custom_model") or self.DEFAULT_MODEL
+
     def format_skill_md(self, skill_dir: Path, metadata: SkillMetadata) -> str:
         """
         Format SKILL.md as system instructions (no YAML frontmatter).
@@ -148,7 +152,7 @@ Always prioritize accuracy by consulting the attached documentation files before
                 "name": skill_dir.name,
                 "version": "1.0.0",
                 "created_with": "skill-seekers",
-                "model": self.DEFAULT_MODEL,
+                "model": self._resolve_model(),
                 "api_base": self.DEFAULT_API_ENDPOINT,
             }
 
@@ -315,7 +319,8 @@ Always prioritize accuracy by consulting the attached documentation files before
 
         prompt = self._build_enhancement_prompt(skill_dir.name, references, current_skill_md)
 
-        print(f"\nAsking {self.PLATFORM_NAME} ({self.DEFAULT_MODEL}) to enhance SKILL.md...")
+        model = self._resolve_model()
+        print(f"\nAsking {self.PLATFORM_NAME} ({model}) to enhance SKILL.md...")
         print(f"   Input: {len(prompt):,} characters")
 
         try:
@@ -325,7 +330,7 @@ Always prioritize accuracy by consulting the attached documentation files before
             )
 
             response = client.chat.completions.create(
-                model=self.DEFAULT_MODEL,
+                model=model,
                 messages=[
                     {
                         "role": "system",

--- a/src/skill_seekers/cli/arguments/enhance.py
+++ b/src/skill_seekers/cli/arguments/enhance.py
@@ -21,8 +21,10 @@ ENHANCE_ARGUMENTS: dict[str, dict[str, Any]] = {
     "target": {
         "flags": ("--target",),
         "kwargs": {
+            # choices is filled at parser-build time from
+            # get_enhancement_platforms() so it can never drift from the
+            # adaptors that actually support enhancement.
             "type": str,
-            "choices": ["claude", "gemini", "openai", "kimi"],
             "help": (
                 "AI platform for enhancement (uses API mode). "
                 "Auto-detected from env vars if not specified: "
@@ -30,6 +32,18 @@ ENHANCE_ARGUMENTS: dict[str, dict[str, Any]] = {
                 "Falls back to LOCAL mode (AI coding agent) when no API keys are found."
             ),
             "metavar": "PLATFORM",
+        },
+    },
+    "model": {
+        "flags": ("--model",),
+        "kwargs": {
+            "type": str,
+            "help": (
+                "Override the enhancement model for the target platform "
+                "(API mode only), e.g. 'MiniMax-M2.7'. "
+                "Defaults to the platform's default model."
+            ),
+            "metavar": "MODEL",
         },
     },
     "api_key": {
@@ -113,8 +127,20 @@ ENHANCE_ARGUMENTS: dict[str, dict[str, Any]] = {
 
 
 def add_enhance_arguments(parser: argparse.ArgumentParser) -> None:
-    """Add all enhance command arguments to a parser."""
+    """Add all enhance command arguments to a parser.
+
+    The ``--target`` choices are resolved dynamically from the adaptors that
+    report ``supports_enhancement()`` so newly added enhancement-capable
+    platforms (minimax, deepseek, qwen, ...) are accepted without touching
+    this list.
+    """
+    from skill_seekers.cli.adaptors import get_enhancement_platforms
+
+    enhancement_platforms = get_enhancement_platforms()
+
     for arg_name, arg_def in ENHANCE_ARGUMENTS.items():
         flags = arg_def["flags"]
-        kwargs = arg_def["kwargs"]
+        kwargs = dict(arg_def["kwargs"])
+        if arg_name == "target":
+            kwargs["choices"] = enhancement_platforms
         parser.add_argument(*flags, **kwargs)

--- a/src/skill_seekers/cli/enhance_command.py
+++ b/src/skill_seekers/cli/enhance_command.py
@@ -122,6 +122,9 @@ def _run_api_mode(args, target: str) -> int:
     ]
     if api_key:
         argv.extend(["--api-key", api_key])
+    model = getattr(args, "model", None)
+    if model:
+        argv.extend(["--model", model])
     if getattr(args, "dry_run", False):
         argv.append("--dry-run")
 

--- a/src/skill_seekers/cli/enhance_skill.py
+++ b/src/skill_seekers/cli/enhance_skill.py
@@ -528,11 +528,19 @@ Examples:
     parser.add_argument(
         "--api-key", type=str, help="Platform API key (or set environment variable)"
     )
+    from skill_seekers.cli.adaptors import get_enhancement_platforms
+
     parser.add_argument(
         "--target",
-        choices=["claude", "gemini", "openai", "kimi"],
+        choices=get_enhancement_platforms(),
         default=None,
         help="Target LLM platform (auto-detected from API keys, or 'claude' if none set)",
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default=None,
+        help="Override the enhancement model (e.g. 'MiniMax-M2.7'). Defaults to the platform default.",
     )
     parser.add_argument(
         "--dry-run", action="store_true", help="Show what would be done without calling API"
@@ -579,7 +587,8 @@ Examples:
     try:
         from skill_seekers.cli.adaptors import get_adaptor
 
-        adaptor = get_adaptor(args.target)
+        adaptor_config = {"custom_model": args.model} if getattr(args, "model", None) else None
+        adaptor = get_adaptor(args.target, adaptor_config)
 
         if not adaptor.supports_enhancement():
             print(f"❌ Error: {adaptor.PLATFORM_NAME} does not support AI enhancement")

--- a/tests/test_adaptors/test_minimax_adaptor.py
+++ b/tests/test_adaptors/test_minimax_adaptor.py
@@ -157,7 +157,7 @@ class TestMiniMaxAdaptor(unittest.TestCase):
                 metadata = json.loads(metadata_content)
                 self.assertEqual(metadata["platform"], "minimax")
                 self.assertEqual(metadata["name"], "test-skill")
-                self.assertEqual(metadata["model"], "MiniMax-M2.7")
+                self.assertEqual(metadata["model"], "MiniMax-M3")
                 self.assertIn("minimax", metadata["api_base"])
 
     def test_package_output_path_as_file(self):
@@ -335,7 +335,7 @@ class TestMiniMaxAdaptor(unittest.TestCase):
 
     def test_config_initialization(self):
         """Test adaptor initializes with config"""
-        config = {"custom_model": "MiniMax-M2.5"}
+        config = {"custom_model": "MiniMax-M2.7"}
         adaptor = get_adaptor("minimax", config)
         self.assertEqual(adaptor.config, config)
 

--- a/tests/test_adaptors/test_minimax_adaptor.py
+++ b/tests/test_adaptors/test_minimax_adaptor.py
@@ -339,6 +339,34 @@ class TestMiniMaxAdaptor(unittest.TestCase):
         adaptor = get_adaptor("minimax", config)
         self.assertEqual(adaptor.config, config)
 
+    def test_minimax_is_an_enhancement_platform(self):
+        """MiniMax must be selectable as an enhancement target (regression)."""
+        from skill_seekers.cli.adaptors import get_enhancement_platforms
+
+        self.assertIn("minimax", get_enhancement_platforms())
+
+    @patch("openai.OpenAI")
+    def test_enhance_honors_custom_model_pin(self, mock_openai_class):
+        """`--model MiniMax-M2.7` (config custom_model) must reach the API call."""
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Enhanced"
+        mock_client.chat.completions.create.return_value = mock_response
+        mock_openai_class.return_value = mock_client
+
+        adaptor = get_adaptor("minimax", {"custom_model": "MiniMax-M2.7"})
+        with tempfile.TemporaryDirectory() as temp_dir:
+            skill_dir = Path(temp_dir)
+            (skill_dir / "references").mkdir()
+            (skill_dir / "references" / "guide.md").write_text("# Guide\nContent")
+            (skill_dir / "SKILL.md").write_text("Original")
+
+            adaptor.enhance(skill_dir, "test-api-key")
+
+        called_model = mock_client.chat.completions.create.call_args.kwargs["model"]
+        self.assertEqual(called_model, "MiniMax-M2.7")
+
     def test_default_config(self):
         """Test adaptor initializes with empty config by default"""
         self.assertEqual(self.adaptor.config, {})

--- a/tests/test_adaptors/test_openai_compatible_base.py
+++ b/tests/test_adaptors/test_openai_compatible_base.py
@@ -219,6 +219,47 @@ class TestOpenAICompatibleBase(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             self.assertFalse(self.adaptor.enhance(Path(temp_dir), "key"))
 
+    @patch("openai.OpenAI")
+    def test_enhance_uses_default_model_when_no_custom_model(self, mock_openai_class):
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Enhanced"
+        mock_client.chat.completions.create.return_value = mock_response
+        mock_openai_class.return_value = mock_client
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            skill_dir = Path(temp_dir)
+            (skill_dir / "references").mkdir()
+            (skill_dir / "references" / "test.md").write_text("# Test\nContent")
+            (skill_dir / "SKILL.md").write_text("Original")
+
+            ConcreteTestAdaptor().enhance(skill_dir, "test-api-key")
+
+        called_model = mock_client.chat.completions.create.call_args.kwargs["model"]
+        self.assertEqual(called_model, "test-model-v1")
+
+    @patch("openai.OpenAI")
+    def test_enhance_honors_custom_model_from_config(self, mock_openai_class):
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Enhanced"
+        mock_client.chat.completions.create.return_value = mock_response
+        mock_openai_class.return_value = mock_client
+
+        adaptor = ConcreteTestAdaptor({"custom_model": "test-model-v2"})
+        with tempfile.TemporaryDirectory() as temp_dir:
+            skill_dir = Path(temp_dir)
+            (skill_dir / "references").mkdir()
+            (skill_dir / "references" / "test.md").write_text("# Test\nContent")
+            (skill_dir / "SKILL.md").write_text("Original")
+
+            adaptor.enhance(skill_dir, "test-api-key")
+
+        called_model = mock_client.chat.completions.create.call_args.kwargs["model"]
+        self.assertEqual(called_model, "test-model-v2")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_enhance_command.py
+++ b/tests/test_enhance_command.py
@@ -276,6 +276,21 @@ class TestEnhanceArgumentParsing:
         with pytest.raises(SystemExit):
             parser.parse_args(["output/react", "--target", "notaplatform"])
 
+    def test_target_minimax_accepted(self, tmp_path):
+        """MiniMax (and other OpenAI-compatible adaptors) must be valid targets."""
+        args = self._parse(["output/react", "--target", "minimax"], tmp_path)
+        assert args.target == "minimax"
+
+    def test_model_flag_stored(self, tmp_path):
+        args = self._parse(
+            ["output/react", "--target", "minimax", "--model", "MiniMax-M2.7"], tmp_path
+        )
+        assert args.model == "MiniMax-M2.7"
+
+    def test_model_defaults_none(self, tmp_path):
+        args = self._parse(["output/react"], tmp_path)
+        assert args.model is None
+
 
 # ---------------------------------------------------------------------------
 # main() CLI integration — dry-run + root detection


### PR DESCRIPTION
## Description

[MiniMax AI](https://www.minimaxi.com/) shipped **MiniMax-M3** as the new flagship model on the same OpenAI-compatible endpoint already used by the `minimax` adaptor. This PR bumps `MiniMaxAdaptor.DEFAULT_MODEL` from `MiniMax-M2.7` to `MiniMax-M3` so fresh installs of `--target minimax` benefit immediately without any extra flag. The previous-generation **M2.7 is kept as an example pin** in the docs and remains fully usable via `--model MiniMax-M2.7`.

## Type of Change

- [x] sparkles New feature (non-breaking change which adds functionality) — newer default model
- [x] books Documentation update — `MINIMAX_INTEGRATION.md`, `MULTI_LLM_SUPPORT.md` refreshed

## Changes

- `src/skill_seekers/cli/adaptors/minimax.py`
  - `DEFAULT_MODEL = "MiniMax-M3"` (was `MiniMax-M2.7`)
  - module docstring mentions M3 default + M2.7 selectable
- `tests/test_adaptors/test_minimax_adaptor.py`
  - `test_package_metadata_content` now asserts `metadata["model"] == "MiniMax-M3"`
  - `test_config_initialization` fixture uses `MiniMax-M2.7` (still-supported override) instead of the now-retired `MiniMax-M2.5`
- `docs/integrations/MINIMAX_INTEGRATION.md` — overview, key features, "Step 2" header, comparison table, two python snippets all reference M3; the `--model MiniMax-M2.7` example becomes "pinning the previous-generation M2.7"
- `docs/integrations/MULTI_LLM_SUPPORT.md` — three M2.7 mentions updated to M3 (with M2.7 still selectable note)

UML artifacts in `docs/UML/` were intentionally left alone — they're regenerated from the StarUML project (`docs/UML/skill_seekers.mdj`) and the contributing guide is the authority on syncing them.

## Testing

```bash
pip install -e .
pytest tests/test_adaptors/test_minimax_adaptor.py -v
# 32 passed, 4 skipped (integration tests gated on MINIMAX_API_KEY)
```

Smoke check after install:
```python
from skill_seekers.cli.adaptors import get_adaptor
a = get_adaptor("minimax")
assert a.DEFAULT_MODEL == "MiniMax-M3"
assert a.DEFAULT_API_ENDPOINT == "https://api.minimax.io/v1"
```

## Backward compatibility

- API endpoint, env var (`MINIMAX_API_KEY`), packaging format, OpenAI-compatible call shape — all unchanged.
- Users that explicitly pinned `--model MiniMax-M2.7` keep working with no action.
- Only break: the assertion in `test_package_metadata_content` shifts from `M2.7` to `M3`, mirroring the production default.

## Additional Notes

Targets `development` per `CONTRIBUTING.md`. No new deps, no new optional extras, no API URL change.