### PR TITLE
feat(package): add --model to override package metadata model

### DIFF
--- a/docs/integrations/MINIMAX_INTEGRATION.md
+++ b/docs/integrations/MINIMAX_INTEGRATION.md
@@ -81,8 +81,8 @@ This step:
 # Package as MiniMax-compatible ZIP
 skill-seekers package output/react/ --target minimax
 
-# Custom output path
-skill-seekers package output/react/ --target minimax --output my-skill.zip
+# Pin a specific model in the package metadata (default: MiniMax-M3)
+skill-seekers package output/react/ --target minimax --model MiniMax-M2.7
 ```
 
 **Output structure:**

--- a/src/skill_seekers/cli/arguments/package.py
+++ b/src/skill_seekers/cli/arguments/package.py
@@ -67,6 +67,19 @@ PACKAGE_ARGUMENTS: dict[str, dict[str, Any]] = {
             "metavar": "PLATFORM",
         },
     },
+    "model": {
+        "flags": ("--model",),
+        "kwargs": {
+            "type": str,
+            "default": None,
+            "help": (
+                "Override the model recorded in the package metadata for the "
+                "target platform, e.g. 'MiniMax-M2.7'. Defaults to the "
+                "platform's default model."
+            ),
+            "metavar": "MODEL",
+        },
+    },
     "upload": {
         "flags": ("--upload",),
         "kwargs": {

--- a/src/skill_seekers/cli/package_skill.py
+++ b/src/skill_seekers/cli/package_skill.py
@@ -42,6 +42,7 @@ def package_skill(
     open_folder_after=True,
     skip_quality_check=False,
     target="claude",
+    model=None,
     streaming=False,
     chunk_size=4000,
     chunk_overlap=200,
@@ -59,6 +60,7 @@ def package_skill(
         open_folder_after: Whether to open the output folder after packaging
         skip_quality_check: Skip quality checks before packaging
         target: Target LLM platform ('claude', 'gemini', 'openai', 'markdown')
+        model: Override the model recorded in package metadata (platform default if None)
         streaming: Use streaming ingestion for large docs
         chunk_size: Maximum characters per chunk (streaming mode)
         chunk_overlap: Overlap between chunks (streaming mode)
@@ -106,7 +108,7 @@ def package_skill(
     try:
         from skill_seekers.cli.adaptors import get_adaptor
 
-        adaptor = get_adaptor(target)
+        adaptor = get_adaptor(target, {"custom_model": model} if model else None)
     except (ImportError, ValueError) as e:
         print(f"❌ Error: {e}")
         return False, None
@@ -231,6 +233,7 @@ Examples:
         open_folder_after=not args.no_open,
         skip_quality_check=args.skip_quality_check,
         target=args.target,
+        model=args.model,
         streaming=args.streaming,
         chunk_size=args.streaming_chunk_chars,
         chunk_overlap=args.streaming_overlap_chars,
@@ -250,7 +253,7 @@ Examples:
             from skill_seekers.cli.adaptors import get_adaptor
 
             # Get adaptor for target platform
-            adaptor = get_adaptor(args.target)
+            adaptor = get_adaptor(args.target, {"custom_model": args.model} if args.model else None)
 
             # Get API key from environment
             api_key = os.environ.get(adaptor.get_env_var_name(), "").strip()

--- a/tests/test_package_skill.py
+++ b/tests/test_package_skill.py
@@ -73,6 +73,55 @@ class TestPackageSkill(unittest.TestCase):
                 self.assertTrue(any("references/index.md" in name for name in names))
                 self.assertTrue(any("references/getting_started.md" in name for name in names))
 
+    def test_package_model_override_recorded_in_metadata(self):
+        """`package --target minimax --model X` records X in the package metadata."""
+        import json
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = self.create_test_skill_directory(tmpdir)
+
+            success, zip_path = package_skill(
+                skill_dir,
+                open_folder_after=False,
+                skip_quality_check=True,
+                target="minimax",
+                model="MiniMax-M2.7",
+            )
+
+            self.assertTrue(success)
+            with zipfile.ZipFile(zip_path, "r") as zf:
+                metadata = json.loads(zf.read("minimax_metadata.json").decode("utf-8"))
+            self.assertEqual(metadata["model"], "MiniMax-M2.7")
+
+    def test_package_default_model_when_no_override(self):
+        """Without --model, the package metadata keeps the platform default."""
+        import json
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = self.create_test_skill_directory(tmpdir)
+
+            success, zip_path = package_skill(
+                skill_dir,
+                open_folder_after=False,
+                skip_quality_check=True,
+                target="minimax",
+            )
+
+            self.assertTrue(success)
+            with zipfile.ZipFile(zip_path, "r") as zf:
+                metadata = json.loads(zf.read("minimax_metadata.json").decode("utf-8"))
+            self.assertEqual(metadata["model"], "MiniMax-M3")
+
+    def test_package_arguments_accept_model_flag(self):
+        """The package CLI parser exposes --model."""
+        import argparse
+        from skill_seekers.cli.arguments.package import add_package_arguments
+
+        parser = argparse.ArgumentParser()
+        add_package_arguments(parser)
+        args = parser.parse_args(["output/react", "--target", "minimax", "--model", "MiniMax-M2.7"])
+        self.assertEqual(args.model, "MiniMax-M2.7")
+
     def test_package_excludes_backup_files(self):
         """Test that .backup files are excluded from zip"""
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Description

Follow-up to #395. That PR added `--model` to `enhance`; this mirrors it on `package`.

The OpenAI-compatible adaptors already resolve `config["custom_model"]` via `_resolve_model()`, but `package` never passed it — so the model recorded in package metadata (e.g. `minimax_metadata.json` `"model"`) was always the platform default with no way to override.

## Changes

- `arguments/package.py` — new `--model MODEL` flag
- `package_skill.py` — `package_skill(..., model=None)`; threads `get_adaptor(target, {"custom_model": model})` for both packaging and the `--upload` path
- `docs/integrations/MINIMAX_INTEGRATION.md` — Step 3 shows `--model MiniMax-M2.7` (replaces a stale `--output` example)

## Behavior

```bash
skill-seekers package output/react/ --target minimax --model MiniMax-M2.7
# -> minimax_metadata.json "model": "MiniMax-M2.7"  (default stays MiniMax-M3)
```

## Testing

3 new TDD tests in `tests/test_package_skill.py` (override recorded, default kept, parser exposes `--model`). Verified end-to-end through the installed CLI.

## Notes

The MCP `package_skill` tool does not yet expose `model` — left as a follow-up to avoid pulling the MCP suite into this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)