### PR TITLE
refactor(scrapers): share score_code_quality + extract_table_from_html

### DIFF
--- a/src/skill_seekers/cli/asciidoc_scraper.py
+++ b/src/skill_seekers/cli/asciidoc_scraper.py
@@ -30,6 +30,7 @@ except ImportError:
     ASCIIDOC_AVAILABLE = False
 
 from skill_seekers.cli.skill_converter import SkillConverter
+from skill_seekers.cli.scraper_utils import score_code_quality as _score_code_quality
 
 logger = logging.getLogger(__name__)
 
@@ -87,29 +88,6 @@ def infer_description_from_asciidoc(metadata: dict | None = None, name: str = ""
         if name
         else "Use when referencing this documentation"
     )
-
-
-def _score_code_quality(code: str) -> float:
-    """Simple quality heuristic for code blocks (0-10 scale)."""
-    if not code:
-        return 0.0
-    score = 5.0
-    line_count = len(code.strip().split("\n"))
-    if line_count >= 10:
-        score += 2.0
-    elif line_count >= 5:
-        score += 1.0
-    if re.search(r"\b(def |class |function |func |fn )", code):
-        score += 1.5
-    if re.search(r"\b(import |from .+ import|require\(|#include|using )", code):
-        score += 0.5
-    if re.search(r"^    ", code, re.MULTILINE):
-        score += 0.5
-    if re.search(r"[=:{}()\[\]]", code):
-        score += 0.3
-    if len(code) < 30:
-        score -= 2.0
-    return min(10.0, max(0.0, score))
 
 
 class AsciiDocToSkillConverter(SkillConverter):

--- a/src/skill_seekers/cli/chat_scraper.py
+++ b/src/skill_seekers/cli/chat_scraper.py
@@ -43,6 +43,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from skill_seekers.cli.skill_converter import SkillConverter
+from skill_seekers.cli.scraper_utils import score_code_quality as _score_code_quality
 
 # Optional dependency guard — Slack SDK
 try:
@@ -201,41 +202,6 @@ def _check_discord_deps() -> None:
 # ---------------------------------------------------------------------------
 # Helper: code quality scoring (consistent with other scrapers)
 # ---------------------------------------------------------------------------
-
-
-def _score_code_quality(code: str) -> float:
-    """Score code quality on a 0-10 scale using heuristics.
-
-    Args:
-        code: Source code text to score.
-
-    Returns:
-        Float quality score between 0.0 and 10.0.
-    """
-    if not code:
-        return 0.0
-
-    score = 5.0
-    lines = code.strip().split("\n")
-    line_count = len(lines)
-
-    if line_count >= 10:
-        score += 2.0
-    elif line_count >= 5:
-        score += 1.0
-
-    if re.search(r"\b(def |class |function |func |fn )", code):
-        score += 1.5
-    if re.search(r"\b(import |from .+ import|require\(|#include|using )", code):
-        score += 0.5
-    if re.search(r"^    ", code, re.MULTILINE):
-        score += 0.5
-    if re.search(r"[=:{}()\[\]]", code):
-        score += 0.3
-    if len(code) < 30:
-        score -= 2.0
-
-    return min(10.0, max(0.0, score))
 
 
 # ---------------------------------------------------------------------------

--- a/src/skill_seekers/cli/confluence_scraper.py
+++ b/src/skill_seekers/cli/confluence_scraper.py
@@ -51,6 +51,7 @@ except ImportError:
 
 # BeautifulSoup is a core dependency (always available)
 from bs4 import BeautifulSoup, Comment, Tag
+from skill_seekers.cli.scraper_utils import score_code_quality as _score_code_quality
 
 logger = logging.getLogger(__name__)
 
@@ -1878,51 +1879,3 @@ class ConfluenceToSkillConverter(SkillConverter):
 # ──────────────────────────────────────────────────────────────────────────────
 # Module-level helpers
 # ──────────────────────────────────────────────────────────────────────────────
-
-
-def _score_code_quality(code: str) -> float:
-    """Simple quality heuristic for code blocks (0-10 scale).
-
-    Scores based on line count, presence of definitions, imports,
-    indentation, and operator usage. Short snippets are penalised.
-
-    Args:
-        code: Source code string.
-
-    Returns:
-        Quality score between 0.0 and 10.0.
-    """
-    if not code:
-        return 0.0
-
-    score = 5.0
-    lines = code.strip().split("\n")
-    line_count = len(lines)
-
-    # More lines = more substantial
-    if line_count >= 10:
-        score += 2.0
-    elif line_count >= 5:
-        score += 1.0
-
-    # Has function/class definitions
-    if re.search(r"\b(def |class |function |func |fn )", code):
-        score += 1.5
-
-    # Has imports/require
-    if re.search(r"\b(import |from .+ import|require\(|#include|using )", code):
-        score += 0.5
-
-    # Has indentation (structured code)
-    if re.search(r"^    ", code, re.MULTILINE):
-        score += 0.5
-
-    # Has assignment, operators, or common code syntax
-    if re.search(r"[=:{}()\[\]]", code):
-        score += 0.3
-
-    # Very short snippets get penalised
-    if len(code) < 30:
-        score -= 2.0
-
-    return min(10.0, max(0.0, score))

--- a/src/skill_seekers/cli/epub_scraper.py
+++ b/src/skill_seekers/cli/epub_scraper.py
@@ -29,6 +29,8 @@ except ImportError:
 from bs4 import BeautifulSoup, Comment
 
 from .skill_converter import SkillConverter
+from skill_seekers.cli.scraper_utils import score_code_quality as _score_code_quality
+from skill_seekers.cli.scraper_utils import extract_table_from_html as _extract_table_from_html
 
 logger = logging.getLogger(__name__)
 
@@ -1007,71 +1009,3 @@ def _build_section(
         "tables": tables,
         "images": images,
     }
-
-
-def _extract_table_from_html(table_elem) -> dict | None:
-    """Extract headers and rows from a BeautifulSoup <table> element."""
-    headers = []
-    rows = []
-
-    # Try <thead> first for headers
-    thead = table_elem.find("thead")
-    if thead:
-        header_row = thead.find("tr")
-        if header_row:
-            headers = [th.get_text(strip=True) for th in header_row.find_all(["th", "td"])]
-
-    # Body rows
-    tbody = table_elem.find("tbody") or table_elem
-    for row in tbody.find_all("tr"):
-        cells = [td.get_text(strip=True) for td in row.find_all(["td", "th"])]
-        # Skip the header row we already captured
-        if cells and cells != headers:
-            rows.append(cells)
-
-    # If no explicit thead, use first row as header
-    if not headers and rows:
-        headers = rows.pop(0)
-
-    if not headers and not rows:
-        return None
-
-    return {"headers": headers, "rows": rows}
-
-
-def _score_code_quality(code: str) -> float:
-    """Simple quality heuristic for code blocks (0-10 scale)."""
-    if not code:
-        return 0.0
-
-    score = 5.0
-    lines = code.strip().split("\n")
-    line_count = len(lines)
-
-    # More lines = more substantial
-    if line_count >= 10:
-        score += 2.0
-    elif line_count >= 5:
-        score += 1.0
-
-    # Has function/class definitions
-    if re.search(r"\b(def |class |function |func |fn )", code):
-        score += 1.5
-
-    # Has imports/require
-    if re.search(r"\b(import |from .+ import|require\(|#include|using )", code):
-        score += 0.5
-
-    # Has indentation (common in Python, JS, etc.)
-    if re.search(r"^    ", code, re.MULTILINE):
-        score += 0.5
-
-    # Has assignment, operators, or common code syntax
-    if re.search(r"[=:{}()\[\]]", code):
-        score += 0.3
-
-    # Very short snippets get penalized
-    if len(code) < 30:
-        score -= 2.0
-
-    return min(10.0, max(0.0, score))

--- a/src/skill_seekers/cli/html_scraper.py
+++ b/src/skill_seekers/cli/html_scraper.py
@@ -26,6 +26,7 @@ from pathlib import Path
 from bs4 import BeautifulSoup, Comment, Tag
 
 from .skill_converter import SkillConverter
+from skill_seekers.cli.scraper_utils import score_code_quality as _score_code_quality
 
 logger = logging.getLogger(__name__)
 
@@ -1701,51 +1702,3 @@ class HtmlToSkillConverter(SkillConverter):
 # ---------------------------------------------------------------------------
 # Module-level helpers
 # ---------------------------------------------------------------------------
-
-
-def _score_code_quality(code: str) -> float:
-    """Simple quality heuristic for code blocks (0-10 scale).
-
-    Scores based on line count, presence of definitions, imports,
-    indentation, and operator usage. Short snippets are penalized.
-
-    Args:
-        code: Source code string.
-
-    Returns:
-        Quality score between 0.0 and 10.0.
-    """
-    if not code:
-        return 0.0
-
-    score = 5.0
-    lines = code.strip().split("\n")
-    line_count = len(lines)
-
-    # More lines = more substantial
-    if line_count >= 10:
-        score += 2.0
-    elif line_count >= 5:
-        score += 1.0
-
-    # Has function/class definitions
-    if re.search(r"\b(def |class |function |func |fn )", code):
-        score += 1.5
-
-    # Has imports/require
-    if re.search(r"\b(import |from .+ import|require\(|#include|using )", code):
-        score += 0.5
-
-    # Has indentation (structured code)
-    if re.search(r"^    ", code, re.MULTILINE):
-        score += 0.5
-
-    # Has assignment, operators, or common code syntax
-    if re.search(r"[=:{}()\[\]]", code):
-        score += 0.3
-
-    # Very short snippets get penalized
-    if len(code) < 30:
-        score -= 2.0
-
-    return min(10.0, max(0.0, score))

--- a/src/skill_seekers/cli/jupyter_scraper.py
+++ b/src/skill_seekers/cli/jupyter_scraper.py
@@ -29,6 +29,7 @@ except ImportError:
     JUPYTER_AVAILABLE = False
 
 from .skill_converter import SkillConverter
+from skill_seekers.cli.scraper_utils import score_code_quality
 
 logger = logging.getLogger(__name__)
 
@@ -438,7 +439,7 @@ class JupyterToSkillConverter(SkillConverter):
                     {
                         "code": code,
                         "language": lang,
-                        "quality_score": _score_code_quality(code),
+                        "quality_score": score_code_quality(code, notebook_mode=True),
                     }
                 )
         prose_text = code_block_pattern.sub("", text).strip()
@@ -476,7 +477,7 @@ class JupyterToSkillConverter(SkillConverter):
                 {
                     "code": source.strip(),
                     "language": language,
-                    "quality_score": _score_code_quality(source),
+                    "quality_score": score_code_quality(source, notebook_mode=True),
                     "execution_count": execution_count,
                 }
             )
@@ -1058,34 +1059,3 @@ class JupyterToSkillConverter(SkillConverter):
 # ---------------------------------------------------------------------------
 # Module-level helpers
 # ---------------------------------------------------------------------------
-
-
-def _score_code_quality(code: str) -> float:
-    """Simple quality heuristic for code blocks (0–10 scale)."""
-    if not code:
-        return 0.0
-    score = 5.0
-    lines = code.strip().split("\n")
-    line_count = len(lines)
-    if line_count >= 10:
-        score += 2.0
-    elif line_count >= 5:
-        score += 1.0
-    if re.search(r"\b(def |class |function |func |fn )", code):
-        score += 1.5
-    if re.search(r"\b(import |from .+ import|require\(|#include|using )", code):
-        score += 0.5
-    if re.search(r"^    ", code, re.MULTILINE):
-        score += 0.5
-    if re.search(r"[=:{}()\[\]]", code):
-        score += 0.3
-    if re.search(r'""".*?"""|\'\'\'.*?\'\'\'', code, re.DOTALL):
-        score += 0.3
-    if re.search(r"^%", code, re.MULTILINE):
-        score += 0.2
-    if len(code) < 30:
-        score -= 2.0
-    non_magic = [ln for ln in lines if ln.strip() and not ln.strip().startswith(("%", "!"))]
-    if line_count > 0 and not non_magic:
-        score -= 1.0
-    return min(10.0, max(0.0, score))

--- a/src/skill_seekers/cli/pptx_scraper.py
+++ b/src/skill_seekers/cli/pptx_scraper.py
@@ -32,6 +32,7 @@ except ImportError:
     PPTX_AVAILABLE = False
 
 from skill_seekers.cli.skill_converter import SkillConverter
+from skill_seekers.cli.scraper_utils import score_code_quality as _score_code_quality
 
 logger = logging.getLogger(__name__)
 
@@ -1619,52 +1620,3 @@ class PptxToSkillConverter(SkillConverter):
 # ---------------------------------------------------------------------------
 # Module-level helpers
 # ---------------------------------------------------------------------------
-
-
-def _score_code_quality(code: str) -> float:
-    """Score code quality on a 0-10 scale using heuristics.
-
-    Higher scores indicate more substantial, well-structured code.
-    Factors include line count, presence of definitions, imports,
-    indentation, and code syntax characters.
-
-    Args:
-        code: Source code text to score
-
-    Returns:
-        Float quality score between 0.0 and 10.0
-    """
-    if not code:
-        return 0.0
-
-    score = 5.0
-    lines = code.strip().split("\n")
-    line_count = len(lines)
-
-    # More lines = more substantial
-    if line_count >= 10:
-        score += 2.0
-    elif line_count >= 5:
-        score += 1.0
-
-    # Has function/class definitions
-    if re.search(r"\b(def |class |function |func |fn )", code):
-        score += 1.5
-
-    # Has imports/require
-    if re.search(r"\b(import |from .+ import|require\(|#include|using )", code):
-        score += 0.5
-
-    # Has indentation (common in Python, JS, etc.)
-    if re.search(r"^    ", code, re.MULTILINE):
-        score += 0.5
-
-    # Has assignment, operators, or common code syntax
-    if re.search(r"[=:{}()\[\]]", code):
-        score += 0.3
-
-    # Very short snippets get penalized
-    if len(code) < 30:
-        score -= 2.0
-
-    return min(10.0, max(0.0, score))

--- a/src/skill_seekers/cli/scraper_utils.py
+++ b/src/skill_seekers/cli/scraper_utils.py
@@ -1,0 +1,110 @@
+"""
+Shared helpers for the source-type scrapers.
+
+Single home for small utilities that were copy-pasted across many
+``*_scraper.py`` modules:
+
+- ``score_code_quality``: a 0-10 heuristic for code blocks. Six scrapers had a
+  byte-identical version and asciidoc a formatting-only variant; jupyter added
+  notebook-specific rules (docstring/magic-line bonuses, all-magic penalty),
+  now gated behind ``notebook_mode``.
+- ``extract_table_from_html``: pull headers/rows from a BeautifulSoup ``<table>``
+  (was byte-identical in the word and epub scrapers).
+"""
+
+import re
+
+
+def score_code_quality(code: str, *, notebook_mode: bool = False) -> float:
+    """Heuristic quality score for a code block (0.0-10.0).
+
+    Scores on line count, definitions, imports, indentation and operators;
+    short snippets are penalized. With ``notebook_mode=True`` (Jupyter), also
+    rewards docstrings and ``%`` magic lines, and penalizes cells that are
+    entirely ``%``/``!`` magic/shell lines.
+
+    Args:
+        code: Source code string.
+        notebook_mode: Enable Jupyter-notebook-specific scoring rules.
+
+    Returns:
+        Quality score between 0.0 and 10.0.
+    """
+    if not code:
+        return 0.0
+
+    score = 5.0
+    lines = code.strip().split("\n")
+    line_count = len(lines)
+
+    # More lines = more substantial
+    if line_count >= 10:
+        score += 2.0
+    elif line_count >= 5:
+        score += 1.0
+
+    # Has function/class definitions
+    if re.search(r"\b(def |class |function |func |fn )", code):
+        score += 1.5
+
+    # Has imports/require
+    if re.search(r"\b(import |from .+ import|require\(|#include|using )", code):
+        score += 0.5
+
+    # Has indentation (structured code)
+    if re.search(r"^    ", code, re.MULTILINE):
+        score += 0.5
+
+    # Has assignment, operators, or common code syntax
+    if re.search(r"[=:{}()\[\]]", code):
+        score += 0.3
+
+    if notebook_mode:
+        # Has a docstring
+        if re.search(r'""".*?"""|\'\'\'.*?\'\'\'', code, re.DOTALL):
+            score += 0.3
+        # Has a magic line
+        if re.search(r"^%", code, re.MULTILINE):
+            score += 0.2
+
+    # Very short snippets get penalized
+    if len(code) < 30:
+        score -= 2.0
+
+    if notebook_mode:
+        # Penalize cells that are entirely magic/shell commands
+        non_magic = [ln for ln in lines if ln.strip() and not ln.strip().startswith(("%", "!"))]
+        if line_count > 0 and not non_magic:
+            score -= 1.0
+
+    return min(10.0, max(0.0, score))
+
+
+def extract_table_from_html(table_elem) -> dict | None:
+    """Extract headers and rows from a BeautifulSoup <table> element."""
+    headers = []
+    rows = []
+
+    # Try <thead> first for headers
+    thead = table_elem.find("thead")
+    if thead:
+        header_row = thead.find("tr")
+        if header_row:
+            headers = [th.get_text(strip=True) for th in header_row.find_all(["th", "td"])]
+
+    # Body rows
+    tbody = table_elem.find("tbody") or table_elem
+    for row in tbody.find_all("tr"):
+        cells = [td.get_text(strip=True) for td in row.find_all(["td", "th"])]
+        # Skip the header row we already captured
+        if cells and cells != headers:
+            rows.append(cells)
+
+    # If no explicit thead, use first row as header
+    if not headers and rows:
+        headers = rows.pop(0)
+
+    if not headers and not rows:
+        return None
+
+    return {"headers": headers, "rows": rows}

--- a/src/skill_seekers/cli/word_scraper.py
+++ b/src/skill_seekers/cli/word_scraper.py
@@ -26,6 +26,8 @@ except ImportError:
     WORD_AVAILABLE = False
 
 from .skill_converter import SkillConverter
+from skill_seekers.cli.scraper_utils import score_code_quality as _score_code_quality
+from skill_seekers.cli.scraper_utils import extract_table_from_html as _extract_table_from_html
 
 logger = logging.getLogger(__name__)
 
@@ -857,71 +859,3 @@ def _build_section(
         "tables": tables,
         "images": images,
     }
-
-
-def _extract_table_from_html(table_elem) -> dict | None:
-    """Extract headers and rows from a BeautifulSoup <table> element."""
-    headers = []
-    rows = []
-
-    # Try <thead> first for headers
-    thead = table_elem.find("thead")
-    if thead:
-        header_row = thead.find("tr")
-        if header_row:
-            headers = [th.get_text(strip=True) for th in header_row.find_all(["th", "td"])]
-
-    # Body rows
-    tbody = table_elem.find("tbody") or table_elem
-    for row in tbody.find_all("tr"):
-        cells = [td.get_text(strip=True) for td in row.find_all(["td", "th"])]
-        # Skip the header row we already captured
-        if cells and cells != headers:
-            rows.append(cells)
-
-    # If no explicit thead, use first row as header
-    if not headers and rows:
-        headers = rows.pop(0)
-
-    if not headers and not rows:
-        return None
-
-    return {"headers": headers, "rows": rows}
-
-
-def _score_code_quality(code: str) -> float:
-    """Simple quality heuristic for code blocks (0-10 scale)."""
-    if not code:
-        return 0.0
-
-    score = 5.0
-    lines = code.strip().split("\n")
-    line_count = len(lines)
-
-    # More lines = more substantial
-    if line_count >= 10:
-        score += 2.0
-    elif line_count >= 5:
-        score += 1.0
-
-    # Has function/class definitions
-    if re.search(r"\b(def |class |function |func |fn )", code):
-        score += 1.5
-
-    # Has imports/require
-    if re.search(r"\b(import |from .+ import|require\(|#include|using )", code):
-        score += 0.5
-
-    # Has indentation (common in Python, JS, etc.)
-    if re.search(r"^    ", code, re.MULTILINE):
-        score += 0.5
-
-    # Has assignment, operators, or common code syntax
-    if re.search(r"[=:{}()\[\]]", code):
-        score += 0.3
-
-    # Very short snippets get penalized
-    if len(code) < 30:
-        score -= 2.0
-
-    return min(10.0, max(0.0, score))

--- a/tests/test_scraper_utils.py
+++ b/tests/test_scraper_utils.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""
+Tests for the shared scraper helpers in cli/scraper_utils.py.
+
+Pins the exact scoring behavior so the consolidation of 8 duplicated
+`_score_code_quality` functions (3 logic variants) into one parametrized helper
+cannot silently change scores.
+"""
+
+import pathlib
+import unittest
+
+from skill_seekers.cli.scraper_utils import score_code_quality, extract_table_from_html
+
+# Representative inputs with their pinned scores (captured from the pre-merge
+# implementations: standard == the 6-module/asciidoc variant; notebook == jupyter).
+_FIXTURES = {
+    "empty": "",
+    "short": "x=1",
+    "func": "def foo():\n    return 1\n",
+    "long": "\n".join(f"line_{i} = {i}" for i in range(12)),
+    "magic": "%matplotlib inline\n!pip install x\n",
+    "docstring": 'def f():\n    """doc"""\n    return 1\n' + "\n".join(str(i) for i in range(8)),
+}
+_STANDARD = {"empty": 0.0, "short": 3.3, "func": 5.3, "long": 7.3, "magic": 5.0, "docstring": 9.3}
+_NOTEBOOK = {"empty": 0.0, "short": 3.3, "func": 5.3, "long": 7.3, "magic": 4.2, "docstring": 9.6}
+
+_SCORE_MODULES = [
+    "asciidoc_scraper",
+    "chat_scraper",
+    "pptx_scraper",
+    "confluence_scraper",
+    "epub_scraper",
+    "jupyter_scraper",
+    "word_scraper",
+    "html_scraper",
+]
+
+
+class TestScoreCodeQuality(unittest.TestCase):
+    def test_standard_mode_parity(self):
+        for key, expected in _STANDARD.items():
+            self.assertAlmostEqual(score_code_quality(_FIXTURES[key]), expected, places=2, msg=key)
+
+    def test_notebook_mode_parity(self):
+        for key, expected in _NOTEBOOK.items():
+            self.assertAlmostEqual(
+                score_code_quality(_FIXTURES[key], notebook_mode=True), expected, places=2, msg=key
+            )
+
+    def test_clamped_range(self):
+        self.assertEqual(score_code_quality(""), 0.0)
+        big = "def f():\n" + "\n".join(f"    x{i} = import_thing()" for i in range(50))
+        self.assertLessEqual(score_code_quality(big), 10.0)
+
+
+class TestExtractTable(unittest.TestCase):
+    def test_thead_and_rows(self):
+        from bs4 import BeautifulSoup
+
+        html = "<table><thead><tr><th>A</th><th>B</th></tr></thead>"
+        html += "<tbody><tr><td>1</td><td>2</td></tr></tbody></table>"
+        table = BeautifulSoup(html, "html.parser").find("table")
+        self.assertEqual(
+            extract_table_from_html(table), {"headers": ["A", "B"], "rows": [["1", "2"]]}
+        )
+
+    def test_no_thead_uses_first_row_as_header(self):
+        from bs4 import BeautifulSoup
+
+        html = "<table><tr><td>H1</td><td>H2</td></tr><tr><td>x</td><td>y</td></tr></table>"
+        table = BeautifulSoup(html, "html.parser").find("table")
+        self.assertEqual(
+            extract_table_from_html(table), {"headers": ["H1", "H2"], "rows": [["x", "y"]]}
+        )
+
+    def test_empty_table_returns_none(self):
+        from bs4 import BeautifulSoup
+
+        table = BeautifulSoup("<table></table>", "html.parser").find("table")
+        self.assertIsNone(extract_table_from_html(table))
+
+
+class TestNoDuplicateDefinitions(unittest.TestCase):
+    """No scraper should still define its own _score_code_quality."""
+
+    def test_score_helper_not_redefined(self):
+        import skill_seekers.cli as cli_pkg
+
+        cli_dir = pathlib.Path(cli_pkg.__file__).parent
+        for mod in _SCORE_MODULES:
+            src = (cli_dir / f"{mod}.py").read_text()
+            self.assertNotIn(
+                "def _score_code_quality",
+                src,
+                f"{mod} should import score_code_quality from scraper_utils, not redefine it",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Tier 3 (scoped to the safe, behavior-preserving wins). `_score_code_quality` was copy-pasted into 8 scrapers and `_extract_table_from_html` into word/epub. Consolidated into a new `cli/scraper_utils.py`.

## Changes

- **`score_code_quality(code, *, notebook_mode=False)`** — unifies 3 logic variants found across the 8 scrapers: 6 modules + asciidoc were identical (standard), and jupyter added notebook-specific rules (docstring/magic-line bonuses, all-magic-cell penalty), now gated behind `notebook_mode`. Jupyter call sites pass `notebook_mode=True`. **Strict behavior superset** — pinned by parity tests for both modes (standard scores unchanged; notebook scores unchanged).
- **`extract_table_from_html`** — shared by word/epub (was byte-identical).
- Scrapers import the helper (alias-imported as `_score_code_quality` so internal call sites are unchanged); duplicate defs removed.

## Deferred to a separate PR (intentionally)

- `_sanitize_filename` — **4 divergent behaviors** across 12 method/static variants; consolidating would change some scrapers' output filenames (a real behavior change, low payoff).
- `_build_section` — word/epub diverge (epub has extra language detection).

Left untouched so this PR stays behavior-preserving.

## Testing

New `tests/test_scraper_utils.py` pins standard + notebook scores and table extraction. Scraper suites green: **988 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)