### PR TITLE
feat: derive install/upload/package targets from the adaptor registry

### DIFF
--- a/src/skill_seekers/cli/adaptors/__init__.py
+++ b/src/skill_seekers/cli/adaptors/__init__.py
@@ -236,6 +236,27 @@ def get_enhancement_platforms() -> list[str]:
     return platforms
 
 
+def get_upload_platforms() -> list[str]:
+    """
+    List platforms whose adaptor performs a real upload/push.
+
+    Derived from each adaptor's ``supports_upload()`` so the upload command's
+    ``--target`` choices can never drift from the adaptors that actually upload
+    (unlike a hand-maintained list).
+
+    Returns:
+        Platform identifiers in registry order.
+    """
+    platforms = []
+    for name, adaptor_class in ADAPTORS.items():
+        try:
+            if adaptor_class().supports_upload():
+                platforms.append(name)
+        except Exception:
+            continue
+    return platforms
+
+
 def is_platform_available(platform: str) -> bool:
     """
     Check if a platform adaptor is available.
@@ -262,6 +283,7 @@ __all__ = [
     "get_adaptor",
     "list_platforms",
     "get_enhancement_platforms",
+    "get_upload_platforms",
     "is_platform_available",
     "ADAPTORS",
 ]

--- a/src/skill_seekers/cli/adaptors/base.py
+++ b/src/skill_seekers/cli/adaptors/base.py
@@ -154,6 +154,21 @@ class SkillAdaptor(ABC):
         """
         return False
 
+    def supports_upload(self) -> bool:
+        """
+        Whether this platform's ``upload()`` performs a real upload/push.
+
+        Default is False. Adaptors whose ``upload()`` only returns an
+        "unsupported" message (e.g. markdown, or vector-DB adaptors that direct
+        users to a client library) leave this False; only adaptors that actually
+        push to a remote platform override it to True. Used to derive the
+        ``--target`` choices for the upload command from the registry.
+
+        Returns:
+            True if platform can upload skills
+        """
+        return False
+
     def enhance(self, _skill_dir: Path, _api_key: str) -> bool:
         """
         Optionally enhance SKILL.md using platform's AI.

--- a/src/skill_seekers/cli/adaptors/chroma.py
+++ b/src/skill_seekers/cli/adaptors/chroma.py
@@ -378,6 +378,10 @@ class ChromaAdaptor(SkillAdaptor):
         """
         return ""
 
+    def supports_upload(self) -> bool:
+        """Chroma supports pushing documents to a ChromaDB instance."""
+        return True
+
     def supports_enhancement(self) -> bool:
         """
         Chroma format doesn't support AI enhancement.

--- a/src/skill_seekers/cli/adaptors/claude.py
+++ b/src/skill_seekers/cli/adaptors/claude.py
@@ -307,6 +307,10 @@ version: {metadata.version}
         """
         return "ANTHROPIC_API_KEY"
 
+    def supports_upload(self) -> bool:
+        """Claude supports uploading skills via the Anthropic API."""
+        return True
+
     def supports_enhancement(self) -> bool:
         """
         Claude supports AI enhancement via Anthropic API.

--- a/src/skill_seekers/cli/adaptors/gemini.py
+++ b/src/skill_seekers/cli/adaptors/gemini.py
@@ -279,6 +279,10 @@ See the references directory for complete documentation with examples and best p
         """
         return "GOOGLE_API_KEY"
 
+    def supports_upload(self) -> bool:
+        """Gemini supports uploading skills via the Gemini API."""
+        return True
+
     def supports_enhancement(self) -> bool:
         """
         Gemini supports AI enhancement via Gemini 2.5 Flash.

--- a/src/skill_seekers/cli/adaptors/openai.py
+++ b/src/skill_seekers/cli/adaptors/openai.py
@@ -321,6 +321,10 @@ Always prioritize accuracy by consulting the attached documentation files before
         """
         return "OPENAI_API_KEY"
 
+    def supports_upload(self) -> bool:
+        """OpenAI supports uploading assistants via the OpenAI API."""
+        return True
+
     def supports_enhancement(self) -> bool:
         """
         OpenAI supports AI enhancement via GPT-4o.

--- a/src/skill_seekers/cli/adaptors/openai_compatible.py
+++ b/src/skill_seekers/cli/adaptors/openai_compatible.py
@@ -280,6 +280,10 @@ Always prioritize accuracy by consulting the attached documentation files before
         """Get environment variable name for API key."""
         return self.ENV_VAR_NAME
 
+    def supports_upload(self) -> bool:
+        """OpenAI-compatible platforms support uploading via their API."""
+        return True
+
     def supports_enhancement(self) -> bool:
         """OpenAI-compatible platforms support enhancement."""
         return True

--- a/src/skill_seekers/cli/adaptors/pinecone_adaptor.py
+++ b/src/skill_seekers/cli/adaptors/pinecone_adaptor.py
@@ -440,6 +440,10 @@ class PineconeAdaptor(SkillAdaptor):
         """Return the expected env var for Pinecone API key."""
         return "PINECONE_API_KEY"
 
+    def supports_upload(self) -> bool:
+        """Pinecone supports upserting vectors to a Pinecone index."""
+        return True
+
     def supports_enhancement(self) -> bool:
         """Pinecone format doesn't support AI enhancement."""
         return False

--- a/src/skill_seekers/cli/adaptors/weaviate.py
+++ b/src/skill_seekers/cli/adaptors/weaviate.py
@@ -463,6 +463,10 @@ class WeaviateAdaptor(SkillAdaptor):
         """
         return ""
 
+    def supports_upload(self) -> bool:
+        """Weaviate supports pushing objects to a Weaviate instance."""
+        return True
+
     def supports_enhancement(self) -> bool:
         """
         Weaviate format doesn't support AI enhancement.

--- a/src/skill_seekers/cli/arguments/package.py
+++ b/src/skill_seekers/cli/arguments/package.py
@@ -38,30 +38,9 @@ PACKAGE_ARGUMENTS: dict[str, dict[str, Any]] = {
     "target": {
         "flags": ("--target",),
         "kwargs": {
+            # choices is filled at parser-build time from list_platforms() so it
+            # can never drift from the ADAPTORS registry.
             "type": str,
-            "choices": [
-                "claude",
-                "gemini",
-                "openai",
-                "kimi",
-                "minimax",
-                "opencode",
-                "deepseek",
-                "qwen",
-                "openrouter",
-                "together",
-                "fireworks",
-                "ibm-bob",
-                "markdown",
-                "langchain",
-                "llama-index",
-                "haystack",
-                "weaviate",
-                "chroma",
-                "faiss",
-                "qdrant",
-                "pinecone",
-            ],
             "default": None,
             "help": "Target LLM platform (auto-detected from API keys, or 'markdown' if none set)",
             "metavar": "PLATFORM",
@@ -185,10 +164,21 @@ PACKAGE_ARGUMENTS: dict[str, dict[str, Any]] = {
 
 
 def add_package_arguments(parser: argparse.ArgumentParser) -> None:
-    """Add all package command arguments to a parser."""
+    """Add all package command arguments to a parser.
+
+    The ``--target`` choices are resolved dynamically from the ADAPTORS registry
+    (``list_platforms()``) so newly registered platforms are accepted without
+    touching this list.
+    """
+    from skill_seekers.cli.adaptors import list_platforms
+
+    platforms = list_platforms()
+
     for arg_name, arg_def in PACKAGE_ARGUMENTS.items():
         flags = arg_def["flags"]
-        kwargs = arg_def["kwargs"]
+        kwargs = dict(arg_def["kwargs"])
+        if arg_name == "target":
+            kwargs["choices"] = platforms
         parser.add_argument(*flags, **kwargs)
 
     # Deprecated alias for backward compatibility (removed in v4.0.0)

--- a/src/skill_seekers/cli/arguments/upload.py
+++ b/src/skill_seekers/cli/arguments/upload.py
@@ -21,8 +21,9 @@ UPLOAD_ARGUMENTS: dict[str, dict[str, Any]] = {
     "target": {
         "flags": ("--target",),
         "kwargs": {
+            # choices is filled at parser-build time from get_upload_platforms()
+            # so it can never drift from the adaptors that actually upload.
             "type": str,
-            "choices": ["claude", "gemini", "openai", "kimi", "chroma", "weaviate"],
             "default": None,
             "help": "Target platform (auto-detected from API keys, or 'claude' if none set)",
             "metavar": "PLATFORM",
@@ -100,8 +101,19 @@ UPLOAD_ARGUMENTS: dict[str, dict[str, Any]] = {
 
 
 def add_upload_arguments(parser: argparse.ArgumentParser) -> None:
-    """Add all upload command arguments to a parser."""
+    """Add all upload command arguments to a parser.
+
+    The ``--target`` choices are resolved dynamically from the adaptors that
+    report ``supports_upload()`` so newly added upload-capable platforms are
+    accepted without touching this list.
+    """
+    from skill_seekers.cli.adaptors import get_upload_platforms
+
+    upload_platforms = get_upload_platforms()
+
     for arg_name, arg_def in UPLOAD_ARGUMENTS.items():
         flags = arg_def["flags"]
-        kwargs = arg_def["kwargs"]
+        kwargs = dict(arg_def["kwargs"])
+        if arg_name == "target":
+            kwargs["choices"] = upload_platforms
         parser.add_argument(*flags, **kwargs)

--- a/src/skill_seekers/cli/enhance_command.py
+++ b/src/skill_seekers/cli/enhance_command.py
@@ -76,8 +76,10 @@ def _pick_mode(args) -> tuple[str, str | None]:
         return "api", target
 
     # 2. Config default_agent preference (if a matching key is available).
+    from skill_seekers.cli.adaptors import get_enhancement_platforms
+
     config_agent = _get_config_default_agent()
-    if config_agent in ("claude", "gemini", "openai", "kimi") and api_keys.get(config_agent):
+    if config_agent in get_enhancement_platforms() and api_keys.get(config_agent):
         return "api", config_agent
 
     # 3. Auto-detect from environment variables.

--- a/src/skill_seekers/cli/install_skill.py
+++ b/src/skill_seekers/cli/install_skill.py
@@ -119,9 +119,13 @@ Phases:
 
     parser.add_argument("--dry-run", action="store_true", help="Preview workflow without executing")
 
+    from skill_seekers.cli.adaptors import get_enhancement_platforms
+
     parser.add_argument(
         "--target",
-        choices=["claude", "gemini", "openai", "kimi", "markdown"],
+        # install requires AI enhancement, so targets are the enhancement-capable
+        # platforms (derived from the registry) plus markdown (export-only).
+        choices=get_enhancement_platforms() + ["markdown"],
         default=None,
         help="Target LLM platform (auto-detected from API keys, or 'claude' if none set)",
     )

--- a/src/skill_seekers/cli/upload_skill.py
+++ b/src/skill_seekers/cli/upload_skill.py
@@ -160,9 +160,13 @@ Examples:
 
     parser.add_argument("package_file", help="Path to skill package file (e.g., output/react.zip)")
 
+    from skill_seekers.cli.adaptors import get_upload_platforms
+
     parser.add_argument(
         "--target",
-        choices=["claude", "gemini", "openai", "kimi", "chroma", "weaviate"],
+        # derived from adaptors that report supports_upload() so the list can't
+        # drift from the adaptors that actually upload.
+        choices=get_upload_platforms(),
         default=None,
         help="Target platform (auto-detected from API keys, or 'claude' if none set)",
     )

--- a/tests/test_pinecone_adaptor.py
+++ b/tests/test_pinecone_adaptor.py
@@ -858,11 +858,14 @@ class TestPineconeInPackageChoices:
     """Test pinecone is in package CLI choices."""
 
     def test_pinecone_in_package_arguments(self):
-        """pinecone is listed in package --target choices."""
-        from skill_seekers.cli.arguments.package import PACKAGE_ARGUMENTS
+        """pinecone is listed in package --target choices (now registry-derived)."""
+        import argparse
+        from skill_seekers.cli.arguments.package import add_package_arguments
 
-        choices = PACKAGE_ARGUMENTS["target"]["kwargs"]["choices"]
-        assert "pinecone" in choices
+        parser = argparse.ArgumentParser()
+        add_package_arguments(parser)
+        target = next(a for a in parser._actions if a.dest == "target")
+        assert "pinecone" in target.choices
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_registry_platform_lists.py
+++ b/tests/test_registry_platform_lists.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""
+Tests for registry-derived platform lists.
+
+Guards against the "hardcoded list drifts from the ADAPTORS registry" bug class
+(the same one fixed for `enhance` in #395) now applied to upload/install/package:
+platform choices must be derived from adaptor capabilities, not hand-maintained.
+"""
+
+import argparse
+import unittest
+
+from skill_seekers.cli.adaptors import (
+    get_adaptor,
+    get_enhancement_platforms,
+    get_upload_platforms,
+    list_platforms,
+)
+
+
+class TestSupportsUpload(unittest.TestCase):
+    """supports_upload() must be True only for adaptors with a real upload/push."""
+
+    def test_real_uploaders(self):
+        for name in ("claude", "gemini", "openai", "minimax", "chroma", "weaviate", "pinecone"):
+            self.assertTrue(get_adaptor(name).supports_upload(), f"{name} should support upload")
+
+    def test_non_uploaders(self):
+        # markdown + vector-DB stubs explicitly do not perform an upload.
+        for name in ("markdown", "qdrant", "faiss", "langchain", "llama-index", "haystack"):
+            self.assertFalse(
+                get_adaptor(name).supports_upload(), f"{name} should NOT support upload"
+            )
+
+
+class TestGetUploadPlatforms(unittest.TestCase):
+    def test_includes_openai_compatible_family(self):
+        platforms = get_upload_platforms()
+        for name in (
+            "claude",
+            "gemini",
+            "openai",
+            "minimax",
+            "kimi",
+            "deepseek",
+            "qwen",
+            "openrouter",
+            "together",
+            "fireworks",
+            "chroma",
+            "weaviate",
+            "pinecone",
+        ):
+            self.assertIn(name, platforms)
+
+    def test_excludes_stubs(self):
+        platforms = get_upload_platforms()
+        for name in ("markdown", "qdrant", "faiss", "langchain", "haystack"):
+            self.assertNotIn(name, platforms)
+
+    def test_superset_of_legacy_choices_non_breaking(self):
+        """The new derived list must not drop any previously-valid upload target."""
+        legacy = {"claude", "gemini", "openai", "kimi", "chroma", "weaviate"}
+        self.assertTrue(legacy.issubset(set(get_upload_platforms())))
+
+
+class TestEnhancementListUnchanged(unittest.TestCase):
+    def test_minimax_present_markdown_absent(self):
+        platforms = get_enhancement_platforms()
+        self.assertIn("minimax", platforms)
+        self.assertNotIn("markdown", platforms)
+
+
+class TestArgumentBuildersDeriveChoices(unittest.TestCase):
+    """The dict-based builders must inject registry-derived choices."""
+
+    def _parse(self, add_args, argv):
+        parser = argparse.ArgumentParser()
+        add_args(parser)
+        return parser.parse_args(argv)
+
+    def test_upload_accepts_openai_compatible_and_vector(self):
+        from skill_seekers.cli.arguments.upload import add_upload_arguments
+
+        for target in ("minimax", "deepseek", "pinecone"):
+            args = self._parse(add_upload_arguments, ["pkg.zip", "--target", target])
+            self.assertEqual(args.target, target)
+
+    def test_upload_rejects_unknown_target(self):
+        from skill_seekers.cli.arguments.upload import add_upload_arguments
+
+        parser = argparse.ArgumentParser()
+        add_upload_arguments(parser)
+        with self.assertRaises(SystemExit):
+            parser.parse_args(["pkg.zip", "--target", "notaplatform"])
+
+    def test_package_accepts_all_registered_platforms(self):
+        from skill_seekers.cli.arguments.package import add_package_arguments
+
+        for target in ("minimax", "qdrant", "markdown"):
+            args = self._parse(add_package_arguments, ["output/x", "--target", target])
+            self.assertEqual(args.target, target)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_registry_platform_lists.py
+++ b/tests/test_registry_platform_lists.py
@@ -14,7 +14,6 @@ from skill_seekers.cli.adaptors import (
     get_adaptor,
     get_enhancement_platforms,
     get_upload_platforms,
-    list_platforms,
 )
 
 


### PR DESCRIPTION
## Description

Tier 1 of a consolidation effort. Hardcoded platform-choice lists had **drifted from the `ADAPTORS` registry** — the same bug class fixed for `enhance` in #395.

Most importantly this is a **bug fix**: `upload --target` rejected the six OpenAI-compatible platforms (`minimax`, `deepseek`, `qwen`, `openrouter`, `together`, `fireworks`) and `pinecone`, even though all have functional `upload()` implementations.

## Changes

- **New `supports_upload()` capability** on `adaptors/base.py` (default `False`), mirroring `supports_enhancement()`. Overridden `True` on adaptors with a real upload/push: claude, gemini, openai, openai_compatible (→ the 7 OpenAI-compatible subclasses), chroma, weaviate, pinecone. Vector-DB stubs (qdrant/faiss/langchain/llama-index/haystack) and markdown stay `False`.
- **New `get_upload_platforms()`** in `adaptors/__init__.py`, derived from `supports_upload()`.
- Route choices through the registry:
  - `arguments/upload.py` + `upload_skill.py` → `get_upload_platforms()`
  - `arguments/package.py` → `list_platforms()`
  - `install_skill.py` → `get_enhancement_platforms() + ["markdown"]`
  - `enhance_command.py` auto-detect → `get_enhancement_platforms()`

## Behavior

Non-breaking — the new upload list is a **superset** of the old (`claude/gemini/openai/kimi/chroma/weaviate`) plus the 7 previously-unreachable platforms. `skill-seekers upload --target minimax` is now accepted; future adaptors appear automatically.

## Testing

New `tests/test_registry_platform_lists.py` (capability flags + registry-derived choices, non-breaking superset check). Updated the pinecone package-choices test to assert against the built parser. Full non-MCP suite: 3566 passed (only the known network/e2e sandbox failures remain).

## Notes

`skill-seekers install` (unified CLI) has no `--target` argument at all — a separate pre-existing gap, not addressed here. Env-var auto-detection maps for the new platforms (`agent_client.py`/`config_manager.py`) are a separate concern left as follow-up; users can pass `--api-key` explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)