### PR TITLE
Add Xquik preset config

### DIFF
--- a/configs/xquik.json
+++ b/configs/xquik.json
@@ -1,0 +1,114 @@
+{
+  "name": "xquik",
+  "description": "Xquik REST, webhook, MCP, and X data automation knowledge base.",
+  "version": "1.0.0",
+  "merge_mode": "rule-based",
+  "sources": [
+    {
+      "type": "documentation",
+      "base_url": "https://docs.xquik.com/",
+      "start_urls": [
+        "https://docs.xquik.com/api-reference/overview",
+        "https://docs.xquik.com/api-reference/authentication",
+        "https://docs.xquik.com/api-reference/errors",
+        "https://docs.xquik.com/mcp",
+        "https://docs.xquik.com/webhooks",
+        "https://docs.xquik.com/monitors",
+        "https://docs.xquik.com/extractions",
+        "https://docs.xquik.com/alternatives/x-api"
+      ],
+      "selectors": {
+        "main_content": "main, article, #content-area, #content-container",
+        "title": "h1",
+        "code_blocks": "pre code"
+      },
+      "url_patterns": {
+        "include": [
+          "/api-reference/",
+          "/mcp",
+          "/webhooks",
+          "/monitors",
+          "/extractions",
+          "/alternatives/"
+        ],
+        "exclude": [
+          "/blog/",
+          "/changelog/",
+          "/legal/"
+        ]
+      },
+      "categories": {
+        "getting_started": [
+          "overview",
+          "quickstart",
+          "authentication"
+        ],
+        "rest_api": [
+          "api-reference",
+          "endpoint",
+          "pagination",
+          "errors"
+        ],
+        "mcp": [
+          "mcp",
+          "model-context-protocol",
+          "agent"
+        ],
+        "webhooks": [
+          "webhook",
+          "hmac",
+          "events"
+        ],
+        "monitoring": [
+          "monitor",
+          "keyword",
+          "account"
+        ],
+        "extractions": [
+          "extraction",
+          "tweets",
+          "users",
+          "followers"
+        ]
+      },
+      "rate_limit": 0.5,
+      "max_pages": 120
+    },
+    {
+      "type": "openapi",
+      "url": "https://docs.xquik.com/openapi.yaml",
+      "name": "xquik-openapi"
+    },
+    {
+      "type": "github",
+      "repo": "Xquik-dev/x-twitter-scraper",
+      "enable_codebase_analysis": true,
+      "code_analysis_depth": "surface",
+      "fetch_changelog": true,
+      "fetch_releases": true,
+      "fetch_issues": false,
+      "file_patterns": [
+        "README.md",
+        "package.json",
+        "src/**/*.ts",
+        "sdks/typescript/**/*.ts"
+      ]
+    }
+  ],
+  "metadata": {
+    "author": "Xquik-dev",
+    "language": "TypeScript",
+    "framework_type": "X Data API Platform",
+    "use_cases": [
+      "Build X data integrations",
+      "Connect MCP clients to X data",
+      "Receive webhook events",
+      "Run account and keyword monitors"
+    ],
+    "related_skills": [
+      "mcp",
+      "rest-api",
+      "webhooks"
+    ]
+  }
+}


### PR DESCRIPTION
## Description

Adds `configs/xquik.json`, a unified preset config for building an Xquik knowledge asset from public Xquik docs, the public OpenAPI YAML, and the public `Xquik-dev/x-twitter-scraper` repository.

## Related Issues

Relates to AgentIndex tool coverage for Skill Seekers.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Documentation updated (README, examples, AGENTS.md if CLI changed)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Testing

Config-only change. No package install was required.

Test Configuration:
- Python version: 3.11
- OS: macOS
- Dependencies installed: none

Commands run:
- `python3 -m json.tool configs/xquik.json`
- `/Users/burak/.local/bin/python3.11 src/skill_seekers/cli/config_validator.py configs/xquik.json`
- `git diff --check`
- Checked public URLs for docs, MCP docs, OpenAPI YAML, and GitHub source

## Screenshots

Not applicable.

## Additional Notes

The config uses public Xquik docs and public repository sources only. It disables issue fetching to keep generated skills focused on stable documentation and source metadata.
