### PR TITLE
refactor(mcp): share TextContent fallback + CLI_DIR via tools/_common.py

### DIFF
--- a/src/skill_seekers/mcp/tools/_common.py
+++ b/src/skill_seekers/mcp/tools/_common.py
@@ -1,0 +1,36 @@
+"""
+Shared boilerplate for MCP tool modules.
+
+Single home for the things every tool module used to duplicate:
+- the `TextContent` import with a graceful fallback when the external `mcp`
+  package is not installed (e.g. during testing),
+- the `CLI_DIR` path to the bundled CLI tools,
+- tiny helpers for the ubiquitous `[TextContent(type="text", text=...)]` return.
+
+Tool modules import from here (like `subprocess_utils.py`) so the boilerplate
+lives in exactly one place.
+"""
+
+from pathlib import Path
+from typing import Any
+
+try:
+    from mcp.types import TextContent
+except ImportError:
+    # Graceful degradation: a minimal fallback so modules import without `mcp`.
+    class TextContent:
+        """Fallback TextContent for when MCP is not installed."""
+
+        def __init__(self, type: str, text: str):
+            self.type = type
+            self.text = text
+
+
+# Path to the bundled CLI tools (src/skill_seekers/cli), resolved relative to
+# this module which lives at src/skill_seekers/mcp/tools/.
+CLI_DIR = Path(__file__).parent.parent.parent / "cli"
+
+
+def text_response(message: str) -> list[Any]:
+    """Wrap a message in the standard single-TextContent list return shape."""
+    return [TextContent(type="text", text=message)]

--- a/src/skill_seekers/mcp/tools/config_tools.py
+++ b/src/skill_seekers/mcp/tools/config_tools.py
@@ -9,20 +9,10 @@ import json
 import sys
 from pathlib import Path
 
-try:
-    from mcp.types import TextContent
-except ImportError:
-    # Graceful degradation: Create a simple fallback class for testing
-    class TextContent:
-        """Fallback TextContent for when MCP is not installed"""
-
-        def __init__(self, type: str, text: str):
-            self.type = type
-            self.text = text
+from skill_seekers.mcp.tools._common import CLI_DIR, TextContent
 
 
 # Path to CLI tools
-CLI_DIR = Path(__file__).parent.parent.parent / "cli"
 
 # Import config validator for validation
 sys.path.insert(0, str(CLI_DIR))

--- a/src/skill_seekers/mcp/tools/marketplace_tools.py
+++ b/src/skill_seekers/mcp/tools/marketplace_tools.py
@@ -9,20 +9,7 @@ This module contains tools for managing plugin marketplace repositories:
 """
 
 # MCP types (imported conditionally)
-try:
-    from mcp.types import TextContent
-
-    MCP_AVAILABLE = True
-except ImportError:
-
-    class TextContent:
-        """Fallback TextContent for when MCP is not installed"""
-
-        def __init__(self, type: str, text: str):
-            self.type = type
-            self.text = text
-
-    MCP_AVAILABLE = False
+from skill_seekers.mcp.tools._common import TextContent
 
 
 async def add_marketplace_tool(args: dict) -> list[TextContent]:

--- a/src/skill_seekers/mcp/tools/packaging_tools.py
+++ b/src/skill_seekers/mcp/tools/packaging_tools.py
@@ -13,20 +13,10 @@ from pathlib import Path
 
 from skill_seekers.mcp.tools.subprocess_utils import run_subprocess_with_streaming
 
-try:
-    from mcp.types import TextContent
-except ImportError:
-    # Graceful degradation: Create a simple fallback class for testing
-    class TextContent:
-        """Fallback TextContent for when MCP is not installed"""
-
-        def __init__(self, type: str, text: str):
-            self.type = type
-            self.text = text
+from skill_seekers.mcp.tools._common import CLI_DIR, TextContent
 
 
 # Path to CLI tools
-CLI_DIR = Path(__file__).parent.parent.parent / "cli"
 
 
 async def package_skill_tool(args: dict) -> list[TextContent]:

--- a/src/skill_seekers/mcp/tools/scraping_tools.py
+++ b/src/skill_seekers/mcp/tools/scraping_tools.py
@@ -22,20 +22,10 @@ from pathlib import Path
 from skill_seekers.mcp.tools.subprocess_utils import run_subprocess_with_streaming
 
 # MCP types - with graceful fallback for testing
-try:
-    from mcp.types import TextContent
-except ImportError:
-    # Graceful degradation: Create a simple fallback class for testing
-    class TextContent:
-        """Fallback TextContent for when MCP is not installed"""
-
-        def __init__(self, type: str, text: str):
-            self.type = type
-            self.text = text
+from skill_seekers.mcp.tools._common import TextContent
 
 
 # Path to CLI tools
-CLI_DIR = Path(__file__).parent.parent.parent / "cli"
 
 
 def _run_converter(converter, progress_msg: str) -> list:

--- a/src/skill_seekers/mcp/tools/source_tools.py
+++ b/src/skill_seekers/mcp/tools/source_tools.py
@@ -15,20 +15,8 @@ import re
 from pathlib import Path
 
 # MCP types (imported conditionally)
-try:
-    from mcp.types import TextContent
+from skill_seekers.mcp.tools._common import CLI_DIR, TextContent
 
-    MCP_AVAILABLE = True
-except ImportError:
-    # Graceful degradation: Create a simple fallback class for testing
-    class TextContent:
-        """Fallback TextContent for when MCP is not installed"""
-
-        def __init__(self, type: str, text: str):
-            self.type = type
-            self.text = text
-
-    MCP_AVAILABLE = False
 
 import httpx
 
@@ -376,7 +364,6 @@ async def submit_config_tool(args: dict) -> list[TextContent]:
         import sys
         from pathlib import Path
 
-        CLI_DIR = Path(__file__).parent.parent.parent / "cli"
         sys.path.insert(0, str(CLI_DIR))
         from config_validator import ConfigValidator
     except ImportError:

--- a/src/skill_seekers/mcp/tools/splitting_tools.py
+++ b/src/skill_seekers/mcp/tools/splitting_tools.py
@@ -7,24 +7,13 @@ focused skills and generating router/hub skills for managing split documentation
 
 import glob
 import sys
-from pathlib import Path
 
 from skill_seekers.mcp.tools.subprocess_utils import run_subprocess_with_streaming
 
-try:
-    from mcp.types import TextContent
-except ImportError:
-    # Graceful degradation: Create a simple fallback class for testing
-    class TextContent:
-        """Fallback TextContent for when MCP is not installed"""
-
-        def __init__(self, type: str, text: str):
-            self.type = type
-            self.text = text
+from skill_seekers.mcp.tools._common import CLI_DIR, TextContent
 
 
 # Path to CLI tools
-CLI_DIR = Path(__file__).parent.parent.parent / "cli"
 
 
 async def split_config(args: dict) -> list[TextContent]:

--- a/src/skill_seekers/mcp/tools/sync_config_tools.py
+++ b/src/skill_seekers/mcp/tools/sync_config_tools.py
@@ -4,16 +4,7 @@ Provides the ``sync_config`` tool that diffs a config's start_urls against
 the live docs site and optionally applies the update.
 """
 
-try:
-    from mcp.types import TextContent
-except ImportError:
-
-    class TextContent:
-        """Fallback TextContent for when MCP is not installed."""
-
-        def __init__(self, type: str, text: str):
-            self.type = type
-            self.text = text
+from skill_seekers.mcp.tools._common import TextContent
 
 
 async def sync_config_tool(args: dict) -> list[TextContent]:

--- a/src/skill_seekers/mcp/tools/vector_db_tools.py
+++ b/src/skill_seekers/mcp/tools/vector_db_tools.py
@@ -13,20 +13,10 @@ Each tool provides a direct interface to its respective vector database adaptor.
 import sys
 from pathlib import Path
 
-try:
-    from mcp.types import TextContent
-except ImportError:
-    # Graceful degradation for testing
-    class TextContent:
-        """Fallback TextContent for when MCP is not installed"""
-
-        def __init__(self, type: str, text: str):
-            self.type = type
-            self.text = text
+from skill_seekers.mcp.tools._common import CLI_DIR, TextContent
 
 
 # Path to CLI adaptors
-CLI_DIR = Path(__file__).parent.parent.parent / "cli"
 sys.path.insert(0, str(CLI_DIR))
 
 try:

--- a/tests/test_mcp_tools_common.py
+++ b/tests/test_mcp_tools_common.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""
+Tests that MCP tool modules share one TextContent fallback and one CLI_DIR.
+
+Guards against the boilerplate being copy-pasted back into each module (the
+class of duplication consolidated into mcp/tools/_common.py).
+"""
+
+import importlib
+import pathlib
+import unittest
+
+# Modules that carried the duplicated TextContent fallback.
+_TEXTCONTENT_MODULES = [
+    "packaging_tools",
+    "scraping_tools",
+    "splitting_tools",
+    "config_tools",
+    "marketplace_tools",
+    "vector_db_tools",
+    "sync_config_tools",
+    "source_tools",
+]
+
+# Modules that actually use CLI_DIR (marketplace_tools and scraping_tools do not).
+_CLI_DIR_MODULES = [
+    "packaging_tools",
+    "splitting_tools",
+    "config_tools",
+    "vector_db_tools",
+    "source_tools",
+]
+
+
+def _mod(name):
+    return importlib.import_module(f"skill_seekers.mcp.tools.{name}")
+
+
+class TestSharedCommon(unittest.TestCase):
+    def test_textcontent_is_shared(self):
+        from skill_seekers.mcp.tools import _common
+
+        for name in _TEXTCONTENT_MODULES:
+            self.assertIs(
+                _mod(name).TextContent,
+                _common.TextContent,
+                f"{name}.TextContent should be the shared _common.TextContent",
+            )
+
+    def test_cli_dir_is_shared(self):
+        from skill_seekers.mcp.tools import _common
+
+        for name in _CLI_DIR_MODULES:
+            self.assertIs(
+                _mod(name).CLI_DIR,
+                _common.CLI_DIR,
+                f"{name}.CLI_DIR should be the shared _common.CLI_DIR",
+            )
+
+    def test_no_duplicate_fallback_definitions(self):
+        """The fallback class must live only in _common, not be re-pasted."""
+        for name in _TEXTCONTENT_MODULES:
+            src = pathlib.Path(_mod(name).__file__).read_text()
+            self.assertNotIn(
+                "Fallback TextContent for when MCP is not installed",
+                src,
+                f"{name} should import TextContent from _common, not redefine it",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Tier 2 of the consolidation effort — pure cleanup, no behavior change. The `TextContent` import-with-fallback block was copy-pasted into **8** MCP tool modules, and `CLI_DIR` into several. Consolidated into one `mcp/tools/_common.py` (same precedent as `subprocess_utils.py` from #397).

## Changes

- New **`src/skill_seekers/mcp/tools/_common.py`** exporting `TextContent` (single canonical fallback), `CLI_DIR`, and a `text_response()` helper.
- All 8 tool modules now `from skill_seekers.mcp.tools._common import TextContent`; the 5 modules that actually use `CLI_DIR` import it too.
- `source_tools.py` no longer redefines `CLI_DIR` inside `fetch_config_tool()`.
- Removed dead `MCP_AVAILABLE` flags (assigned, never read) in `marketplace_tools`/`source_tools` and a dead module-level `CLI_DIR` in `scraping_tools` (never referenced).

## Testing

New `tests/test_mcp_tools_common.py` asserts every module shares `_common.TextContent`/`CLI_DIR` and that no module redefines the fallback. MCP suites (`test_mcp_fastmcp` + `test_mcp_server`) green: **108 passed**. No test referenced the removed `MCP_AVAILABLE`/in-function `CLI_DIR`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)