### PR TITLE
fix: 8 UX/correctness findings from real-world CLI testing

### DIFF
--- a/src/skill_seekers/cli/arguments/package.py
+++ b/src/skill_seekers/cli/arguments/package.py
@@ -34,6 +34,13 @@ PACKAGE_ARGUMENTS: dict[str, dict[str, Any]] = {
             "help": "Skip quality checks before packaging",
         },
     },
+    "yes": {
+        "flags": ("--yes", "-y"),
+        "kwargs": {
+            "action": "store_true",
+            "help": "Proceed past quality warnings without prompting (for CI/non-interactive use)",
+        },
+    },
     # Target platform
     "target": {
         "flags": ("--target",),

--- a/src/skill_seekers/cli/codebase_scraper.py
+++ b/src/skill_seekers/cli/codebase_scraper.py
@@ -1101,6 +1101,13 @@ def analyze_codebase(
             continue
 
     logger.info(f"✅ Successfully analyzed {analyzed_count} files")
+    if analyzed_count == 0 and depth == "surface" and files:
+        # surface depth intentionally skips per-file analysis; say so instead of
+        # leaving a bare "analyzed 0 files" that reads like a failure.
+        logger.info(
+            "   (surface depth only maps the file tree — pass --depth deep to "
+            "extract signatures / API reference)"
+        )
 
     # Save results
     output_json = output_dir / "code_analysis.json"

--- a/src/skill_seekers/cli/create_command.py
+++ b/src/skill_seekers/cli/create_command.py
@@ -328,7 +328,12 @@ class CreateCommand:
             config.update(
                 {
                     "directory": directory,
-                    "depth": ctx.analysis.depth,
+                    # Default a bare `create ./path` to deep analysis so it
+                    # actually extracts an API reference (matching the scraper's
+                    # own default and the scan-emitted config path). `surface`
+                    # only walks the file tree and produced an empty
+                    # code_analysis.json. An explicit --depth still wins.
+                    "depth": getattr(self.args, "depth", None) or "deep",
                     "output_dir": ctx.output.output_dir or f"output/{name}",
                     "languages": ctx.scraping.languages or None,
                     "file_patterns": ctx.analysis.file_patterns,

--- a/src/skill_seekers/cli/doc_scraper.py
+++ b/src/skill_seekers/cli/doc_scraper.py
@@ -65,6 +65,12 @@ FALLBACK_MAIN_SELECTORS = [
     "#main-content",
 ]
 
+# (connect, read) timeout for the best-effort sitemap probes that run before the
+# crawl. A tight connect bound fails fast on an unreachable host (so `create
+# <url>` doesn't look hung) while the read bound still allows a slow but real
+# sitemap to download.
+SITEMAP_PROBE_TIMEOUT = (5, 10)
+
 # Pre-compiled regex patterns for frequently called methods
 _WHITESPACE_RE = re.compile(r"\s+")
 _SAFE_TITLE_RE = re.compile(r"[^\w\s-]")
@@ -1342,7 +1348,9 @@ class DocToSkillConverter(SkillConverter):
         for sitemap_url in sitemap_urls_to_try:
             try:
                 response = requests.get(
-                    sitemap_url, timeout=10, headers={"User-Agent": "SkillSeekers/3.4"}
+                    sitemap_url,
+                    timeout=SITEMAP_PROBE_TIMEOUT,
+                    headers={"User-Agent": "SkillSeekers/3.4"},
                 )
                 if response.status_code != 200:
                     continue
@@ -1361,7 +1369,7 @@ class DocToSkillConverter(SkillConverter):
                             continue
                         sub_resp = requests.get(
                             sitemap_text,
-                            timeout=10,
+                            timeout=SITEMAP_PROBE_TIMEOUT,
                             headers={"User-Agent": "SkillSeekers/3.4"},
                         )
                         if sub_resp.status_code == 200:

--- a/src/skill_seekers/cli/doctor.py
+++ b/src/skill_seekers/cli/doctor.py
@@ -196,10 +196,15 @@ def check_api_keys() -> CheckResult:
             verbose_detail="\n".join(details),
         )
     if set_keys:
+        # Name the keys that ARE set so a bare GITHUB_TOKEN (a rate-limit token,
+        # not an AI enhancement provider) isn't misread as a provider key being
+        # configured. Previously the summary only listed the missing keys, so
+        # "1 set" looked like enhancement was ready when only GITHUB_TOKEN was set.
         return CheckResult(
             "API keys",
             "warn",
-            f"{len(set_keys)} set ({', '.join(missing_keys)} not set)",
+            f"{len(set_keys)} set ({', '.join(set_keys)}); "
+            f"{len(missing_keys)} not set ({', '.join(missing_keys)})",
             verbose_detail="\n".join(details),
         )
     return CheckResult(

--- a/src/skill_seekers/cli/estimate_pages.py
+++ b/src/skill_seekers/cli/estimate_pages.py
@@ -223,6 +223,15 @@ def print_results(results, config):
 
 def load_config(config_path):
     """Load configuration from JSON file"""
+    # `estimate` needs a config file, but `create` accepts URLs — so users
+    # naturally try `estimate <url>`. Catch that early with an actionable hint
+    # instead of a bare "Config file not found: <url>".
+    if isinstance(config_path, str) and config_path.startswith(("http://", "https://")):
+        print(f"❌ Error: estimate expects a config file, not a URL: {config_path}")
+        print("   Generate one first, then estimate it:")
+        print(f"     skill-seekers create {config_path} --dry-run   # writes a config")
+        print("     skill-seekers estimate <config.json>")
+        sys.exit(EXIT_ERROR)
     try:
         with open(config_path) as f:
             config = json.load(f)

--- a/src/skill_seekers/cli/package_skill.py
+++ b/src/skill_seekers/cli/package_skill.py
@@ -37,10 +37,27 @@ except ImportError:
     )
 
 
+def _confirm_packaging(report, assume_yes=False):
+    """Decide whether to proceed past the quality-warning gate.
+
+    Packaging only writes a zip, so a non-interactive run (CI, pipes) should
+    proceed rather than crash on ``EOFError`` from ``input()``. ``--yes`` forces
+    the same. An interactive TTY still gets the y/n prompt.
+    """
+    print("=" * 60)
+    if not (report.has_errors or report.has_warnings):
+        return True
+    if assume_yes or not sys.stdin.isatty():
+        print("\n⚠️  Proceeding with packaging (non-interactive or --yes).")
+        return True
+    return input("\nContinue with packaging? (y/n): ").strip().lower() == "y"
+
+
 def package_skill(
     skill_dir,
     open_folder_after=True,
     skip_quality_check=False,
+    assume_yes=False,
     target="claude",
     model=None,
     streaming=False,
@@ -92,17 +109,12 @@ def package_skill(
         # Print report
         print_report(report, verbose=False)
 
-        # If there are errors or warnings, ask user to confirm
-        if report.has_errors or report.has_warnings:
-            print("=" * 60)
-            response = input("\nContinue with packaging? (y/n): ").strip().lower()
-            if response != "y":
-                print("\n❌ Packaging cancelled by user")
-                return False, None
-            print()
-        else:
-            print("=" * 60)
-            print()
+        # Confirm past the quality gate (auto-proceeds when non-interactive
+        # or --yes; only an interactive TTY with issues gets the prompt).
+        if not _confirm_packaging(report, assume_yes=assume_yes):
+            print("\n❌ Packaging cancelled by user")
+            return False, None
+        print()
 
     # Get platform-specific adaptor
     try:
@@ -233,6 +245,7 @@ Examples:
         args.skill_directory,
         open_folder_after=not args.no_open,
         skip_quality_check=args.skip_quality_check,
+        assume_yes=args.yes,
         target=args.target,
         model=args.model,
         streaming=args.streaming,

--- a/src/skill_seekers/cli/quality_metrics.py
+++ b/src/skill_seekers/cli/quality_metrics.py
@@ -24,6 +24,17 @@ class MetricLevel(Enum):
     CRITICAL = "critical"
 
 
+def _json_default(obj):
+    """JSON serializer for report dataclasses.
+
+    Serializes Enums by their value ('info') so the saved report doesn't leak
+    the Python repr ('MetricLevel.INFO'); falls back to str() for anything else.
+    """
+    if isinstance(obj, Enum):
+        return obj.value
+    return str(obj)
+
+
 @dataclass
 class QualityMetric:
     """Individual quality metric."""
@@ -554,15 +565,19 @@ def main(args=None):
     # Generate report
     report = analyzer.generate_report()
 
-    # Display report
+    # Display report. --report prints the full breakdown; otherwise still show a
+    # one-line score summary so the user doesn't have to open the JSON to learn it.
     if args.report:
         formatted = analyzer.format_report(report)
         print(formatted)
+    else:
+        score = report.overall_score
+        print(f"\n📊 Quality Score: {score.total_score:.1f}/100 (Grade: {score.grade})")
 
     # Save report
     report_path = Path(args.output) if args.output else skill_dir / "quality_report.json"
 
-    report_path.write_text(json.dumps(asdict(report), indent=2, default=str))
+    report_path.write_text(json.dumps(asdict(report), indent=2, default=_json_default))
     print(f"\n✅ Report saved: {report_path}")
 
     # Quality gating: only when --threshold is explicitly given. Report-only

--- a/src/skill_seekers/cli/unified_skill_builder.py
+++ b/src/skill_seekers/cli/unified_skill_builder.py
@@ -1431,6 +1431,8 @@ This skill combines knowledge from multiple sources:
             "how_to_guides",
             "config_patterns",
             "architecture",
+            "api_reference",
+            "dependency_graph",
         )
         for local_source in local_list:
             if not any(local_source.get(k) for k in c3_keys):
@@ -1480,6 +1482,8 @@ This skill combines knowledge from multiple sources:
             ("examples", "Usage examples"),
             ("guides", "How-to guides"),
             ("configuration", "Configuration"),
+            ("api_reference", "API reference"),
+            ("dependencies", "Dependencies"),
         )
 
         with open(index_path, "w", encoding="utf-8") as f:
@@ -1521,6 +1525,8 @@ This skill combines knowledge from multiple sources:
         self._generate_guide_references(c3_dir, c3_data.get("how_to_guides"))
         self._generate_config_references(c3_dir, c3_data.get("config_patterns"))
         self._copy_architecture_details(c3_dir, c3_data.get("architecture"))
+        self._generate_api_reference_references(c3_dir, c3_data.get("api_reference"))
+        self._generate_dependency_references(c3_dir, c3_data.get("dependency_graph"))
 
         logger.info("✅ Created codebase analysis references")
 
@@ -1971,6 +1977,52 @@ This skill combines knowledge from multiple sources:
                     f.write("\n")
 
         logger.info(f"   ✓ Architectural details: {len(patterns)} patterns")
+
+    def _generate_api_reference_references(self, c3_dir: str, api_data: dict):
+        """Write per-module API reference markdown (C2.5).
+
+        ``api_data`` maps module name -> markdown content (as loaded by
+        ``UnifiedScraper._load_api_reference``). Previously this payload was
+        carried on the source dict but never written out, so the packaged skill
+        lost its API reference entirely.
+        """
+        if not api_data:
+            return
+
+        api_dir = os.path.join(c3_dir, "api_reference")
+        os.makedirs(api_dir, exist_ok=True)
+
+        for module_name, content in api_data.items():
+            # basename() guards against any path separators in the module key.
+            stem = os.path.basename(str(module_name)) or "module"
+            with open(os.path.join(api_dir, f"{stem}.md"), "w", encoding="utf-8") as f:
+                f.write(content)
+
+        logger.info(f"   ✓ API reference: {len(api_data)} module(s)")
+
+    def _generate_dependency_references(self, c3_dir: str, dep_data: dict):
+        """Write the dependency graph (C2.6) JSON plus a short summary index."""
+        if not dep_data:
+            return
+
+        dep_dir = os.path.join(c3_dir, "dependencies")
+        os.makedirs(dep_dir, exist_ok=True)
+
+        json_path = os.path.join(dep_dir, "dependency_graph.json")
+        with open(json_path, "w", encoding="utf-8") as f:
+            json.dump(dep_data, f, indent=2, ensure_ascii=False)
+
+        nodes = dep_data.get("nodes") or []
+        edges = dep_data.get("edges") or []
+        md_path = os.path.join(dep_dir, "index.md")
+        with open(md_path, "w", encoding="utf-8") as f:
+            f.write("# Dependency Graph\n\n")
+            f.write("*Module dependency graph from codebase analysis (C2.6)*\n\n")
+            f.write(f"- **Modules**: {len(nodes)}\n")
+            f.write(f"- **Dependencies**: {len(edges)}\n\n")
+            f.write("See `dependency_graph.json` for the full graph.\n")
+
+        logger.info(f"   ✓ Dependency graph: {len(nodes)} module(s), {len(edges)} edge(s)")
 
     def _collect_c3_payloads(self) -> list[dict]:
         """Gather C3.x analysis payloads across GitHub and local sources (#363).

--- a/tests/test_c3_integration.py
+++ b/tests/test_c3_integration.py
@@ -403,5 +403,122 @@ class TestC3AnalyzeCodebaseSignature:
         assert captured_kwargs["enhance_level"] == 0  # ai_mode "none" → enhance_level 0
 
 
+class TestLocalCodebaseApiAndDependencyReferences:
+    """Local codebase create must surface api_reference + dependency graph.
+
+    Regression: ``_write_codebase_analysis_references`` emitted patterns/
+    examples/guides/configuration/architecture but silently dropped the
+    ``api_reference`` and dependency graph the local scraper had already
+    produced. They were stranded in the scrape cache and never reached the
+    packaged skill, so a skill built from a scan-emitted ``*-codebase.json``
+    config shipped without its API reference.
+    """
+
+    @pytest.fixture
+    def temp_dir(self):
+        temp = tempfile.mkdtemp()
+        yield temp
+        shutil.rmtree(temp, ignore_errors=True)
+
+    @pytest.fixture
+    def config(self):
+        return {
+            "name": "acme",
+            "description": "Acme local codebase",
+            "sources": [{"type": "local", "path": "/tmp/acme"}],
+        }
+
+    @pytest.fixture
+    def scraped_data(self):
+        return {
+            "local": [
+                {
+                    "source_id": "acme_local_0_acme",
+                    "name": "acme",
+                    "architecture": {"patterns": [], "languages": {"Python": 2}},
+                    "api_reference": {
+                        "arithmetic": "# API Reference: arithmetic.py\n\n## add(a, b)\n",
+                        "stats": "# API Reference: stats.py\n\n## mean(values)\n",
+                    },
+                    "dependency_graph": {
+                        "nodes": ["arithmetic", "stats"],
+                        "edges": [["__init__", "arithmetic"]],
+                    },
+                }
+            ]
+        }
+
+    def test_api_reference_promoted_into_skill(self, config, scraped_data, temp_dir):
+        builder = UnifiedSkillBuilder(config, scraped_data)
+        builder.skill_dir = temp_dir
+        builder._generate_local_codebase_analysis_references()
+
+        api_dir = os.path.join(
+            temp_dir,
+            "references",
+            "codebase_analysis",
+            "acme_local_0_acme",
+            "api_reference",
+        )
+        assert os.path.isfile(os.path.join(api_dir, "arithmetic.md"))
+        assert os.path.isfile(os.path.join(api_dir, "stats.md"))
+        with open(os.path.join(api_dir, "arithmetic.md")) as f:
+            assert "## add(a, b)" in f.read()
+
+    def test_dependency_graph_promoted_into_skill(self, config, scraped_data, temp_dir):
+        builder = UnifiedSkillBuilder(config, scraped_data)
+        builder.skill_dir = temp_dir
+        builder._generate_local_codebase_analysis_references()
+
+        dep_file = os.path.join(
+            temp_dir,
+            "references",
+            "codebase_analysis",
+            "acme_local_0_acme",
+            "dependencies",
+            "dependency_graph.json",
+        )
+        assert os.path.isfile(dep_file)
+        with open(dep_file) as f:
+            assert json.load(f)["nodes"] == ["arithmetic", "stats"]
+
+    def test_index_links_api_reference_and_dependencies(self, config, scraped_data, temp_dir):
+        builder = UnifiedSkillBuilder(config, scraped_data)
+        builder.skill_dir = temp_dir
+        builder._generate_local_codebase_analysis_references()
+        builder._generate_codebase_analysis_index()
+
+        index_path = os.path.join(temp_dir, "references", "codebase_analysis", "index.md")
+        with open(index_path) as f:
+            index = f.read()
+        assert "api_reference/" in index
+        assert "dependencies/" in index
+
+    def test_api_reference_only_source_is_not_skipped(self, config, temp_dir):
+        """A source that produced only an API reference must still be written."""
+        scraped_data = {
+            "local": [
+                {
+                    "source_id": "lib_local_0_lib",
+                    "name": "lib",
+                    "api_reference": {"core": "# API Reference: core.py\n"},
+                }
+            ]
+        }
+        builder = UnifiedSkillBuilder(config, scraped_data)
+        builder.skill_dir = temp_dir
+        builder._generate_local_codebase_analysis_references()
+
+        api_md = os.path.join(
+            temp_dir,
+            "references",
+            "codebase_analysis",
+            "lib_local_0_lib",
+            "api_reference",
+            "core.md",
+        )
+        assert os.path.isfile(api_md)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_create_local_depth.py
+++ b/tests/test_create_local_depth.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""A bare `create ./path` should produce a real analysis by default.
+
+Regression: local create defaulted to ``surface`` depth, which skips per-file
+AST analysis. The result was an empty ``code_analysis.json`` and a misleading
+"Found N source files / Successfully analyzed 0 files" log, while a skill built
+from a scan-emitted config (which defaults to deep) had a full API reference.
+Local create now defaults to ``deep`` and still honors an explicit ``--depth``.
+"""
+
+import argparse
+
+import pytest
+
+from skill_seekers.cli.arguments.create import get_create_defaults
+from skill_seekers.cli.create_command import CreateCommand
+from skill_seekers.cli.execution_context import ExecutionContext
+from skill_seekers.cli.source_detector import SourceInfo
+
+
+def _local_command(directory, **overrides):
+    defaults = get_create_defaults()
+    defaults.update({"name": "mylib"})
+    defaults.update(overrides)
+    args = argparse.Namespace(**defaults)
+    cmd = CreateCommand(args)
+    cmd.source_info = SourceInfo(
+        type="local",
+        parsed={"directory": str(directory)},
+        suggested_name="mylib",
+        raw_input=str(directory),
+    )
+    ExecutionContext.reset()
+    ExecutionContext.initialize(args=args, config_path=None, source_info=cmd.source_info)
+    return cmd
+
+
+@pytest.fixture(autouse=True)
+def _reset_context():
+    yield
+    ExecutionContext.reset()
+
+
+def test_local_create_defaults_to_deep(tmp_path):
+    cmd = _local_command(tmp_path, depth=None)
+    config = cmd._build_config("local", ExecutionContext.get())
+    assert config["depth"] == "deep"
+
+
+def test_local_create_respects_explicit_surface(tmp_path):
+    cmd = _local_command(tmp_path, depth="surface")
+    config = cmd._build_config("local", ExecutionContext.get())
+    assert config["depth"] == "surface"

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -101,6 +101,16 @@ class TestCheckApiKeys:
             assert result.status == "warn"
             assert "1 set" in result.detail
 
+    def test_set_keys_are_named(self):
+        """The summary must name which keys are set, so a bare GITHUB_TOKEN
+        isn't misread as an AI provider key being configured."""
+        env = {"GITHUB_TOKEN": "ghp_test123456789"}
+        with patch.dict(os.environ, env, clear=True):
+            result = check_api_keys()
+            assert result.status == "warn"
+            assert "1 set" in result.detail
+            assert "GITHUB_TOKEN" in result.detail
+
 
 class TestCheckMcpServer:
     def test_returns_result(self):

--- a/tests/test_estimate_url_guard.py
+++ b/tests/test_estimate_url_guard.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Unit tests for estimate's input guard.
+
+`estimate` takes a config JSON file, but `create` accepts URLs — so users
+naturally try `estimate <url>`. The error must explain that and point them at
+the right command instead of the bare "Config file not found: <url>".
+"""
+
+import pytest
+
+from skill_seekers.cli.estimate_pages import load_config
+
+
+class TestEstimateUrlGuard:
+    def test_url_argument_gives_actionable_error(self, capsys):
+        with pytest.raises(SystemExit) as exc:
+            load_config("https://docs.example.com/")
+        assert exc.value.code != 0
+        out = capsys.readouterr().out.lower()
+        # Names that a config file is required and points at how to make one.
+        assert "config" in out
+        assert "create" in out
+
+    def test_missing_file_still_errors_cleanly(self, capsys):
+        with pytest.raises(SystemExit) as exc:
+            load_config("/nonexistent/path/to/config.json")
+        assert exc.value.code != 0
+        out = capsys.readouterr().out.lower()
+        assert "not found" in out

--- a/tests/test_package_confirm.py
+++ b/tests/test_package_confirm.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Unit tests for package's quality-gate confirmation.
+
+Packaging is non-destructive (it writes a zip), so a non-interactive
+invocation (CI, pipes) must proceed past the quality-warning gate instead of
+crashing on ``EOFError`` from ``input()``. ``--yes`` forces the same.
+"""
+
+from types import SimpleNamespace
+
+from skill_seekers.cli.package_skill import _confirm_packaging
+
+
+def _report(errors=False, warnings=False):
+    return SimpleNamespace(has_errors=errors, has_warnings=warnings)
+
+
+class TestConfirmPackaging:
+    def test_proceeds_when_no_issues(self):
+        assert _confirm_packaging(_report(), assume_yes=False) is True
+
+    def test_assume_yes_proceeds_despite_warnings(self):
+        assert _confirm_packaging(_report(warnings=True), assume_yes=True) is True
+
+    def test_non_tty_proceeds_without_prompting(self, monkeypatch):
+        # input() must NOT be called in non-interactive mode — it would EOFError.
+        def _boom(*_a, **_k):
+            raise AssertionError("input() should not be called when stdin is not a TTY")
+
+        monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+        monkeypatch.setattr("builtins.input", _boom)
+        assert _confirm_packaging(_report(warnings=True), assume_yes=False) is True
+
+    def test_tty_declines_on_no(self, monkeypatch):
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+        monkeypatch.setattr("builtins.input", lambda *_a: "n")
+        assert _confirm_packaging(_report(warnings=True), assume_yes=False) is False
+
+    def test_tty_accepts_on_yes(self, monkeypatch):
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+        monkeypatch.setattr("builtins.input", lambda *_a: "y")
+        assert _confirm_packaging(_report(errors=True), assume_yes=False) is True

--- a/tests/test_quality_metrics.py
+++ b/tests/test_quality_metrics.py
@@ -12,6 +12,7 @@ Validates:
 """
 
 import argparse
+import json
 
 import pytest
 from pathlib import Path
@@ -378,3 +379,35 @@ def test_main_explicit_threshold_gates(minimal_skill_dir):
 
     assert main(_quality_args(minimal_skill_dir, threshold=10.0)) == 1
     assert main(_quality_args(minimal_skill_dir, threshold=0.0)) == 0
+
+
+def test_main_prints_score_summary(minimal_skill_dir, capsys):
+    """`quality` must show the score on stdout even without --report; a bare
+    'Report saved' left users having to open the JSON to learn the score."""
+    from skill_seekers.cli.quality_metrics import main
+
+    main(_quality_args(minimal_skill_dir))
+    out = capsys.readouterr().out
+    assert "Quality Score" in out
+    assert "Grade" in out
+
+
+def test_report_json_uses_plain_enum_values(minimal_skill_dir, tmp_path):
+    """Saved JSON must record metric levels as 'info'/'warning', not the enum
+    repr 'MetricLevel.INFO' (which leaked via json.dumps(default=str))."""
+    from skill_seekers.cli.quality_metrics import main
+
+    out_file = tmp_path / "q.json"
+    main(_quality_args(minimal_skill_dir, output=str(out_file)))
+    text = out_file.read_text()
+    assert "MetricLevel." not in text
+    data = json.loads(text)
+    levels = {m["level"] for m in data["metrics"]}
+    assert levels <= {"info", "warning", "error", "critical"}
+
+
+def test_json_default_serializes_enum_value():
+    from skill_seekers.cli.quality_metrics import _json_default
+
+    assert _json_default(MetricLevel.INFO) == "info"
+    assert _json_default(MetricLevel.WARNING) == "warning"

--- a/tests/test_sitemap_timeout.py
+++ b/tests/test_sitemap_timeout.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""The pre-crawl sitemap probe must fail fast on unreachable hosts.
+
+`_try_sitemap` runs up to two blocking probes before the crawl starts. With a
+single scalar timeout an unreachable host blocked the full window each time,
+making `create <url>` look hung before any output. A (connect, read) timeout
+bounds the connect phase tightly while still allowing a slow real sitemap to
+download.
+"""
+
+from skill_seekers.cli import doc_scraper
+
+
+def test_sitemap_probe_uses_connect_read_timeout(monkeypatch):
+    seen_timeouts = []
+
+    class _Resp:
+        status_code = 404
+        headers = {"content-type": "text/html"}
+        text = ""
+
+    def fake_get(_url, **kwargs):
+        seen_timeouts.append(kwargs.get("timeout"))
+        return _Resp()
+
+    monkeypatch.setattr(doc_scraper.requests, "get", fake_get)
+    converter = doc_scraper.DocToSkillConverter(
+        {"name": "t", "base_url": "https://example.com/"}, dry_run=True
+    )
+    converter._try_sitemap()
+
+    assert seen_timeouts, "sitemap probe made no request"
+    for timeout in seen_timeouts:
+        assert isinstance(timeout, tuple) and len(timeout) == 2, (
+            f"expected a (connect, read) timeout tuple, got {timeout!r}"
+        )
+        connect, read = timeout
+        assert connect <= read


### PR DESCRIPTION
Fixes 8 issues surfaced by driving the unified CLI end-to-end as a normal user across every primary source type and command (local codebase, scan→config, PDF, web, package, doctor, quality, estimate). Each fix is TDD-backed and verified against the real CLI.

## Fixes

1. **Unified/scan-config codebase create dropped the API reference + dependency graph.** The local source dict carried `api_reference` and `dependency_graph`, but `_write_codebase_analysis_references` never emitted them — they were stranded in the scrape cache, so a skill built from a scan-emitted `*-codebase.json` shipped without its API reference. Now promoted into `references/codebase_analysis/<source>/` and linked from the index.
2. **`doctor` miscounted `GITHUB_TOKEN` as an AI provider key** ("1 set" with no provider configured). The summary now names which keys are set.
3. **`estimate <url>`** gave a bare "Config file not found: <url>"; now detects a URL, points at `create --dry-run`, and exits non-zero.
4. **`package` crashed on `EOFError`** when non-interactive. New `_confirm_packaging` helper auto-proceeds on a non-TTY or with the new `--yes`/`-y` flag (packaging only writes a zip); an interactive TTY still prompts.
5. **`quality` printed only "Report saved"**; now prints the score/grade summary even without `--report`.
6. **`quality` report serialized metric level as the enum repr** (`"MetricLevel.INFO"`); now the plain value (`"info"`) via `_json_default`.
7. **Bare `create ./path` defaulted to surface depth** → empty `code_analysis.json` and a misleading "analyzed 0 files" log. Local create now defaults to **deep** (matching the scraper default and the scan-config path); explicit `--depth` still wins. Surface runs get a clarifying log.
8. **Web sitemap probes used a single scalar timeout**, so an unreachable host blocked the full window before the crawl. Now a `(connect, read)` timeout fails fast on connect.

## Testing

- New/updated tests for every fix (4 new test files + 3 extended). Each was written failing-first, then verified green and confirmed on the real CLI.
- `ruff check` + `ruff format --check` clean.
- Full CI-fast suite: **3831 passed, 33 skipped**. The one unrelated failure (`test_how_to_guide_builder::test_full_workflow`) is a pre-existing env-bound flake — it spawns a real local AI agent subprocess and exceeds the pytest timeout; it fails identically on `development` with these changes stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)