### PR TITLE
fix: make Kotlin analyzer string-aware

### DIFF
--- a/src/skill_seekers/cli/code_analyzer.py
+++ b/src/skill_seekers/cli/code_analyzer.py
@@ -583,6 +583,200 @@ class CodeAnalyzer:
 
         return params
 
+    def _mask_c_style_non_code(
+        self,
+        content: str,
+        *,
+        mask_comments: bool,
+        mask_backticks: bool = True,
+        backtick_escapes: bool = True,
+        nested_block_comments: bool = False,
+    ) -> str:
+        """Mask string literals, and optionally comments, while preserving offsets."""
+        masked = list(content)
+        content_len = len(content)
+        i = 0
+
+        def mask_span(start: int, end: int) -> None:
+            for pos in range(start, end):
+                if masked[pos] not in "\r\n":
+                    masked[pos] = " "
+
+        while i < content_len:
+            if content.startswith('"""', i):
+                start = i
+                i += 3
+                while i < content_len and not content.startswith('"""', i):
+                    i += 1
+                i = min(i + 3, content_len)
+                mask_span(start, i)
+                continue
+
+            if content[i] == "`" and mask_backticks:
+                start = i
+                i += 1
+                escaped = False
+                while i < content_len:
+                    char = content[i]
+                    if backtick_escapes and escaped:
+                        escaped = False
+                    elif backtick_escapes and char == "\\":
+                        escaped = True
+                    elif char == "`":
+                        i += 1
+                        break
+                    i += 1
+                mask_span(start, i)
+                continue
+
+            if content[i] in ("'", '"'):
+                start = i
+                quote = content[i]
+                i += 1
+                escaped = False
+                while i < content_len:
+                    char = content[i]
+                    if escaped:
+                        escaped = False
+                    elif char == "\\":
+                        escaped = True
+                    elif char == quote:
+                        i += 1
+                        break
+                    i += 1
+                mask_span(start, i)
+                continue
+
+            if content.startswith("//", i):
+                start = i
+                i += 2
+                while i < content_len and content[i] not in "\r\n":
+                    i += 1
+                if mask_comments:
+                    mask_span(start, i)
+                continue
+
+            if content.startswith("/*", i):
+                start = i
+                i += 2
+                depth = 1
+                while i < content_len - 1 and depth > 0:
+                    if nested_block_comments and content.startswith("/*", i):
+                        depth += 1
+                        i += 2
+                    elif content.startswith("*/", i):
+                        depth -= 1
+                        i += 2
+                    else:
+                        i += 1
+                if mask_comments:
+                    mask_span(start, i)
+                continue
+
+            i += 1
+
+        return "".join(masked)
+
+    def _extract_c_style_comments(
+        self,
+        content: str,
+        *,
+        doc_blocks: bool,
+        backtick_escapes: bool = True,
+        nested_block_comments: bool = False,
+    ) -> list[dict]:
+        """Extract C-style comments without matching markers inside strings/comments."""
+        comments = []
+        content_len = len(content)
+        i = 0
+
+        while i < content_len:
+            if content.startswith('"""', i):
+                i += 3
+                while i < content_len and not content.startswith('"""', i):
+                    i += 1
+                i = min(i + 3, content_len)
+                continue
+
+            if content[i] == "`":
+                i += 1
+                escaped = False
+                while i < content_len:
+                    char = content[i]
+                    if backtick_escapes and escaped:
+                        escaped = False
+                    elif backtick_escapes and char == "\\":
+                        escaped = True
+                    elif char == "`":
+                        i += 1
+                        break
+                    i += 1
+                continue
+
+            if content[i] in ("'", '"'):
+                quote = content[i]
+                i += 1
+                escaped = False
+                while i < content_len:
+                    char = content[i]
+                    if escaped:
+                        escaped = False
+                    elif char == "\\":
+                        escaped = True
+                    elif char == quote:
+                        i += 1
+                        break
+                    i += 1
+                continue
+
+            if content.startswith("//", i):
+                start = i
+                text_start = i + 2
+                i = text_start
+                while i < content_len and content[i] not in "\r\n":
+                    i += 1
+                if i > text_start:
+                    comments.append(
+                        {
+                            "line": self._offset_to_line(start),
+                            "text": content[text_start:i].strip(),
+                            "type": "inline",
+                        }
+                    )
+                continue
+
+            if content.startswith("/*", i):
+                start = i
+                is_doc = content.startswith("/**", i)
+                text_start = i + 3 if is_doc else i + 2
+                i += 2
+                depth = 1
+                text_end = content_len
+                while i < content_len - 1 and depth > 0:
+                    if nested_block_comments and content.startswith("/*", i):
+                        depth += 1
+                        i += 2
+                    elif content.startswith("*/", i):
+                        depth -= 1
+                        if depth == 0:
+                            text_end = i
+                        i += 2
+                    else:
+                        i += 1
+
+                comments.append(
+                    {
+                        "line": self._offset_to_line(start),
+                        "text": content[text_start:text_end].strip(),
+                        "type": "doc" if doc_blocks and is_doc else "block",
+                    }
+                )
+                continue
+
+            i += 1
+
+        return comments
+
     def _extract_python_comments(self, content: str) -> list[dict]:
         """
         Extract Python comments (# style).
@@ -605,29 +799,18 @@ class CodeAnalyzer:
 
         return comments
 
-    def _extract_js_comments(self, content: str) -> list[dict]:
+    def _extract_js_comments(self, content: str, *, backtick_escapes: bool = True) -> list[dict]:
         """
         Extract JavaScript/TypeScript comments (// and /* */ styles).
 
         Returns list of comment dictionaries with line number, text, and type.
         """
-        comments = []
-
-        # Extract single-line comments (//)
-        for match in re.finditer(r"//(.+)$", content, re.MULTILINE):
-            line_num = self._offset_to_line(match.start())
-            comment_text = match.group(1).strip()
-
-            comments.append({"line": line_num, "text": comment_text, "type": "inline"})
-
-        # Extract multi-line comments (/* */)
-        for match in re.finditer(r"/\*(.+?)\*/", content, re.DOTALL):
-            start_line = self._offset_to_line(match.start())
-            comment_text = match.group(1).strip()
-
-            comments.append({"line": start_line, "text": comment_text, "type": "block"})
-
-        return comments
+        comments = self._extract_c_style_comments(
+            content, doc_blocks=False, backtick_escapes=backtick_escapes
+        )
+        return [c for c in comments if c["type"] == "inline"] + [
+            c for c in comments if c["type"] == "block"
+        ]
 
     def _extract_cpp_comments(self, content: str) -> list[dict]:
         """
@@ -957,7 +1140,7 @@ class CodeAnalyzer:
     def _extract_go_comments(self, content: str) -> list[dict]:
         """Extract Go comments (// and /* */ styles)."""
         # Go uses C-style comments
-        return self._extract_js_comments(content)
+        return self._extract_js_comments(content, backtick_escapes=False)
 
     def _analyze_rust(self, content: str, _file_path: str) -> dict[str, Any]:
         """
@@ -1260,28 +1443,16 @@ class CodeAnalyzer:
 
         return params
 
-    def _extract_java_comments(self, content: str) -> list[dict]:
+    def _extract_java_comments(
+        self, content: str, *, nested_block_comments: bool = False
+    ) -> list[dict]:
         """Extract Java comments (// and /* */ and /** JavaDoc */)."""
-        comments = []
-
-        # Single-line comments (//)
-        for match in re.finditer(r"//(.+)$", content, re.MULTILINE):
-            line_num = self._offset_to_line(match.start())
-            comment_text = match.group(1).strip()
-
-            comments.append({"line": line_num, "text": comment_text, "type": "inline"})
-
-        # Multi-line and JavaDoc comments (/* */ and /** */)
-        for match in re.finditer(r"/\*\*?(.+?)\*/", content, re.DOTALL):
-            start_line = self._offset_to_line(match.start())
-            comment_text = match.group(1).strip()
-
-            # Distinguish JavaDoc (starts with **)
-            comment_type = "doc" if match.group(0).startswith("/**") else "block"
-
-            comments.append({"line": start_line, "text": comment_text, "type": comment_type})
-
-        return comments
+        comments = self._extract_c_style_comments(
+            content, doc_blocks=True, nested_block_comments=nested_block_comments
+        )
+        return [c for c in comments if c["type"] == "inline"] + [
+            c for c in comments if c["type"] in {"block", "doc"}
+        ]
 
     def _analyze_kotlin(self, content: str, _file_path: str) -> dict[str, Any]:
         """
@@ -1298,6 +1469,12 @@ class CodeAnalyzer:
         https://kotlinlang.org/spec/
         """
         self._newline_offsets = build_line_index(content)
+        structural_content = self._mask_c_style_non_code(
+            content,
+            mask_comments=True,
+            mask_backticks=False,
+            nested_block_comments=True,
+        )
         classes = []
         functions = []
 
@@ -1311,9 +1488,11 @@ class CodeAnalyzer:
             r"(?:\s*:\s*([\w\s,.<>()]+?))?"  # Superclass/interfaces
             r"\s*\{"
         )
-        for match in re.finditer(class_pattern, content):
+        for match in re.finditer(class_pattern, structural_content):
             class_name = match.group(1)
-            supertypes_str = match.group(2)
+            supertypes_str = (
+                content[match.start(2) : match.end(2)] if match.group(2) is not None else None
+            )
 
             base_classes = []
             if supertypes_str:
@@ -1331,8 +1510,8 @@ class CodeAnalyzer:
             class_block_end = class_block_start
             # Index-based scan — slicing content[class_block_start:] copied the
             # whole remainder of the file for every class match.
-            for i in range(class_block_start, len(content)):
-                char = content[i]
+            for i in range(class_block_start, len(structural_content)):
+                char = structural_content[i]
                 if char == "{":
                     brace_count += 1
                 elif char == "}":
@@ -1359,9 +1538,11 @@ class CodeAnalyzer:
 
         # Extract object declarations (Kotlin singletons)
         object_pattern = r"(?:(?:public|private|protected|internal)\s+)?object\s+(\w+)(?:\s*:\s*([\w\s,.<>()]+?))?\s*\{"
-        for match in re.finditer(object_pattern, content):
+        for match in re.finditer(object_pattern, structural_content):
             obj_name = match.group(1)
-            supertypes_str = match.group(2)
+            supertypes_str = (
+                content[match.start(2) : match.end(2)] if match.group(2) is not None else None
+            )
 
             base_classes = []
             if supertypes_str:
@@ -1374,7 +1555,7 @@ class CodeAnalyzer:
             block_start = match.end()
             brace_count = 1
             block_end = block_start
-            for i, char in enumerate(content[block_start:], block_start):
+            for i, char in enumerate(structural_content[block_start:], block_start):
                 if char == "{":
                     brace_count += 1
                 elif char == "}":
@@ -1415,11 +1596,13 @@ class CodeAnalyzer:
         # was O(n²) on large Kotlin files.)
         brace_depth = 0
         last_pos = 0
-        for match in re.finditer(func_pattern, content):
+        for match in re.finditer(func_pattern, structural_content):
             _receiver_type = match.group(1)
             func_name = match.group(2)
-            params_str = match.group(3)
-            return_type = match.group(4)
+            params_str = content[match.start(3) : match.end(3)]
+            return_type = (
+                content[match.start(4) : match.end(4)] if match.group(4) is not None else None
+            )
 
             if return_type:
                 return_type = return_type.strip()
@@ -1428,7 +1611,7 @@ class CodeAnalyzer:
             # by _extract_kotlin_methods). Brace-counting is more reliable than
             # the old indentation heuristic, which mis-handled tabs / 2-space
             # styles.
-            gap = content[last_pos : match.start()]
+            gap = structural_content[last_pos : match.start()]
             brace_depth += gap.count("{") - gap.count("}")
             last_pos = match.start()
             if brace_depth > 0:
@@ -1457,7 +1640,9 @@ class CodeAnalyzer:
             )
 
         # Extract comments (// and /* */ and /** KDoc */)
-        comments = self._extract_java_comments(content)  # Same syntax as Java
+        comments = self._extract_java_comments(
+            content, nested_block_comments=True
+        )  # Same syntax as Java, plus Kotlin nested block comments.
 
         # Extract imports
         imports = []
@@ -1479,6 +1664,12 @@ class CodeAnalyzer:
     def _extract_kotlin_methods(self, class_body: str) -> list[dict]:
         """Extract Kotlin method signatures from class body."""
         methods = []
+        method_source = self._mask_c_style_non_code(
+            class_body,
+            mask_comments=True,
+            mask_backticks=False,
+            nested_block_comments=True,
+        )
 
         method_pattern = (
             r"(?:(?:public|private|protected|internal|override)\s+)*"
@@ -1490,10 +1681,12 @@ class CodeAnalyzer:
             r"\(([^)]*)\)"
             r"(?:\s*:\s*([\w<>.,\s?*]+))?"
         )
-        for match in re.finditer(method_pattern, class_body):
+        for match in re.finditer(method_pattern, method_source):
             method_name = match.group(1)
-            params_str = match.group(2)
-            return_type = match.group(3)
+            params_str = class_body[match.start(2) : match.end(2)]
+            return_type = (
+                class_body[match.start(3) : match.end(3)] if match.group(3) is not None else None
+            )
 
             if return_type:
                 return_type = return_type.strip()

--- a/src/skill_seekers/cli/code_analyzer.py
+++ b/src/skill_seekers/cli/code_analyzer.py
@@ -583,150 +583,119 @@ class CodeAnalyzer:
 
         return params
 
-    def _mask_c_style_non_code(
+    def _iter_c_style_spans(
         self,
         content: str,
         *,
-        mask_comments: bool,
-        mask_backticks: bool = True,
         backtick_escapes: bool = True,
         nested_block_comments: bool = False,
-    ) -> str:
-        """Mask string literals, and optionally comments, while preserving offsets."""
-        masked = list(content)
+        string_templates: bool = False,
+    ):
+        """Yield the non-code spans (strings, backtick spans, comments) of C-style source.
+
+        Each yielded dict carries:
+          ``kind``       — "string" | "backtick" | "line_comment" | "block_comment"
+          ``start``/``end`` — span bounds (``end`` exclusive, covering the closing marker)
+          ``text_start``/``text_end`` — comment-text bounds with markers stripped
+                                        (both equal ``start`` for non-comments)
+          ``closed``     — whether a block comment terminated with ``*/`` (always True
+                           for other kinds)
+          ``is_doc``     — whether a block comment opened with ``/**``
+
+        This scanner is the single source of truth for "what is a string/comment".
+        ``_mask_c_style_non_code`` and ``_extract_c_style_comments`` both consume it, so a
+        scanning fix applies to masking and extraction at once. ``string_templates`` makes
+        double-quoted strings honour Kotlin ``${...}`` interpolation (so nested quotes/braces
+        inside an interpolation don't prematurely end the string).
+        """
         content_len = len(content)
-        i = 0
 
-        def mask_span(start: int, end: int) -> None:
-            for pos in range(start, end):
-                if masked[pos] not in "\r\n":
-                    masked[pos] = " "
-
-        while i < content_len:
-            if content.startswith('"""', i):
-                start = i
-                i += 3
-                while i < content_len and not content.startswith('"""', i):
-                    i += 1
-                i = min(i + 3, content_len)
-                mask_span(start, i)
-                continue
-
-            if content[i] == "`" and mask_backticks:
-                start = i
-                i += 1
-                escaped = False
-                while i < content_len:
-                    char = content[i]
-                    if backtick_escapes and escaped:
-                        escaped = False
-                    elif backtick_escapes and char == "\\":
-                        escaped = True
-                    elif char == "`":
-                        i += 1
-                        break
-                    i += 1
-                mask_span(start, i)
-                continue
-
-            if content[i] in ("'", '"'):
-                start = i
-                quote = content[i]
-                i += 1
-                escaped = False
-                while i < content_len:
-                    char = content[i]
+        def skip_string(j: int, *, triple: bool, escapes: bool, templates: bool) -> int:
+            """Return the index just past the end of a string starting at ``j``."""
+            if triple:
+                j += 3
+            else:
+                quote = content[j]
+                j += 1
+            escaped = False
+            while j < content_len:
+                if triple:
+                    if content.startswith('"""', j):
+                        return j + 3
+                else:
                     if escaped:
                         escaped = False
-                    elif char == "\\":
+                        j += 1
+                        continue
+                    if escapes and content[j] == "\\":
                         escaped = True
-                    elif char == quote:
-                        i += 1
-                        break
-                    i += 1
-                mask_span(start, i)
-                continue
+                        j += 1
+                        continue
+                    if content[j] == quote:
+                        return j + 1
+                if templates and content.startswith("${", j):
+                    j = skip_interpolation(j)
+                    continue
+                j += 1
+            return content_len  # unterminated
 
-            if content.startswith("//", i):
-                start = i
-                i += 2
-                while i < content_len and content[i] not in "\r\n":
-                    i += 1
-                if mask_comments:
-                    mask_span(start, i)
-                continue
+        def skip_interpolation(j: int) -> int:
+            """Return the index just past the closing ``}`` of a ``${...}`` block at ``j``."""
+            j += 2  # past "${"
+            depth = 1
+            while j < content_len and depth > 0:
+                ch = content[j]
+                if ch == "{":
+                    depth += 1
+                    j += 1
+                elif ch == "}":
+                    depth -= 1
+                    j += 1
+                elif ch == '"':
+                    j = skip_string(
+                        j, triple=content.startswith('"""', j), escapes=True, templates=True
+                    )
+                elif ch == "'":
+                    j = skip_string(j, triple=False, escapes=True, templates=False)
+                elif ch == "`":
+                    j = skip_string(j, triple=False, escapes=backtick_escapes, templates=False)
+                else:
+                    j += 1
+            return j
 
-            if content.startswith("/*", i):
-                start = i
-                i += 2
-                depth = 1
-                while i < content_len - 1 and depth > 0:
-                    if nested_block_comments and content.startswith("/*", i):
-                        depth += 1
-                        i += 2
-                    elif content.startswith("*/", i):
-                        depth -= 1
-                        i += 2
-                    else:
-                        i += 1
-                if mask_comments:
-                    mask_span(start, i)
-                continue
-
-            i += 1
-
-        return "".join(masked)
-
-    def _extract_c_style_comments(
-        self,
-        content: str,
-        *,
-        doc_blocks: bool,
-        backtick_escapes: bool = True,
-        nested_block_comments: bool = False,
-    ) -> list[dict]:
-        """Extract C-style comments without matching markers inside strings/comments."""
-        comments = []
-        content_len = len(content)
         i = 0
-
         while i < content_len:
             if content.startswith('"""', i):
-                i += 3
-                while i < content_len and not content.startswith('"""', i):
-                    i += 1
-                i = min(i + 3, content_len)
+                end = skip_string(i, triple=True, escapes=False, templates=string_templates)
+                yield {"kind": "string", "start": i, "end": end}
+                i = end
                 continue
 
+            # Backtick spans (JS template strings, Go raw strings, Kotlin escaped
+            # identifiers) are always consumed so a quote/marker inside them is never
+            # misread as the start of a string or comment.
             if content[i] == "`":
+                end = skip_string(i, triple=False, escapes=backtick_escapes, templates=False)
+                yield {"kind": "backtick", "start": i, "end": end}
+                i = end
+                continue
+
+            # A ``'`` flanked by alphanumerics is a digit separator (e.g. C++ ``1'000``)
+            # or stray apostrophe, not a char-literal delimiter.
+            if (
+                content[i] == "'"
+                and 0 < i < content_len - 1
+                and content[i - 1].isalnum()
+                and content[i + 1].isalnum()
+            ):
                 i += 1
-                escaped = False
-                while i < content_len:
-                    char = content[i]
-                    if backtick_escapes and escaped:
-                        escaped = False
-                    elif backtick_escapes and char == "\\":
-                        escaped = True
-                    elif char == "`":
-                        i += 1
-                        break
-                    i += 1
                 continue
 
             if content[i] in ("'", '"'):
-                quote = content[i]
-                i += 1
-                escaped = False
-                while i < content_len:
-                    char = content[i]
-                    if escaped:
-                        escaped = False
-                    elif char == "\\":
-                        escaped = True
-                    elif char == quote:
-                        i += 1
-                        break
-                    i += 1
+                templates = string_templates and content[i] == '"'
+                end = skip_string(i, triple=False, escapes=True, templates=templates)
+                yield {"kind": "string", "start": i, "end": end}
+                i = end
                 continue
 
             if content.startswith("//", i):
@@ -735,14 +704,14 @@ class CodeAnalyzer:
                 i = text_start
                 while i < content_len and content[i] not in "\r\n":
                     i += 1
-                if i > text_start:
-                    comments.append(
-                        {
-                            "line": self._offset_to_line(start),
-                            "text": content[text_start:i].strip(),
-                            "type": "inline",
-                        }
-                    )
+                yield {
+                    "kind": "line_comment",
+                    "start": start,
+                    "end": i,
+                    "text_start": text_start,
+                    "text_end": i,
+                    "closed": True,
+                }
                 continue
 
             if content.startswith("/*", i):
@@ -752,7 +721,7 @@ class CodeAnalyzer:
                 i += 2
                 depth = 1
                 text_end = content_len
-                while i < content_len - 1 and depth > 0:
+                while i < content_len and depth > 0:
                     if nested_block_comments and content.startswith("/*", i):
                         depth += 1
                         i += 2
@@ -763,17 +732,96 @@ class CodeAnalyzer:
                         i += 2
                     else:
                         i += 1
-
-                comments.append(
-                    {
-                        "line": self._offset_to_line(start),
-                        "text": content[text_start:text_end].strip(),
-                        "type": "doc" if doc_blocks and is_doc else "block",
-                    }
-                )
+                yield {
+                    "kind": "block_comment",
+                    "start": start,
+                    "end": i,
+                    "text_start": text_start,
+                    "text_end": text_end,
+                    "closed": depth == 0,
+                    "is_doc": is_doc,
+                }
                 continue
 
             i += 1
+
+    def _mask_c_style_non_code(
+        self,
+        content: str,
+        *,
+        mask_comments: bool,
+        mask_backticks: bool = True,
+        backtick_escapes: bool = True,
+        nested_block_comments: bool = False,
+        string_templates: bool = False,
+    ) -> str:
+        """Mask string literals, and optionally comments, while preserving offsets."""
+        masked = list(content)
+
+        def mask_span(start: int, end: int) -> None:
+            for pos in range(start, end):
+                if masked[pos] not in "\r\n":
+                    masked[pos] = " "
+
+        for span in self._iter_c_style_spans(
+            content,
+            backtick_escapes=backtick_escapes,
+            nested_block_comments=nested_block_comments,
+            string_templates=string_templates,
+        ):
+            kind = span["kind"]
+            if kind == "string":
+                mask_span(span["start"], span["end"])
+            elif kind == "backtick":
+                if mask_backticks:
+                    mask_span(span["start"], span["end"])
+            elif mask_comments:  # line_comment / block_comment
+                mask_span(span["start"], span["end"])
+
+        return "".join(masked)
+
+    def _extract_c_style_comments(
+        self,
+        content: str,
+        *,
+        doc_blocks: bool,
+        backtick_escapes: bool = True,
+        nested_block_comments: bool = False,
+        string_templates: bool = False,
+    ) -> list[dict]:
+        """Extract C-style comments without matching markers inside strings/comments."""
+        comments = []
+
+        for span in self._iter_c_style_spans(
+            content,
+            backtick_escapes=backtick_escapes,
+            nested_block_comments=nested_block_comments,
+            string_templates=string_templates,
+        ):
+            kind = span["kind"]
+            if kind not in ("line_comment", "block_comment"):
+                continue
+
+            # Skip unterminated block comments and empty comments — mirrors the prior
+            # regex behaviour, which required a closing marker plus at least one inner
+            # character (so a bare ``//``, ``/**/`` or a stray ``/*`` produced nothing).
+            if not span["closed"] or span["text_end"] <= span["text_start"]:
+                continue
+
+            if kind == "line_comment":
+                comment_type = "inline"
+            elif doc_blocks and span["is_doc"]:
+                comment_type = "doc"
+            else:
+                comment_type = "block"
+
+            comments.append(
+                {
+                    "line": self._offset_to_line(span["start"]),
+                    "text": content[span["text_start"] : span["text_end"]].strip(),
+                    "type": comment_type,
+                }
+            )
 
         return comments
 
@@ -1444,11 +1492,18 @@ class CodeAnalyzer:
         return params
 
     def _extract_java_comments(
-        self, content: str, *, nested_block_comments: bool = False
+        self,
+        content: str,
+        *,
+        nested_block_comments: bool = False,
+        string_templates: bool = False,
     ) -> list[dict]:
         """Extract Java comments (// and /* */ and /** JavaDoc */)."""
         comments = self._extract_c_style_comments(
-            content, doc_blocks=True, nested_block_comments=nested_block_comments
+            content,
+            doc_blocks=True,
+            nested_block_comments=nested_block_comments,
+            string_templates=string_templates,
         )
         return [c for c in comments if c["type"] == "inline"] + [
             c for c in comments if c["type"] in {"block", "doc"}
@@ -1474,6 +1529,7 @@ class CodeAnalyzer:
             mask_comments=True,
             mask_backticks=False,
             nested_block_comments=True,
+            string_templates=True,
         )
         classes = []
         functions = []
@@ -1641,8 +1697,8 @@ class CodeAnalyzer:
 
         # Extract comments (// and /* */ and /** KDoc */)
         comments = self._extract_java_comments(
-            content, nested_block_comments=True
-        )  # Same syntax as Java, plus Kotlin nested block comments.
+            content, nested_block_comments=True, string_templates=True
+        )  # Same syntax as Java, plus Kotlin nested block comments and ${...} templates.
 
         # Extract imports
         imports = []
@@ -1669,6 +1725,7 @@ class CodeAnalyzer:
             mask_comments=True,
             mask_backticks=False,
             nested_block_comments=True,
+            string_templates=True,
         )
 
         method_pattern = (

--- a/tests/test_code_analyzer.py
+++ b/tests/test_code_analyzer.py
@@ -730,6 +730,81 @@ function test() {
         self.assertGreaterEqual(len(inline_comments), 2)
         self.assertGreaterEqual(len(block_comments), 2)
 
+    def test_javascript_comments_ignore_markers_inside_strings(self):
+        """Comment markers inside string literals are not comments."""
+        code = """
+const url = "https://example.com/path";
+const block = "/* not a block comment */";
+const slash = '// not an inline comment';
+const template = `https://example.com/${value}/* not a block either */`;
+
+/* Real block */
+const value = 1;
+// Real inline
+"""
+        result = self.analyzer.analyze_file("test.js", code, "JavaScript")
+
+        comment_texts = [c["text"] for c in result["comments"]]
+        self.assertEqual(comment_texts, ["Real inline", "Real block"])
+
+    def test_javascript_comments_ignore_markers_inside_comments(self):
+        """Comment markers inside real comments are not counted twice."""
+        code = """
+/* Block mentions // not an inline comment */
+const value = 1;
+// Inline mentions /* not a block comment */
+"""
+        result = self.analyzer.analyze_file("test.js", code, "JavaScript")
+
+        comment_texts = [c["text"] for c in result["comments"]]
+        self.assertEqual(
+            comment_texts,
+            [
+                "Inline mentions /* not a block comment */",
+                "Block mentions // not an inline comment",
+            ],
+        )
+
+    def test_java_comments_ignore_markers_inside_strings(self):
+        """Java comment extraction ignores string literals but keeps JavaDoc."""
+        code = """
+public class Demo {
+    String url = "https://example.com/path";
+    String block = "/* not a block comment */";
+
+    // Real inline
+    /** Real JavaDoc */
+    /* Real block */
+    void run() {}
+}
+"""
+        result = self.analyzer.analyze_file("Demo.java", code, "Java")
+
+        comments = [(c["text"], c["type"]) for c in result["comments"]]
+        self.assertEqual(
+            comments,
+            [
+                ("Real inline", "inline"),
+                ("Real JavaDoc", "doc"),
+                ("Real block", "block"),
+            ],
+        )
+
+    def test_go_raw_string_backslash_does_not_hide_following_comment(self):
+        """Go raw strings use backticks without backslash escaping."""
+        code = r"""
+package main
+
+func main() {
+    raw := `ends with \`
+    // Real Go comment
+}
+"""
+        result = self.analyzer.analyze_file("main.go", code, "Go")
+
+        comment_texts = [c["text"] for c in result["comments"]]
+        self.assertEqual(comment_texts, ["Real Go comment"])
+
     def test_cpp_comment_extraction(self):
         """Test C++ comment extraction (uses same logic as JavaScript)."""
         code = """

--- a/tests/test_code_analyzer.py
+++ b/tests/test_code_analyzer.py
@@ -805,6 +805,33 @@ func main() {
         comment_texts = [c["text"] for c in result["comments"]]
         self.assertEqual(comment_texts, ["Real Go comment"])
 
+    def test_cpp_digit_separator_does_not_swallow_comments(self):
+        """A single ' digit separator (C++14, e.g. 1'000) is not a char-literal opener."""
+        code = """
+int main() {
+    int x = 1'000;  // comment one
+    int y = 5;      // comment two
+}
+"""
+        result = self.analyzer.analyze_file("a.cpp", code, "C++")
+
+        comment_texts = [c["text"] for c in result["comments"]]
+        self.assertEqual(comment_texts, ["comment one", "comment two"])
+
+    def test_unterminated_block_comment_emits_no_comment(self):
+        """An unterminated /* matches the prior regex behaviour and yields nothing."""
+        code = "var a = 1;\n/* never closed\nvar b = 2;"
+        result = self.analyzer.analyze_file("x.js", code, "JavaScript")
+
+        self.assertEqual(result["comments"], [])
+
+    def test_empty_block_comment_emits_no_comment(self):
+        """An empty /**/ has no inner text and is not reported (matches prior regex)."""
+        code = "public class Demo {\n    /**/\n    void run() {}\n}\n"
+        result = self.analyzer.analyze_file("Demo.java", code, "Java")
+
+        self.assertEqual(result["comments"], [])
+
     def test_cpp_comment_extraction(self):
         """Test C++ comment extraction (uses same logic as JavaScript)."""
         code = """

--- a/tests/test_kotlin_support.py
+++ b/tests/test_kotlin_support.py
@@ -405,6 +405,57 @@ val raw = """// not an inline comment either"""
         comments = [(c["text"], c["type"]) for c in result["comments"]]
         assert comments == [("Real inline", "inline"), ("Real KDoc", "doc")]
 
+    def test_kotlin_backtick_identifier_with_apostrophe_does_not_swallow_code(self):
+        """A ' inside a backtick-escaped identifier must not start a string literal."""
+        code = """\
+package com.example
+
+class Holder {
+    fun `user's profile loads`(): Int { return 1 }
+}
+
+fun topLevel(): Int { return 2 }
+"""
+        result = self.analyzer.analyze_file("Holder.kt", code, "Kotlin")
+
+        function_names = {f["name"] for f in result["functions"]}
+        class_names = {c["name"] for c in result["classes"]}
+        assert "Holder" in class_names
+        # Before the fix the apostrophe opened a string and masked the rest of the
+        # file, so topLevel disappeared entirely.
+        assert "topLevel" in function_names
+
+    def test_kotlin_string_template_with_nested_quotes_keeps_brace_depth(self):
+        """${...} interpolation braces/quotes must not leak into structural parsing."""
+        code = """\
+package com.example
+
+fun a(): Int { return 1 }
+val x = "open ${ if (true) "{" else "" } close"
+fun b(): Int { return 2 }
+fun cc(): Int { return 3 }
+"""
+        result = self.analyzer.analyze_file("Template.kt", code, "Kotlin")
+
+        function_names = {f["name"] for f in result["functions"]}
+        # The nested "{" used to leak a brace, pushing brace_depth positive so b and
+        # cc were misclassified as nested and dropped.
+        assert {"a", "b", "cc"} <= function_names
+
+    def test_kotlin_unterminated_block_comment_does_not_corrupt_braces(self):
+        """An unterminated /* at EOF must be fully masked, last char included."""
+        code = """\
+class C {
+    fun m(): Int { return 1 }
+}
+/* unterminated trailing comment with a } brace
+"""
+        result = self.analyzer.analyze_file("C.kt", code, "Kotlin")
+
+        holder = next(c for c in result["classes"] if c["name"] == "C")
+        method_names = {m["name"] for m in holder["methods"]}
+        assert "m" in method_names
+
     def test_analyze_imports(self):
         result = self.analyzer.analyze_file("User.kt", KOTLIN_DATA_CLASS, "Kotlin")
         imports = result["imports"]

--- a/tests/test_kotlin_support.py
+++ b/tests/test_kotlin_support.py
@@ -351,6 +351,60 @@ class TestKotlinCodeAnalyzer:
         # filterByType uses <reified T> generics — may or may not be captured
         assert len(func_names) >= 2
 
+    def test_kotlin_brace_depth_ignores_strings_and_comments(self):
+        code = '''\
+package com.example
+
+val fakeOpen = "{"
+val raw = """
+class Ghost {
+    fun fake(): Int { return 99 }
+}
+"""
+/* outer { /* nested */ } */
+
+class Holder {
+    val fakeClose = "}"
+    val rawMethod = """fun fakeMethod(): Int { return 100 }"""
+
+    fun method(): Int {
+        return 1
+    }
+}
+
+fun topLevel(): Int {
+    return 2
+}
+'''
+        result = self.analyzer.analyze_file("Holder.kt", code, "Kotlin")
+        holder = next(c for c in result["classes"] if c["name"] == "Holder")
+        method_names = {m["name"] for m in holder["methods"]}
+        function_names = {f["name"] for f in result["functions"]}
+        class_names = {c["name"] for c in result["classes"]}
+
+        assert "Ghost" not in class_names
+        assert "fake" not in function_names
+        assert "fakeMethod" not in method_names
+        assert "method" in method_names
+        assert "topLevel" in function_names
+        assert "method" not in function_names
+
+    def test_kotlin_comments_ignore_markers_inside_strings(self):
+        code = '''\
+package com.example
+
+val url = "https://example.com/path"
+val block = "/* not a block comment */"
+val raw = """// not an inline comment either"""
+
+// Real inline
+/** Real KDoc */
+'''
+        result = self.analyzer.analyze_file("Comments.kt", code, "Kotlin")
+
+        comments = [(c["text"], c["type"]) for c in result["comments"]]
+        assert comments == [("Real inline", "inline"), ("Real KDoc", "doc")]
+
     def test_analyze_imports(self):
         result = self.analyzer.analyze_file("User.kt", KOTLIN_DATA_CLASS, "Kotlin")
         imports = result["imports"]


### PR DESCRIPTION
## Description
- add offset-preserving C-style scanning so Kotlin brace-depth ignores braces in strings and comments
- avoid phantom `//` and `/* */` comments inside string literals for JS-style and Java/Kotlin comment extraction
- handle Kotlin nested block comments and Go raw backtick strings without regressing shared comment extraction

Fixes #407.

## How Has This Been Tested?
- `ruff format --check src/skill_seekers/cli/code_analyzer.py tests/test_code_analyzer.py tests/test_kotlin_support.py`
- `ruff check src/skill_seekers/cli/code_analyzer.py tests/test_code_analyzer.py tests/test_kotlin_support.py`
- `python -m pytest -p no:cacheprovider tests/test_code_analyzer.py tests/test_kotlin_support.py::TestKotlinCodeAnalyzer -q`
- `git diff --check`

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes