### PR TITLE
fix: honor skip_scrape for unified configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Development version: 3.9.0.dev0_
 
+### Fixed
+- **Unified multi-source `skip_scrape` now rebuilds from cache** — `UnifiedScraper` reloads each configured source from `.skillseeker-cache`/cached extraction files before conflict detection and build, so cached unified configs no longer re-scrape the network (#405).
+
 ## [3.8.0] - 2026-06-15
 
 **Theme:** The Grand Unification refactor (one build pipeline, one AI transport, one parser definition, in-process MCP tools — see `docs/UNIFICATION_PLAN.md`) with a 13-bug audit fix-up and a real-world end-to-end CLI testing pass — plus MiniMax-M3, model selection, registry-driven platform targets, a Windows subprocess fix, and codebase de-duplication.

--- a/docs/BUG_AUDIT.md
+++ b/docs/BUG_AUDIT.md
@@ -91,7 +91,7 @@ After the fixes above, every commit in this PR was re-reviewed independently (on
 
 | ID | Sev | Resolution |
 |----|-----|-----------|
-| **I1 (MCP-03)** | High | `skip_scrape` was a no-op (set an attribute no converter read). Now honored at the `SkillConverter.run()` chokepoint (skip `extract()`, build from existing on-disk data) — covers the **single-source** path. The **unified multi-source** path still does not honor it (would require reloading each source's cache before build); the comment in `scraping_tools.py` now says so, and it is **tracked below**. Test: `test_skill_converter.py::TestSkipScrape`. |
+| **I1 (MCP-03)** | High | `skip_scrape` was a no-op (set an attribute no converter read). Now honored at the `SkillConverter.run()` chokepoint for single-source paths and by `UnifiedScraper.run()` for multi-source configs, which reloads each configured source from `.skillseeker-cache`/cached extraction files before conflict detection and build. Tests: `test_skill_converter.py::TestSkipScrape`, `test_unified_scraper_orchestration.py::TestUnifiedSkipScrape`, `test_unified_mcp_integration.py::test_mcp_scrape_docs_unified_skip_scrape_sets_attribute_without_warning`. |
 | **I2 (RT-06)** | Medium | Config-file **inline** `stages` never ran — `_build_inline_engine` re-read `args.enhance_stage` (None for config-only) instead of the resolved list. Now takes the resolved `inline_stages`. Test: `test_workflow_runner.py::...::test_inline_stages_from_config_execute`. |
 | **I3 (ENH-06)** | Low | The OpenAI branch of `_call_api` still hardcoded `timeout=120`; now forwards the caller's `request_timeout`. Test: `test_agent_client.py::...::test_openai_forwards_caller_timeout`. |
 | **I4 (RT-04)** | Low | RT-04 claimed `--timeout` is wired on `create`, but the flag isn't registered there, so the mapping is inert on that path (it only fires for config dicts carrying `timeout`). **Claim corrected here** — no CLI flag added (avoids new surface area for an over-claim). |
@@ -112,7 +112,7 @@ After the fixes above, every commit in this PR was re-reviewed independently (on
 ### Deferred (genuine larger work — not safe to do inline; tracked here)
 
 - **Streaming adaptor format (ADP-01 follow-up):** all 8 RAG/vector adaptors emit a *generic* streamed format rather than each platform's native shape (only the unregistered example classes override the converter). `--streaming` works; per-platform fidelity is a follow-up.
-- **Unified multi-source `skip_scrape` (I1 remainder):** honoring it requires reloading each source's `.skillseeker-cache` before build — a real feature, not a one-liner.
+- **Unified multi-source `skip_scrape` (I1 remainder):** fixed in #405 by rebuilding `scraped_data` from cached per-source files before the unified build, and by forwarding `--skip-scrape` through the config-source `create` path.
 - **Kotlin brace-depth / `is_suspend` corpus robustness (CBA-08, CBA-11):** the brace-depth nesting check is fooled by braces inside strings/comments; a robust fix needs a string/comment-aware scan (shared with the still-open CBA-11).
 ### Low-tier disposition (2026-06-11)
 

--- a/src/skill_seekers/cli/create_command.py
+++ b/src/skill_seekers/cli/create_command.py
@@ -222,6 +222,8 @@ class CreateCommand:
                     "dry_run": bool(ctx.output.dry_run),
                 },
             )
+            if ctx.scraping.skip_scrape:
+                converter.skip_scrape = True
             return converter.run()
 
         config = self._build_config(source_type, ctx)

--- a/src/skill_seekers/cli/unified_scraper.py
+++ b/src/skill_seekers/cli/unified_scraper.py
@@ -253,6 +253,26 @@ class UnifiedScraper(SkillConverter):
 
         return docs_json
 
+    @staticmethod
+    def _cache_slug(value: Any, fallback: str) -> str:
+        """Create a stable path-safe slug for cache directory names."""
+        raw = str(value or fallback).strip().lower()
+        slug = "".join(ch if ch.isalnum() else "_" for ch in raw).strip("_")
+        while "__" in slug:
+            slug = slug.replace("__", "_")
+        return slug[:80] or fallback
+
+    def _documentation_source_name(self, idx: int, source: dict[str, Any]) -> str:
+        """Return the cache/source name for a documentation source."""
+        docs_count = sum(
+            1 for item in self.config.get("sources", []) if item["type"] == "documentation"
+        )
+        if docs_count <= 1:
+            return f"{self.name}_docs"
+
+        slug = self._cache_slug(source.get("name") or source.get("base_url"), f"source_{idx}")
+        return f"{self.name}_docs_{idx}_{slug}"
+
     def scrape_all_sources(self):
         """
         Scrape all configured sources.
@@ -291,6 +311,10 @@ class UnifiedScraper(SkillConverter):
     # not the converter-instance extract()/build_skill() flow.
     def _scrape_documentation(self, source: dict[str, Any]):
         """Scrape documentation website."""
+        idx = self._source_counters["documentation"]
+        self._source_counters["documentation"] += 1
+        source_name = self._documentation_source_name(idx, source)
+
         # Create temporary config for doc scraper in unified format
         # (doc_scraper's ConfigValidator requires "sources" key)
         doc_source = {
@@ -335,7 +359,7 @@ class UnifiedScraper(SkillConverter):
             doc_source["browser_extra_wait"] = source["browser_extra_wait"]
 
         doc_config = {
-            "name": f"{self.name}_docs",
+            "name": source_name,
             "display_name": self.name,
             "description": source.get(
                 "description", self.config.get("description", f"Documentation for {self.name}")
@@ -382,7 +406,7 @@ class UnifiedScraper(SkillConverter):
 
             # Create child context with doc-specific overrides
             doc_ctx = ExecutionContext.get().override(
-                output__name=f"{self.name}_docs",
+                output__name=doc_config["name"],
                 scraping__max_pages=source.get("max_pages", DEFAULTS["scraping"]["max_pages"]),
             )
 
@@ -657,6 +681,10 @@ class UnifiedScraper(SkillConverter):
         """
         from skill_seekers.cli.skill_converter import get_converter
 
+        source_skill_dir = os.path.join(self.sources_dir, config["name"])
+        if os.path.isdir(source_skill_dir):
+            shutil.rmtree(source_skill_dir)
+        config = {**config, "output_dir": source_skill_dir}
         converter = get_converter(converter_type, config)
 
         # Extract content (each converter's extract() delegates to its
@@ -776,6 +804,11 @@ class UnifiedScraper(SkillConverter):
             "whisper_model": source.get("whisper_model", "base"),
         }
 
+        video_skill_dir = os.path.join(self.sources_dir, video_config["name"])
+        if os.path.isdir(video_skill_dir):
+            shutil.rmtree(video_skill_dir)
+        video_config["output_dir"] = video_skill_dir
+
         # Process video
         logger.info(f"Scraping video: {video_id}")
         converter = VideoToSkillConverter(video_config)
@@ -787,13 +820,16 @@ class UnifiedScraper(SkillConverter):
             result = converter.result
             converter.save_extracted_data()
 
+            cache_data_file = os.path.join(self.data_dir, f"video_data_{idx}.json")
+            shutil.copy(converter.data_file, cache_data_file)
+
             # Append to list
             self.scraped_data["video"].append(
                 {
                     "video_id": video_id,
                     "idx": idx,
                     "data": result.to_dict(),
-                    "data_file": converter.data_file,
+                    "data_file": cache_data_file,
                 }
             )
 
@@ -1260,6 +1296,296 @@ class UnifiedScraper(SkillConverter):
             summary_noun="messages",
         )
 
+    def _reset_cached_source_state(self) -> None:
+        """Reset per-source state before rebuilding it from cached files."""
+        self.scraped_data = {source_type: [] for source_type in self.SOURCE_DISPATCH}
+        self._source_counters = dict.fromkeys(self.SOURCE_DISPATCH, 0)
+
+    def _next_source_index(self, source_type: str) -> int:
+        """Return and increment the cached source index for a source type."""
+        idx = self._source_counters[source_type]
+        self._source_counters[source_type] = idx + 1
+        return idx
+
+    @staticmethod
+    def _read_required_json(file_path: str) -> Any:
+        """Read a required cached JSON file, raising a clear error if absent."""
+        if not os.path.exists(file_path):
+            raise FileNotFoundError(
+                "skip_scrape is set but cached data is missing at "
+                f"{file_path}. Run once without skip_scrape to populate the cache."
+            )
+        with open(file_path, encoding="utf-8") as f:
+            return json.load(f)
+
+    def _append_cached_data_source(
+        self, bucket: str, cache_stem: str, record: dict[str, Any]
+    ) -> None:
+        """Load a cached data/<cache_stem>.json payload into scraped_data."""
+        data_file = os.path.join(self.data_dir, f"{cache_stem}.json")
+        data = self._read_required_json(data_file)
+        self.scraped_data[bucket].append({**record, "data": data, "data_file": data_file})
+
+    def _load_cached_sources(self) -> int:
+        """Reload unified scraped_data from prior .skillseeker-cache outputs."""
+        logger.info("=" * 60)
+        logger.info("PHASE 1: Loading cached source data (skip_scrape)")
+        logger.info("=" * 60)
+
+        self._reset_cached_source_state()
+        sources = self.config.get("sources", [])
+        loader_names = {
+            "documentation": "_load_cached_documentation",
+            "github": "_load_cached_github",
+            "pdf": "_load_cached_pdf",
+            "word": "_load_cached_word",
+            "video": "_load_cached_video",
+            "local": "_load_cached_local",
+            "epub": "_load_cached_epub",
+            "jupyter": "_load_cached_jupyter",
+            "html": "_load_cached_html",
+            "openapi": "_load_cached_openapi",
+            "asciidoc": "_load_cached_asciidoc",
+            "pptx": "_load_cached_pptx",
+            "confluence": "_load_cached_confluence",
+            "notion": "_load_cached_notion",
+            "rss": "_load_cached_rss",
+            "manpage": "_load_cached_manpage",
+            "chat": "_load_cached_chat",
+        }
+
+        for i, source in enumerate(sources):
+            source_type = source["type"]
+            logger.info(f"\n[{i + 1}/{len(sources)}] Loading cached {source_type} source...")
+            loader_name = loader_names.get(source_type)
+            if loader_name is None:
+                logger.warning(f"Unknown source type: {source_type}")
+                continue
+            getattr(self, loader_name)(source)
+
+        loaded_count = sum(len(v) for v in self.scraped_data.values())
+        logger.info(f"\n✅ Loaded {loaded_count} cached source item(s) successfully")
+        return loaded_count
+
+    def _load_cached_documentation(self, source: dict[str, Any]) -> None:
+        """Load cached documentation summary written by _scrape_documentation()."""
+        idx = self._next_source_index("documentation")
+        source_name = self._documentation_source_name(idx, source)
+        docs_skill_dir = os.path.join(self.sources_dir, source_name)
+        docs_data_file = f"{docs_skill_dir}_data/summary.json"
+        summary = self._read_required_json(docs_data_file)
+
+        self.scraped_data["documentation"].append(
+            {
+                "source_id": source_name,
+                "base_url": source["base_url"],
+                "pages": summary.get("pages", []),
+                "total_pages": summary.get("total_pages", 0),
+                "data_file": docs_data_file,
+                "refs_dir": os.path.join(docs_skill_dir, "references"),
+            }
+        )
+
+    def _load_cached_github(self, source: dict[str, Any]) -> None:
+        """Load cached GitHub scraper data."""
+        idx = self._next_source_index("github")
+        repo = source["repo"]
+        repo_id = repo.replace("/", "_")
+        self._append_cached_data_source(
+            "github",
+            f"github_data_{idx}_{repo_id}",
+            {"repo": repo, "repo_id": repo_id, "idx": idx},
+        )
+
+    def _load_cached_pdf(self, source: dict[str, Any]) -> None:
+        """Load cached PDF scraper data."""
+        idx = self._next_source_index("pdf")
+        pdf_path = source["path"]
+        pdf_id = os.path.splitext(os.path.basename(pdf_path))[0]
+        self._append_cached_data_source(
+            "pdf",
+            f"pdf_data_{idx}_{pdf_id}",
+            {"pdf_path": pdf_path, "pdf_id": pdf_id, "idx": idx},
+        )
+
+    def _load_cached_word(self, source: dict[str, Any]) -> None:
+        """Load cached Word scraper data."""
+        idx = self._next_source_index("word")
+        docx_path = source["path"]
+        docx_id = os.path.splitext(os.path.basename(docx_path))[0]
+        self._append_cached_data_source(
+            "word",
+            f"word_data_{idx}_{docx_id}",
+            {
+                "docx_path": docx_path,
+                "docx_id": docx_id,
+                "word_id": docx_id,
+                "idx": idx,
+            },
+        )
+
+    def _load_cached_video(self, source: dict[str, Any]) -> None:
+        """Load cached video data."""
+        idx = self._next_source_index("video")
+        video_url = source.get("url", "")
+        video_id = video_url or source.get("path", f"video_{idx}")
+        data_file = os.path.join(self.data_dir, f"video_data_{idx}.json")
+        data = self._read_required_json(data_file)
+        self.scraped_data["video"].append(
+            {"video_id": video_id, "idx": idx, "data": data, "data_file": data_file}
+        )
+
+    def _load_cached_local(self, source: dict[str, Any]) -> None:
+        """Load cached local codebase analysis data."""
+        idx = self._next_source_index("local")
+        local_path = source["path"]
+        path_id = os.path.basename(local_path.rstrip("/"))
+        source_name = source.get("name", path_id)
+        data_file = os.path.join(self.data_dir, f"local_data_{idx}_{path_id}.json")
+        local_data = self._read_required_json(data_file)
+        local_data.update(
+            {
+                "source_id": f"{self.name}_local_{idx}_{path_id}",
+                "path": local_path,
+                "name": source_name,
+                "description": source.get("description", f"Local analysis of {path_id}"),
+                "weight": source.get("weight", 1.0),
+            }
+        )
+
+        skill_md_path = Path(self.sources_dir) / f"local_{idx}_{path_id}" / "SKILL.md"
+        if skill_md_path.exists():
+            local_data["skill_md"] = skill_md_path.read_text(encoding="utf-8")
+
+        self.scraped_data["local"].append(local_data)
+
+    def _load_cached_epub(self, source: dict[str, Any]) -> None:
+        """Load cached EPUB scraper data."""
+        idx = self._next_source_index("epub")
+        epub_path = source["path"]
+        epub_id = os.path.splitext(os.path.basename(epub_path))[0]
+        self._append_cached_data_source(
+            "epub",
+            f"epub_data_{idx}_{epub_id}",
+            {"epub_path": epub_path, "epub_id": epub_id, "idx": idx},
+        )
+
+    def _load_cached_jupyter(self, source: dict[str, Any]) -> None:
+        """Load cached Jupyter scraper data."""
+        idx = self._next_source_index("jupyter")
+        nb_path = source["path"]
+        nb_id = os.path.splitext(os.path.basename(nb_path))[0]
+        self._append_cached_data_source(
+            "jupyter",
+            f"jupyter_data_{idx}_{nb_id}",
+            {"notebook_path": nb_path, "notebook_id": nb_id, "idx": idx},
+        )
+
+    def _load_cached_html(self, source: dict[str, Any]) -> None:
+        """Load cached local HTML scraper data."""
+        idx = self._next_source_index("html")
+        html_path = source["path"]
+        html_id = os.path.splitext(os.path.basename(html_path.rstrip("/")))[0]
+        self._append_cached_data_source(
+            "html",
+            f"html_data_{idx}_{html_id}",
+            {"html_path": html_path, "html_id": html_id, "idx": idx},
+        )
+
+    def _load_cached_openapi(self, source: dict[str, Any]) -> None:
+        """Load cached OpenAPI scraper data."""
+        idx = self._next_source_index("openapi")
+        spec_path = source.get("path", source.get("url", ""))
+        spec_id = os.path.splitext(os.path.basename(spec_path))[0] if spec_path else f"spec_{idx}"
+        self._append_cached_data_source(
+            "openapi",
+            f"openapi_data_{idx}_{spec_id}",
+            {"spec_path": spec_path, "spec_id": spec_id, "idx": idx},
+        )
+
+    def _load_cached_asciidoc(self, source: dict[str, Any]) -> None:
+        """Load cached AsciiDoc scraper data."""
+        idx = self._next_source_index("asciidoc")
+        adoc_path = source["path"]
+        adoc_id = os.path.splitext(os.path.basename(adoc_path.rstrip("/")))[0]
+        self._append_cached_data_source(
+            "asciidoc",
+            f"asciidoc_data_{idx}_{adoc_id}",
+            {"asciidoc_path": adoc_path, "asciidoc_id": adoc_id, "idx": idx},
+        )
+
+    def _load_cached_pptx(self, source: dict[str, Any]) -> None:
+        """Load cached PowerPoint scraper data."""
+        idx = self._next_source_index("pptx")
+        pptx_path = source["path"]
+        pptx_id = os.path.splitext(os.path.basename(pptx_path))[0]
+        self._append_cached_data_source(
+            "pptx",
+            f"pptx_data_{idx}_{pptx_id}",
+            {"pptx_path": pptx_path, "pptx_id": pptx_id, "idx": idx},
+        )
+
+    def _load_cached_confluence(self, source: dict[str, Any]) -> None:
+        """Load cached Confluence scraper data."""
+        idx = self._next_source_index("confluence")
+        source_id = source.get("space_key", source.get("path", f"confluence_{idx}"))
+        if isinstance(source_id, str) and "/" in source_id:
+            source_id = os.path.basename(source_id.rstrip("/"))
+        self._append_cached_data_source(
+            "confluence",
+            f"confluence_data_{idx}_{source_id}",
+            {"source_id": source_id, "idx": idx},
+        )
+
+    def _load_cached_notion(self, source: dict[str, Any]) -> None:
+        """Load cached Notion scraper data."""
+        idx = self._next_source_index("notion")
+        source_id = source.get(
+            "database_id", source.get("page_id", source.get("path", f"notion_{idx}"))
+        )
+        if isinstance(source_id, str) and "/" in source_id:
+            source_id = os.path.basename(source_id.rstrip("/"))
+        self._append_cached_data_source(
+            "notion",
+            f"notion_data_{idx}_{source_id}",
+            {"source_id": source_id, "idx": idx},
+        )
+
+    def _load_cached_rss(self, source: dict[str, Any]) -> None:
+        """Load cached RSS scraper data."""
+        idx = self._next_source_index("rss")
+        feed_url = source.get("url", source.get("path", ""))
+        feed_id = feed_url.split("/")[-1].split(".")[0] if feed_url else f"feed_{idx}"
+        self._append_cached_data_source(
+            "rss",
+            f"rss_data_{idx}_{feed_id}",
+            {"feed_url": feed_url, "feed_id": feed_id, "idx": idx},
+        )
+
+    def _load_cached_manpage(self, source: dict[str, Any]) -> None:
+        """Load cached manpage scraper data."""
+        idx = self._next_source_index("manpage")
+        man_names = source.get("names", [])
+        man_path = source.get("path", "")
+        man_id = man_names[0] if man_names else os.path.basename(man_path.rstrip("/"))
+        self._append_cached_data_source(
+            "manpage",
+            f"manpage_data_{idx}_{man_id}",
+            {"man_id": man_id, "idx": idx},
+        )
+
+    def _load_cached_chat(self, source: dict[str, Any]) -> None:
+        """Load cached chat scraper data."""
+        idx = self._next_source_index("chat")
+        export_path = source.get("path", "")
+        channel = source.get("channel", source.get("channel_id", ""))
+        chat_id = channel or os.path.basename(export_path.rstrip("/")) or f"chat_{idx}"
+        self._append_cached_data_source(
+            "chat",
+            f"chat_data_{idx}_{chat_id}",
+            {"chat_id": chat_id, "platform": source.get("platform", "slack"), "idx": idx},
+        )
+
     def _load_json_fallback(self, primary: Path, fallback: Path) -> dict:
         """Load JSON from primary path, falling back to secondary if not found."""
         if primary.exists():
@@ -1583,7 +1909,10 @@ class UnifiedScraper(SkillConverter):
 
     def extract(self):
         """SkillConverter interface — delegates to scrape_all_sources()."""
-        self.scrape_all_sources()
+        if getattr(self, "skip_scrape", False):
+            self._load_cached_sources()
+        else:
+            self.scrape_all_sources()
 
     def build_skill(self, merged_data: dict | None = None):
         """
@@ -1647,8 +1976,12 @@ class UnifiedScraper(SkillConverter):
             return 0
 
         try:
-            # Phase 1: Scrape all sources
-            scraped_count = self.scrape_all_sources()
+            # Phase 1: Scrape all sources, or rebuild in-memory source state
+            # from the previous .skillseeker-cache when skip_scrape is set.
+            if getattr(self, "skip_scrape", False):
+                scraped_count = self._load_cached_sources()
+            else:
+                scraped_count = self.scrape_all_sources()
 
             # Abort if every source failed — otherwise we'd build (and report
             # success for) an empty skill from no data.

--- a/src/skill_seekers/cli/unified_skill_builder.py
+++ b/src/skill_seekers/cli/unified_skill_builder.py
@@ -100,16 +100,29 @@ class UnifiedSkillBuilder:
         # Determine base directory for source SKILL.md files
         sources_dir = Path(self.cache_dir) / "sources" if self.cache_dir else Path("output")
 
-        # Load documentation SKILL.md
-        docs_skill_path = sources_dir / f"{self.name}_docs" / "SKILL.md"
-        if docs_skill_path.exists():
-            try:
-                skill_mds["documentation"] = docs_skill_path.read_text(encoding="utf-8")
-                logger.debug(
-                    f"Loaded documentation SKILL.md ({len(skill_mds['documentation'])} chars)"
-                )
-            except OSError as e:
-                logger.warning(f"Failed to read documentation SKILL.md: {e}")
+        # Load ALL documentation sources. A single docs source keeps the
+        # historical {name}_docs cache path; multiple docs sources use
+        # {name}_docs_{idx}_{slug}.
+        docs_sources = []
+        docs_dirs = [sources_dir / f"{self.name}_docs"]
+        docs_dirs.extend(sorted(sources_dir.glob(f"{self.name}_docs_*")))
+        for docs_dir in docs_dirs:
+            docs_skill_path = docs_dir / "SKILL.md"
+            if docs_skill_path.exists():
+                try:
+                    content = docs_skill_path.read_text(encoding="utf-8")
+                    docs_sources.append(content)
+                    logger.debug(
+                        f"Loaded documentation SKILL.md from {docs_dir.name} ({len(content)} chars)"
+                    )
+                except OSError as e:
+                    logger.warning(
+                        f"Failed to read documentation SKILL.md from {docs_dir.name}: {e}"
+                    )
+
+        if docs_sources:
+            skill_mds["documentation"] = "\n\n---\n\n".join(docs_sources)
+            logger.debug(f"Combined {len(docs_sources)} documentation SKILL.md files")
 
         # Load ALL GitHub sources (multi-source support)
         github_sources = []

--- a/src/skill_seekers/mcp/tools/scraping_tools.py
+++ b/src/skill_seekers/mcp/tools/scraping_tools.py
@@ -119,9 +119,8 @@ async def scrape_docs_tool(args: dict) -> list[TextContent]:
             - unlimited (bool, optional): Remove page limit (default: False)
             - enhance_local (bool, optional): Open terminal for local enhancement (default: False)
             - skip_scrape (bool, optional): Skip scraping, use cached data (default: False).
-              Single-source configs only — not yet supported for unified
-              multi-source configs (a warning is emitted and all sources are
-              re-scraped).
+              Legacy configs rebuild from each converter's cached extraction file;
+              unified configs rebuild from .skillseeker-cache per-source data.
             - dry_run (bool, optional): Preview without saving (default: False)
             - merge_mode (str, optional): Override merge mode for unified configs
 
@@ -184,16 +183,8 @@ async def scrape_docs_tool(args: dict) -> list[TextContent]:
             # merge_mode/dry_run overrides). dry_run must go through the
             # constructor: UnifiedScraper.run() previews-and-returns and
             # __init__ skips directory creation.
-            # skip_scrape is NOT yet honored on the unified multi-source path
-            # (it would need to reload each source's cached data from
-            # .skillseeker-cache before building); the attribute is set for
-            # forward-compat but currently has no effect here. Single-source
-            # configs DO honor skip_scrape (SkillConverter.run).
-            if skip_scrape:
-                progress_msg += (
-                    "⚠️ skip_scrape is not yet supported for unified multi-source "
-                    "configs — all sources will be re-scraped\n\n"
-                )
+            # skip_scrape is honored by UnifiedScraper.run(), which reloads
+            # cached per-source data from .skillseeker-cache before building.
             converter = get_converter(
                 "config",
                 {"config_path": config_to_use, "merge_mode": merge_mode, "dry_run": dry_run},

--- a/tests/test_create_pipeline_regressions.py
+++ b/tests/test_create_pipeline_regressions.py
@@ -6,7 +6,8 @@ Covers:
    and leftover output from a prior run existed.
 2. create_command: CLI --skip-scrape only landed in the config dict while
    SkillConverter.run() reads the instance attribute via getattr — the CLI
-   flag was a silent no-op (full network re-scrape).
+   flag was a silent no-op (full network re-scrape), including unified config
+   sources whose converter is built through a factory-shaped dict.
 3. skill_converter: the skip_scrape branch went straight to build_skill()
    without reloading cached data — document-family converters (pdf, word,
    epub, …) have self.extracted_data=None and crashed with AttributeError.
@@ -156,6 +157,21 @@ class TestSkipScrapePromotedToConverter:
         assert result == 0
         assert stub.run_called
         assert not hasattr(stub, "skip_scrape")
+
+    def test_config_source_skip_scrape_flag_sets_converter_attribute(self, tmp_path):
+        config = {
+            "name": "uni",
+            "description": "d",
+            "sources": [{"type": "documentation", "base_url": "https://example.com"}],
+        }
+        cfg = tmp_path / "uni.json"
+        cfg.write_text(json.dumps(config), encoding="utf-8")
+
+        result, stub = self._execute_with_stub(make_create_args(source=str(cfg), skip_scrape=True))
+
+        assert result == 0
+        assert stub.run_called
+        assert getattr(stub, "skip_scrape", False) is True
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/tests/test_unified.py
+++ b/tests/test_unified.py
@@ -457,8 +457,34 @@ def test_skill_builder_basic():
         assert skill_md.exists()
 
         content = skill_md.read_text()
-        assert "test_skill" in content.lower()
-        assert "Test skill description" in content
+    assert "test_skill" in content.lower()
+    assert "Test skill description" in content
+
+
+def test_skill_builder_loads_multiple_documentation_skill_mds(tmp_path):
+    """Multiple documentation source SKILL.md files are all loaded from cache."""
+    config = {
+        "name": "test_skill",
+        "description": "Test skill description",
+        "sources": [
+            {"type": "documentation", "base_url": "https://example.com/a"},
+            {"type": "documentation", "base_url": "https://example.com/b"},
+        ],
+    }
+    sources_dir = tmp_path / "cache" / "sources"
+    first_docs = sources_dir / "test_skill_docs_0_a"
+    second_docs = sources_dir / "test_skill_docs_1_b"
+    first_docs.mkdir(parents=True)
+    second_docs.mkdir(parents=True)
+    (first_docs / "SKILL.md").write_text("# First docs\n", encoding="utf-8")
+    (second_docs / "SKILL.md").write_text("# Second docs\n", encoding="utf-8")
+
+    builder = UnifiedSkillBuilder(config, {}, cache_dir=str(tmp_path / "cache"))
+
+    skill_mds = builder._load_source_skill_mds()
+
+    assert "# First docs" in skill_mds["documentation"]
+    assert "# Second docs" in skill_mds["documentation"]
 
 
 def test_skill_builder_with_conflicts():

--- a/tests/test_unified_mcp_integration.py
+++ b/tests/test_unified_mcp_integration.py
@@ -153,11 +153,8 @@ async def test_mcp_scrape_docs_detection():
 
 
 @pytest.mark.skipif(not MCP_AVAILABLE, reason="MCP package not installed")
-async def test_mcp_scrape_docs_unified_skip_scrape_warns():
-    """Regression: skip_scrape is a no-op on the unified path
-    (UnifiedScraper.run() never reads the attribute and re-scrapes every
-    source) — the tool result must say so explicitly instead of silently
-    misleading the caller."""
+async def test_mcp_scrape_docs_unified_skip_scrape_sets_attribute_without_warning():
+    """Unified skip_scrape is honored by UnifiedScraper, so MCP should not warn."""
     from unittest.mock import patch
 
     unified_config = {
@@ -178,7 +175,7 @@ async def test_mcp_scrape_docs_unified_skip_scrape_warns():
         json.dump(legacy_config, f)
         legacy_config_path = f.name
 
-    warning = "skip_scrape is not yet supported for unified multi-source configs"
+    old_warning = "skip_scrape is not yet supported for unified multi-source configs"
 
     try:
         with (
@@ -191,25 +188,24 @@ async def test_mcp_scrape_docs_unified_skip_scrape_warns():
                 TextContent(type="text", text=progress_msg)
             ]
 
-            # Unified + skip_scrape → explicit warning in the tool result.
+            # Unified + skip_scrape → no stale warning, attribute is set.
             result = await scrape_docs_tool(
                 {"config_path": unified_config_path, "skip_scrape": True}
             )
             text = result[0].text
-            assert warning in text, f"Expected skip_scrape warning, got: {text}"
-            assert "all sources will be re-scraped" in text
-            # The attribute is still set for forward-compat.
+            assert old_warning not in text
+            assert "all sources will be re-scraped" not in text
             assert mock_get_converter.return_value.skip_scrape is True
 
             # Unified without skip_scrape → no warning.
             result = await scrape_docs_tool({"config_path": unified_config_path})
-            assert warning not in result[0].text
+            assert old_warning not in result[0].text
 
             # Legacy + skip_scrape → honored (SkillConverter.run), no warning.
             result = await scrape_docs_tool(
                 {"config_path": legacy_config_path, "skip_scrape": True}
             )
-            assert warning not in result[0].text
+            assert old_warning not in result[0].text
     finally:
         Path(unified_config_path).unlink(missing_ok=True)
         Path(legacy_config_path).unlink(missing_ok=True)
@@ -257,7 +253,7 @@ async def run_all_tests():
         await test_mcp_validate_unified_config()
         await test_mcp_validate_legacy_config()
         await test_mcp_scrape_docs_detection()
-        await test_mcp_scrape_docs_unified_skip_scrape_warns()
+        await test_mcp_scrape_docs_unified_skip_scrape_sets_attribute_without_warning()
         await test_mcp_merge_mode_override()
 
         print("\n" + "=" * 60)

--- a/tests/test_unified_scraper_orchestration.py
+++ b/tests/test_unified_scraper_orchestration.py
@@ -372,6 +372,8 @@ class TestScrapePdf:
         mock_cls.assert_called_once()
         init_config = mock_cls.call_args[0][0]
         assert init_config["pdf_path"] == pdf_path
+        assert init_config["output_dir"].startswith(scraper.sources_dir)
+        assert init_config["output_dir"].endswith("test_unified_pdf_0_manual")
 
     def test_extract_called(self, tmp_path, monkeypatch):
         scraper = _make_scraper(tmp_path=tmp_path)
@@ -822,6 +824,47 @@ class TestUnifiedCacheFlow:
         # The flow must not create a stray ./output/<name>_docs staging dir.
         assert not (Path.cwd() / "output" / f"{scraper.name}_docs").exists()
 
+    def test_multiple_documentation_sources_use_distinct_cache_dirs(self, tmp_path, monkeypatch):
+        import os
+
+        monkeypatch.chdir(tmp_path)
+
+        sources = [
+            {"base_url": "https://docs.example.com/a/", "type": "documentation"},
+            {"base_url": "https://docs.example.com/b/", "type": "documentation"},
+        ]
+        scraper = _make_scraper({"sources": sources}, tmp_path=tmp_path)
+        Path(scraper.sources_dir).mkdir(parents=True, exist_ok=True)
+
+        captured = []
+
+        def fake_scrape(config, **_kwargs):
+            out = config["output_dir"]
+            captured.append(out)
+            os.makedirs(f"{out}_data", exist_ok=True)
+            os.makedirs(os.path.join(out, "references"), exist_ok=True)
+            with open(os.path.join(f"{out}_data", "summary.json"), "w") as f:
+                json.dump({"pages": [{"url": f"{out}/page"}], "total_pages": 1}, f)
+            return 0
+
+        with patch("skill_seekers.cli.doc_scraper.scrape_documentation", side_effect=fake_scrape):
+            for source in sources:
+                scraper._scrape_documentation(source)
+
+        assert len(captured) == 2
+        assert captured[0] != captured[1]
+        assert all(path.startswith(scraper.sources_dir) for path in captured)
+        assert (
+            scraper.scraped_data["documentation"][0]["data_file"]
+            != (scraper.scraped_data["documentation"][1]["data_file"])
+        )
+
+        reloaded = _make_scraper({"sources": sources}, tmp_path=tmp_path)
+        assert reloaded._load_cached_sources() == 2
+        loaded_docs = reloaded.scraped_data["documentation"]
+        assert loaded_docs[0]["source_id"] != loaded_docs[1]["source_id"]
+        assert loaded_docs[0]["data_file"] != loaded_docs[1]["data_file"]
+
 
 class TestUnifiedDryRunAndOutput:
     """MCP-03 follow-up: dry_run must actually be honored by UnifiedScraper,
@@ -859,6 +902,97 @@ class TestUnifiedDryRunAndOutput:
         # Trailing slash is normalized by the shared resolver.
         scraper = UnifiedScraper(str(cfg), output_dir=str(tmp_path / "custom") + "/", dry_run=True)
         assert scraper.output_dir == str(tmp_path / "custom")
+
+
+class TestUnifiedSkipScrape:
+    """Unified skip_scrape reloads prior cache instead of scraping again."""
+
+    def test_run_loads_cached_sources_without_rescraping(self, tmp_path):
+        scraper = _make_scraper(
+            {
+                "sources": [
+                    {"type": "documentation", "base_url": "https://example.com/docs"},
+                    {"type": "github", "repo": "owner/repo"},
+                ]
+            },
+            tmp_path=tmp_path,
+        )
+        scraper.skip_scrape = True
+
+        docs_data = Path(scraper.sources_dir) / "test_unified_docs_data" / "summary.json"
+        docs_data.parent.mkdir(parents=True, exist_ok=True)
+        docs_data.write_text(
+            json.dumps({"pages": [{"title": "Intro", "url": "https://example.com"}]}),
+            encoding="utf-8",
+        )
+
+        github_data = Path(scraper.data_dir) / "github_data_0_owner_repo.json"
+        github_data.write_text(json.dumps({"readme": "cached"}), encoding="utf-8")
+
+        with (
+            patch.object(scraper, "scrape_all_sources") as scrape,
+            patch.object(scraper, "detect_conflicts", return_value=[]) as detect,
+            patch.object(scraper, "build_skill") as build,
+        ):
+            result = scraper.run()
+
+        assert result == 0
+        scrape.assert_not_called()
+        detect.assert_called_once()
+        build.assert_called_once_with(None)
+        assert scraper.scraped_data["documentation"][0]["data_file"] == str(docs_data)
+        assert scraper.scraped_data["documentation"][0]["pages"][0]["title"] == "Intro"
+        assert scraper.scraped_data["github"][0]["data"] == {"readme": "cached"}
+
+    def test_run_fails_if_skip_scrape_cache_is_missing(self, tmp_path):
+        scraper = _make_scraper(
+            {"sources": [{"type": "github", "repo": "owner/repo"}]},
+            tmp_path=tmp_path,
+        )
+        scraper.skip_scrape = True
+
+        with (
+            patch.object(scraper, "scrape_all_sources") as scrape,
+            patch.object(scraper, "build_skill") as build,
+        ):
+            result = scraper.run()
+
+        assert result == 1
+        scrape.assert_not_called()
+        build.assert_not_called()
+
+    def test_load_cached_sources_restores_converter_backed_source_shape(self, tmp_path):
+        scraper = _make_scraper(
+            {"sources": [{"type": "pdf", "path": "/tmp/manual.pdf"}]},
+            tmp_path=tmp_path,
+        )
+        pdf_data = Path(scraper.data_dir) / "pdf_data_0_manual.json"
+        pdf_data.write_text(json.dumps({"pages": [{"title": "Manual"}]}), encoding="utf-8")
+
+        assert scraper._load_cached_sources() == 1
+        assert scraper.scraped_data["pdf"][0] == {
+            "pdf_path": "/tmp/manual.pdf",
+            "pdf_id": "manual",
+            "idx": 0,
+            "data": {"pages": [{"title": "Manual"}]},
+            "data_file": str(pdf_data),
+        }
+
+    def test_load_cached_video_uses_unified_data_cache(self, tmp_path):
+        scraper = _make_scraper(
+            {"sources": [{"type": "video", "url": "https://youtu.be/example"}]},
+            tmp_path=tmp_path,
+        )
+        video_data = Path(scraper.data_dir) / "video_data_0.json"
+        video_data.write_text(json.dumps({"videos": [{"title": "Demo"}]}), encoding="utf-8")
+
+        assert scraper._load_cached_sources() == 1
+        assert scraper.scraped_data["video"][0] == {
+            "video_id": "https://youtu.be/example",
+            "idx": 0,
+            "data": {"videos": [{"title": "Demo"}]},
+            "data_file": str(video_data),
+        }
 
 
 # ===========================================================================


### PR DESCRIPTION
## Description

Fixes unified multi-source `skip_scrape` so cached unified configs rebuild from prior extraction data instead of re-scraping every source from the network.

Changes:
- Add `UnifiedScraper` cache reload path for `skip_scrape`, restoring `scraped_data` from `.skillseeker-cache` before conflict detection and build.
- Route converter-backed source outputs, video data, and multi-documentation source caches through the unified cache structure.
- Forward `--skip-scrape` through the `create` config-source path and remove the stale MCP warning that unified configs are unsupported.
- Update CHANGELOG / bug audit notes for #405.

## Related Issues

Closes #405

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test update
- [x] Documentation update

## Testing

- `.venv/bin/ruff format --check src/skill_seekers/cli/unified_scraper.py src/skill_seekers/cli/unified_skill_builder.py src/skill_seekers/cli/create_command.py src/skill_seekers/mcp/tools/scraping_tools.py tests/test_unified_scraper_orchestration.py tests/test_create_pipeline_regressions.py tests/test_unified_mcp_integration.py tests/test_unified.py`
- `.venv/bin/ruff check src/skill_seekers/cli/unified_scraper.py src/skill_seekers/cli/unified_skill_builder.py src/skill_seekers/cli/create_command.py src/skill_seekers/mcp/tools/scraping_tools.py tests/test_unified_scraper_orchestration.py tests/test_create_pipeline_regressions.py tests/test_unified_mcp_integration.py tests/test_unified.py`
- `.venv/bin/python -m pytest tests/test_unified_scraper_orchestration.py tests/test_create_pipeline_regressions.py tests/test_unified_mcp_integration.py tests/test_unified.py -q`

**Test Configuration:**
- Python version: 3.11.15 via uv-created local `.venv`
- OS: macOS / Darwin
- Dependencies installed: dev + MCP extras in local `.venv` only; local artifacts cleaned before commit

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Documentation updated (CHANGELOG, BUG_AUDIT)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing targeted unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

`skip_scrape` now fails fast with a clear missing-cache error when a unified config has no prior cached extraction data, instead of silently falling back to network scraping.
