### PR TITLE
fix: prevent Windows pipe-buffer lock in run_subprocess_with streaming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ wheels/
 .env.*.local
 
 # Virtual Environment
+.venv/
 venv/
 ENV/
 env/

--- a/src/skill_seekers/mcp/server_legacy.py
+++ b/src/skill_seekers/mcp/server_legacy.py
@@ -8,13 +8,13 @@ import asyncio
 import json
 import os
 import re
-import subprocess
 import sys
-import time
 from pathlib import Path
 from typing import Any
 
 import httpx
+
+from skill_seekers.mcp.tools.subprocess_utils import run_subprocess_with_streaming
 
 # Import external MCP package
 # NOTE: Directory renamed from 'mcp/' to 'skill_seeker_mcp/' to avoid shadowing the external mcp package
@@ -61,76 +61,6 @@ def safe_decorator(decorator_func):
             return func
 
         return noop_decorator
-
-
-def run_subprocess_with_streaming(cmd, timeout=None):
-    """
-    Run subprocess with real-time output streaming.
-    Returns (stdout, stderr, returncode).
-
-    This solves the blocking issue where long-running processes (like scraping)
-    would cause MCP to appear frozen. Now we stream output as it comes.
-    """
-    try:
-        process = subprocess.Popen(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            bufsize=1,  # Line buffered
-            universal_newlines=True,
-        )
-
-        stdout_lines = []
-        stderr_lines = []
-        start_time = time.time()
-
-        # Read output line by line as it comes
-        while True:
-            # Check timeout
-            if timeout and (time.time() - start_time) > timeout:
-                process.kill()
-                stderr_lines.append(f"\n⚠️ Process killed after {timeout}s timeout")
-                break
-
-            # Check if process finished
-            if process.poll() is not None:
-                break
-
-            # Read available output (non-blocking)
-            try:
-                import select
-
-                readable, _, _ = select.select([process.stdout, process.stderr], [], [], 0.1)
-
-                if process.stdout in readable:
-                    line = process.stdout.readline()
-                    if line:
-                        stdout_lines.append(line)
-
-                if process.stderr in readable:
-                    line = process.stderr.readline()
-                    if line:
-                        stderr_lines.append(line)
-            except Exception:
-                # Fallback for Windows (no select)
-                time.sleep(0.1)
-
-        # Get any remaining output
-        remaining_stdout, remaining_stderr = process.communicate()
-        if remaining_stdout:
-            stdout_lines.append(remaining_stdout)
-        if remaining_stderr:
-            stderr_lines.append(remaining_stderr)
-
-        stdout = "".join(stdout_lines)
-        stderr = "".join(stderr_lines)
-        returncode = process.returncode
-
-        return stdout, stderr, returncode
-
-    except Exception as e:
-        return "", f"Error running subprocess: {str(e)}", 1
 
 
 @safe_decorator(app.list_tools() if app else lambda: lambda f: f)

--- a/src/skill_seekers/mcp/tools/packaging_tools.py
+++ b/src/skill_seekers/mcp/tools/packaging_tools.py
@@ -10,7 +10,6 @@ import os
 import re
 import subprocess
 import sys
-import time
 from pathlib import Path
 
 try:
@@ -31,10 +30,9 @@ CLI_DIR = Path(__file__).parent.parent.parent / "cli"
 
 def run_subprocess_with_streaming(cmd: list[str], timeout: int = None) -> tuple[str, str, int]:
     """
-    Run subprocess with real-time output streaming.
+    Run subprocess w/o pipe buffering and real-time output streaming.
 
-    This solves the blocking issue where long-running processes (like scraping)
-    would cause MCP to appear frozen. Now we stream output as it comes.
+    Uses stdout/stderr threads to read output as it comes, preventing hanging on large outputs.
 
     Args:
         cmd: Command to run as list of strings
@@ -43,63 +41,42 @@ def run_subprocess_with_streaming(cmd: list[str], timeout: int = None) -> tuple[
     Returns:
         Tuple of (stdout, stderr, returncode)
     """
+    import threading
+
     try:
         process = subprocess.Popen(
             cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
-            bufsize=1,  # Line buffered
             universal_newlines=True,
         )
 
-        stdout_lines = []
-        stderr_lines = []
-        start_time = time.time()
+        stdout_lines: list[str] = []
+        stderr_lines: list[str] = []
 
-        # Read output line by line as it comes
-        while True:
-            # Check timeout
-            if timeout and (time.time() - start_time) > timeout:
-                process.kill()
-                stderr_lines.append(f"\n⚠️ Process killed after {timeout}s timeout")
-                break
+        def _read(stream, target: list[str]) -> None:
+            for line in stream:
+                target.append(line)
 
-            # Check if process finished
-            if process.poll() is not None:
-                break
+        t_out = threading.Thread(target=_read, args=(process.stdout, stdout_lines))
+        t_err = threading.Thread(target=_read, args=(process.stderr, stderr_lines))
+        t_out.daemon = True
+        t_err.daemon = True
+        t_out.start()
+        t_err.start()
 
-            # Read available output (non-blocking)
-            try:
-                import select
+        try:
+            process.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait()  # Ensure process has terminated
+            stderr_lines.append(f"\nTimeout: process killed after exceeding {timeout} seconds.")
 
-                readable, _, _ = select.select([process.stdout, process.stderr], [], [], 0.1)
+        t_out.join()
+        t_err.join()
 
-                if process.stdout in readable:
-                    line = process.stdout.readline()
-                    if line:
-                        stdout_lines.append(line)
-
-                if process.stderr in readable:
-                    line = process.stderr.readline()
-                    if line:
-                        stderr_lines.append(line)
-            except Exception:
-                # Fallback for Windows (no select)
-                time.sleep(0.1)
-
-        # Get any remaining output
-        remaining_stdout, remaining_stderr = process.communicate()
-        if remaining_stdout:
-            stdout_lines.append(remaining_stdout)
-        if remaining_stderr:
-            stderr_lines.append(remaining_stderr)
-
-        stdout = "".join(stdout_lines)
-        stderr = "".join(stderr_lines)
-        returncode = process.returncode
-
-        return stdout, stderr, returncode
+        return "".join(stdout_lines), "".join(stderr_lines), process.returncode or 0
 
     except Exception as e:
         return "", f"Error running subprocess: {str(e)}", 1

--- a/src/skill_seekers/mcp/tools/packaging_tools.py
+++ b/src/skill_seekers/mcp/tools/packaging_tools.py
@@ -8,9 +8,10 @@ Extracted from server.py for better modularity.
 import json
 import os
 import re
-import subprocess
 import sys
 from pathlib import Path
+
+from skill_seekers.mcp.tools.subprocess_utils import run_subprocess_with_streaming
 
 try:
     from mcp.types import TextContent
@@ -26,60 +27,6 @@ except ImportError:
 
 # Path to CLI tools
 CLI_DIR = Path(__file__).parent.parent.parent / "cli"
-
-
-def run_subprocess_with_streaming(cmd: list[str], timeout: int = None) -> tuple[str, str, int]:
-    """
-    Run subprocess w/o pipe buffering and real-time output streaming.
-
-    Uses stdout/stderr threads to read output as it comes, preventing hanging on large outputs.
-
-    Args:
-        cmd: Command to run as list of strings
-        timeout: Maximum time to wait in seconds (None for no timeout)
-
-    Returns:
-        Tuple of (stdout, stderr, returncode)
-    """
-    import threading
-
-    try:
-        process = subprocess.Popen(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            universal_newlines=True,
-        )
-
-        stdout_lines: list[str] = []
-        stderr_lines: list[str] = []
-
-        def _read(stream, target: list[str]) -> None:
-            for line in stream:
-                target.append(line)
-
-        t_out = threading.Thread(target=_read, args=(process.stdout, stdout_lines))
-        t_err = threading.Thread(target=_read, args=(process.stderr, stderr_lines))
-        t_out.daemon = True
-        t_err.daemon = True
-        t_out.start()
-        t_err.start()
-
-        try:
-            process.wait(timeout=timeout)
-        except subprocess.TimeoutExpired:
-            process.kill()
-            process.wait()  # Ensure process has terminated
-            stderr_lines.append(f"\nTimeout: process killed after exceeding {timeout} seconds.")
-
-        t_out.join()
-        t_err.join()
-
-        return "".join(stdout_lines), "".join(stderr_lines), process.returncode or 0
-
-    except Exception as e:
-        return "", f"Error running subprocess: {str(e)}", 1
 
 
 async def package_skill_tool(args: dict) -> list[TextContent]:

--- a/src/skill_seekers/mcp/tools/scraping_tools.py
+++ b/src/skill_seekers/mcp/tools/scraping_tools.py
@@ -19,6 +19,8 @@ import logging
 import sys
 from pathlib import Path
 
+from skill_seekers.mcp.tools.subprocess_utils import run_subprocess_with_streaming
+
 # MCP types - with graceful fallback for testing
 try:
     from mcp.types import TextContent
@@ -76,85 +78,6 @@ def _run_converter(converter, progress_msg: str) -> list:
                 text=f"{output}\n\n❌ Converter returned non-zero exit code ({result})",
             )
         ]
-
-
-def run_subprocess_with_streaming(cmd: list[str], timeout: int = None) -> tuple:
-    """
-    Run subprocess with real-time output streaming.
-
-    This solves the blocking issue where long-running processes (like scraping)
-    would cause MCP to appear frozen. Now we stream output as it comes.
-
-    Args:
-        cmd: Command list to execute
-        timeout: Optional timeout in seconds
-
-    Returns:
-        Tuple of (stdout, stderr, returncode)
-    """
-    import subprocess
-    import time
-
-    try:
-        process = subprocess.Popen(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            bufsize=1,  # Line buffered
-            universal_newlines=True,
-        )
-
-        stdout_lines = []
-        stderr_lines = []
-        start_time = time.time()
-
-        # Read output line by line as it comes
-        while True:
-            # Check timeout
-            if timeout and (time.time() - start_time) > timeout:
-                process.kill()
-                stderr_lines.append(f"\n⚠️ Process killed after {timeout}s timeout")
-                break
-
-            # Check if process finished
-            if process.poll() is not None:
-                break
-
-            # Read available output (non-blocking)
-            try:
-                import select
-
-                readable, _, _ = select.select([process.stdout, process.stderr], [], [], 0.1)
-
-                if process.stdout in readable:
-                    line = process.stdout.readline()
-                    if line:
-                        stdout_lines.append(line)
-
-                if process.stderr in readable:
-                    line = process.stderr.readline()
-                    if line:
-                        stderr_lines.append(line)
-            except Exception:
-                # Fallback for Windows (no select)
-                time.sleep(0.1)
-
-        # Get any remaining output
-        remaining_stdout, remaining_stderr = process.communicate()
-        if remaining_stdout:
-            stdout_lines.append(remaining_stdout)
-        if remaining_stderr:
-            stderr_lines.append(remaining_stderr)
-
-        stdout = "".join(stdout_lines)
-        stderr = "".join(stderr_lines)
-        returncode = process.returncode
-
-        return stdout, stderr, returncode
-
-    except Exception as e:
-        return "", f"Error running subprocess: {str(e)}", 1
 
 
 async def estimate_pages_tool(args: dict) -> list[TextContent]:

--- a/src/skill_seekers/mcp/tools/splitting_tools.py
+++ b/src/skill_seekers/mcp/tools/splitting_tools.py
@@ -9,6 +9,8 @@ import glob
 import sys
 from pathlib import Path
 
+from skill_seekers.mcp.tools.subprocess_utils import run_subprocess_with_streaming
+
 try:
     from mcp.types import TextContent
 except ImportError:
@@ -23,81 +25,6 @@ except ImportError:
 
 # Path to CLI tools
 CLI_DIR = Path(__file__).parent.parent.parent / "cli"
-
-
-# Import subprocess helper from parent module
-# We'll use a local import to avoid circular dependencies
-def run_subprocess_with_streaming(cmd, timeout=None):
-    """
-    Run subprocess with real-time output streaming.
-    Returns (stdout, stderr, returncode).
-
-    This solves the blocking issue where long-running processes (like scraping)
-    would cause MCP to appear frozen. Now we stream output as it comes.
-    """
-    import subprocess
-    import time
-
-    try:
-        process = subprocess.Popen(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            bufsize=1,  # Line buffered
-            universal_newlines=True,
-        )
-
-        stdout_lines = []
-        stderr_lines = []
-        start_time = time.time()
-
-        # Read output line by line as it comes
-        while True:
-            # Check timeout
-            if timeout and (time.time() - start_time) > timeout:
-                process.kill()
-                stderr_lines.append(f"\n⚠️ Process killed after {timeout}s timeout")
-                break
-
-            # Check if process finished
-            if process.poll() is not None:
-                break
-
-            # Read available output (non-blocking)
-            try:
-                import select
-
-                readable, _, _ = select.select([process.stdout, process.stderr], [], [], 0.1)
-
-                if process.stdout in readable:
-                    line = process.stdout.readline()
-                    if line:
-                        stdout_lines.append(line)
-
-                if process.stderr in readable:
-                    line = process.stderr.readline()
-                    if line:
-                        stderr_lines.append(line)
-            except Exception:
-                # Fallback for Windows (no select)
-                time.sleep(0.1)
-
-        # Get any remaining output
-        remaining_stdout, remaining_stderr = process.communicate()
-        if remaining_stdout:
-            stdout_lines.append(remaining_stdout)
-        if remaining_stderr:
-            stderr_lines.append(remaining_stderr)
-
-        stdout = "".join(stdout_lines)
-        stderr = "".join(stderr_lines)
-        returncode = process.returncode
-
-        return stdout, stderr, returncode
-
-    except Exception as e:
-        return "", f"Error running subprocess: {str(e)}", 1
 
 
 async def split_config(args: dict) -> list[TextContent]:

--- a/src/skill_seekers/mcp/tools/subprocess_utils.py
+++ b/src/skill_seekers/mcp/tools/subprocess_utils.py
@@ -1,0 +1,75 @@
+"""
+Shared subprocess helper for MCP tools.
+
+Runs a subprocess while concurrently draining stdout/stderr on reader threads,
+so a child that produces a lot of output never deadlocks on a full OS pipe
+buffer. This replaces the old ``select``-based polling loop, which did not work
+on Windows (``select`` does not support pipes there) and would freeze on large
+outputs such as documentation scraping.
+
+All MCP tool modules import ``run_subprocess_with_streaming`` from here so the
+implementation lives in exactly one place.
+"""
+
+import subprocess
+import threading
+
+# Grace period (seconds) for the reader threads to drain buffered output once
+# the process has exited or been killed. Normally they hit EOF immediately when
+# the write ends close; the bound prevents a grandchild that inherited the pipe
+# from hanging the caller forever (so ``timeout`` always bounds wall-clock).
+_DRAIN_GRACE_SECONDS = 10
+
+
+def run_subprocess_with_streaming(cmd: list[str], timeout: int = None) -> tuple[str, str, int]:
+    """
+    Run a subprocess, streaming stdout/stderr via concurrent reader threads.
+
+    The reader threads keep the OS pipe buffers drained, so the child never
+    blocks writing to a full pipe (the deadlock the old ``select`` loop hit on
+    Windows). On timeout the process is killed and a marker is appended to
+    stderr.
+
+    Args:
+        cmd: Command to run as a list of strings.
+        timeout: Maximum seconds to wait (None for no timeout).
+
+    Returns:
+        Tuple of (stdout, stderr, returncode).
+    """
+    try:
+        process = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
+        stdout_lines: list[str] = []
+        stderr_lines: list[str] = []
+
+        def _read(stream, target: list[str]) -> None:
+            for line in stream:
+                target.append(line)
+
+        t_out = threading.Thread(target=_read, args=(process.stdout, stdout_lines), daemon=True)
+        t_err = threading.Thread(target=_read, args=(process.stderr, stderr_lines), daemon=True)
+        t_out.start()
+        t_err.start()
+
+        try:
+            process.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait()  # Ensure the process has terminated
+            stderr_lines.append(f"\nTimeout: process killed after exceeding {timeout} seconds.")
+
+        # Bounded join: the threads normally finish as soon as the write ends
+        # close; the grace stops an inherited-pipe grandchild from hanging us.
+        t_out.join(_DRAIN_GRACE_SECONDS)
+        t_err.join(_DRAIN_GRACE_SECONDS)
+
+        return "".join(stdout_lines), "".join(stderr_lines), process.returncode or 0
+
+    except Exception as e:
+        return "", f"Error running subprocess: {str(e)}", 1

--- a/tests/test_mcp_fastmcp.py
+++ b/tests/test_mcp_fastmcp.py
@@ -450,8 +450,10 @@ class TestPackagingTools:
         skill_dir.mkdir()
         (skill_dir / "SKILL.md").write_text("# Test Skill")
 
-        with patch("skill_seekers.mcp.tools.packaging_tools.subprocess.run") as mock_run:
-            mock_run.return_value = Mock(returncode=0, stdout="Packaging completed")
+        with patch(
+            "skill_seekers.mcp.tools.packaging_tools.run_subprocess_with_streaming"
+        ) as mock_run:
+            mock_run.return_value = ("Packaging completed", "", 0)
 
             result = await server_fastmcp.package_skill(skill_dir=str(skill_dir), auto_upload=False)
 
@@ -473,8 +475,10 @@ class TestPackagingTools:
         zip_path = temp_dirs["output"] / "test-skill.zip"
         zip_path.write_text("fake zip content")
 
-        with patch("skill_seekers.mcp.tools.packaging_tools.subprocess.run") as mock_run:
-            mock_run.return_value = Mock(returncode=0, stdout="Upload successful")
+        with patch(
+            "skill_seekers.mcp.tools.packaging_tools.run_subprocess_with_streaming"
+        ) as mock_run:
+            mock_run.return_value = ("Upload successful", "", 0)
 
             result = await server_fastmcp.upload_skill(skill_zip=str(zip_path))
 

--- a/tests/test_subprocess_with_streaming.py
+++ b/tests/test_subprocess_with_streaming.py
@@ -58,5 +58,54 @@ class TestRunSubprocessStreaming(unittest.TestCase):
         self.assertEqual(returncode, 42)
 
 
+class TestSharedHelperIsDeduplicated(unittest.TestCase):
+    """All MCP tool modules must route through the single shared helper.
+
+    Guards against the regression where the streaming fix was applied to one
+    copy while three duplicate definitions kept the old (Windows-deadlocking)
+    implementation.
+    """
+
+    def test_tool_modules_use_shared_helper(self):
+        from skill_seekers.mcp.tools import (
+            subprocess_utils,
+            packaging_tools,
+            scraping_tools,
+            splitting_tools,
+        )
+
+        shared = subprocess_utils.run_subprocess_with_streaming
+        self.assertIs(packaging_tools.run_subprocess_with_streaming, shared)
+        self.assertIs(scraping_tools.run_subprocess_with_streaming, shared)
+        self.assertIs(splitting_tools.run_subprocess_with_streaming, shared)
+
+    def test_server_legacy_uses_shared_helper(self):
+        from skill_seekers.mcp.tools import subprocess_utils
+        from skill_seekers.mcp import server_legacy
+
+        self.assertIs(
+            server_legacy.run_subprocess_with_streaming,
+            subprocess_utils.run_subprocess_with_streaming,
+        )
+
+    def test_no_duplicate_definitions_remain(self):
+        """Only subprocess_utils should *define* the helper (others import it)."""
+        import inspect
+        from skill_seekers.mcp.tools import (
+            subprocess_utils,
+            packaging_tools,
+            scraping_tools,
+            splitting_tools,
+        )
+
+        for module in (packaging_tools, scraping_tools, splitting_tools):
+            fn = module.run_subprocess_with_streaming
+            self.assertEqual(
+                inspect.getmodule(fn).__name__,
+                subprocess_utils.__name__,
+                f"{module.__name__} should import the helper, not redefine it",
+            )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_subprocess_with_streaming.py
+++ b/tests/test_subprocess_with_streaming.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""
+Tests for run_subprocess_streaming function in packaging_tools.py
+
+Verifies the function does not hang due to pipe buffering issues and correctly captures stdout, stderr, and return code.
+"""
+
+import sys
+import unittest
+
+from skill_seekers.mcp.tools.packaging_tools import run_subprocess_with_streaming
+
+
+class TestRunSubprocessStreaming(unittest.TestCase):
+    """
+    Unit test for cross-platform subprocess streaming function.
+    """
+
+    def test_does_not_hang_on_buffering(self):
+        """Subprocesses should write >64KB of data."""
+        # Generate more than allowed amount of data
+        cmd = [sys.executable, "-c", 'for i in range(2000): print("x" * 100)']
+
+        stdout, stderr, returncode = run_subprocess_with_streaming(cmd, timeout=10)
+
+        self.assertEqual(returncode, 0, f"Timed out or failed: {stderr}")
+        self.assertGreater(len(stdout), 100_000, "Expected more than 64KB of stdout")
+
+    def test_timeout(self):
+        """Subprocess should timeout if it runs too long."""
+        cmd = [sys.executable, "-c", "import time; time.sleep(5)"]
+
+        _stdout, stderr, returncode = run_subprocess_with_streaming(cmd, timeout=2)
+
+        self.assertIn("timeout", stderr.lower())
+        self.assertIsNotNone(returncode)
+
+    def test_capture_stdout_stderr(self):
+        """Subprocess should capture both stdout and stderr"""
+        cmd = [
+            sys.executable,
+            "-c",
+            'import sys; print("Hello stdout"); print("Hello stderr", file=sys.stderr)',
+        ]
+
+        stdout, stderr, returncode = run_subprocess_with_streaming(cmd, timeout=5)
+
+        self.assertIn("Hello stdout", stdout)
+        self.assertIn("Hello stderr", stderr)
+        self.assertEqual(returncode, 0)
+
+    def test_exit_code(self):
+        """Subprocess should return correct exit code"""
+        cmd = [sys.executable, "-c", "import sys; sys.exit(42)"]
+
+        _stdout, _stderr, returncode = run_subprocess_with_streaming(cmd, timeout=5)
+
+        self.assertEqual(returncode, 42)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 📋 Description

Replaced select.select() loop with stdout/stderr threads as Windows doesn't support piping output to sockets. This prevents the subprocess output from not getting read correctly and freezing the main process which would cause long timeouts during packaging.

Adds regression tests for large outputs (>100 KB), timouts, stream capture, and exit code preservation. Includes `threading` from stdlib, no new dependencies. The return signature `(stdout, stderr, returncode)` is all unchanged, callers require no modification.

## 🎯 Type of Change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## ✅ Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published

## 🧪 Testing

Added `tests/test_subprocess_with_streaming.py` with 4 regression tests:

| Test | What it proves |
|---|---|
| `test_does_not_hang_on_buffering` | Subprocess writing ~200 KB completes in <10s (previously locked) |
| `test_timeout` | Timed-out process is killed and stderr contains "timeout" |
| `test_capture_stdout_stderr` | Both streams are returned correctly |
| `test_exit_code` | Non-zero exit codes are preserved |

**Test Configuration:**

All test functions pass on Windows (Python 3.12). No new failures.

## 📸 Screenshots (if applicable)

Add screenshots to demonstrate visual changes.

## 📝 Additional Notes

This is my first open-source contribution. I'd be happy to make any changes based on review feedback :)