### PR TITLE
Fix two CPU-environment crashes in visual extraction (HoughLinesP shape, EasyOCR quantization SIGILL)

### DIFF
--- a/src/skill_seekers/cli/video_visual.py
+++ b/src/skill_seekers/cli/video_visual.py
@@ -104,16 +104,38 @@ def _detect_gpu() -> bool:
         return False
 
 
+def _cpu_supports_quantized_ops() -> bool:
+    """Check whether the CPU can run PyTorch's quantized ops.
+
+    FBGEMM (torch's x86 quantized backend) requires AVX2. On x86 CPUs
+    without AVX2 (e.g. QEMU's default virtual CPU model), dynamically
+    quantized models crash the whole process with SIGILL, so EasyOCR
+    must fall back to fp32 weights there.
+    """
+    import platform
+
+    if platform.machine().lower() not in ("x86_64", "amd64", "i386", "i686"):
+        return True  # non-x86 (ARM etc.) uses QNNPACK, no AVX2 requirement
+    try:
+        with open("/proc/cpuinfo") as f:
+            return "avx2" in f.read()
+    except OSError:
+        return True  # not Linux or unreadable: assume a modern CPU
+
+
 def _get_ocr_reader():
     """Get or create the EasyOCR reader (lazy singleton)."""
     global _ocr_reader
     if _ocr_reader is None:
         use_gpu = _detect_gpu()
+        quantize = use_gpu or _cpu_supports_quantized_ops()
         logger.info(
             f"Initializing OCR engine ({'GPU' if use_gpu else 'CPU'} mode, "
             "first run may download models)..."
         )
-        _ocr_reader = easyocr.Reader(["en"], gpu=use_gpu)
+        if not quantize:
+            logger.info("CPU lacks AVX2; disabling EasyOCR quantization (slower, but avoids SIGILL)")
+        _ocr_reader = easyocr.Reader(["en"], gpu=use_gpu, quantize=quantize)
     return _ocr_reader
 
 
@@ -746,8 +768,9 @@ def _classify_region(gray, edges, hsv) -> FrameType:
             edges, 1, np.pi / 180, threshold=80, minLineLength=w // 8, maxLineGap=10
         )
         if lines is not None:
-            for line in lines:
-                x1, y1, x2, y2 = line[0]
+            # HoughLinesP returns shape (N, 1, 4) or (N, 4) depending on the
+            # OpenCV version; reshape handles both.
+            for x1, y1, x2, y2 in lines.reshape(-1, 4):
                 angle = abs(np.degrees(np.arctan2(y2 - y1, x2 - x1)))
                 if angle < 5 or angle > 175:
                     horizontal_lines += 1

--- a/src/skill_seekers/cli/video_visual.py
+++ b/src/skill_seekers/cli/video_visual.py
@@ -134,7 +134,9 @@ def _get_ocr_reader():
             "first run may download models)..."
         )
         if not quantize:
-            logger.info("CPU lacks AVX2; disabling EasyOCR quantization (slower, but avoids SIGILL)")
+            logger.info(
+                "CPU lacks AVX2; disabling EasyOCR quantization (slower, but avoids SIGILL)"
+            )
         _ocr_reader = easyocr.Reader(["en"], gpu=use_gpu, quantize=quantize)
     return _ocr_reader
 

--- a/tests/test_video_scraper.py
+++ b/tests/test_video_scraper.py
@@ -2385,6 +2385,104 @@ class TestDarkThemePreprocessing(unittest.TestCase):
             os.unlink(tmp_path)
 
 
+class TestVisualCpuCompat(unittest.TestCase):
+    """Tests for CPU-environment compatibility (HoughLinesP layouts, AVX2 check)."""
+
+    def _classify_dark_region(self, hough_result):
+        """Run _classify_region on a dark region whose classification depends on
+        the horizontal lines parsed from the (mocked) HoughLinesP result."""
+        import numpy as np
+        from unittest.mock import MagicMock, patch
+
+        from skill_seekers.cli import video_visual
+
+        gray = np.full((100, 200), 30, dtype=np.uint8)  # dark: mean 30 < 80
+        # Edge density 0.02 — inside (0.01, 0.05], so the outcome depends on
+        # horizontal_lines >= 3 parsed from the HoughLinesP output.
+        edges = np.zeros((100, 200), dtype=np.uint8)
+        edges[25, :] = 255
+        edges[75, :] = 255
+        hsv = np.zeros((100, 200, 3), dtype=np.uint8)  # saturation 0
+
+        fake_cv2 = MagicMock()
+        fake_cv2.HoughLinesP.return_value = hough_result
+        with patch.object(video_visual, "cv2", fake_cv2):
+            return video_visual._classify_region(gray, edges, hsv)
+
+    def test_classify_region_hough_lines_new_shape(self):
+        """(N, 4) HoughLinesP layout (newer OpenCV builds) parses without crashing."""
+        import numpy as np
+
+        from skill_seekers.cli.video_models import FrameType
+
+        lines = np.array([[0, 10, 199, 10], [0, 20, 199, 20], [0, 30, 199, 30]], dtype=np.int32)
+        self.assertEqual(self._classify_dark_region(lines), FrameType.TERMINAL)
+
+    def test_classify_region_hough_lines_old_shape(self):
+        """(N, 1, 4) HoughLinesP layout (OpenCV 3/4) parses identically."""
+        import numpy as np
+
+        from skill_seekers.cli.video_models import FrameType
+
+        lines = np.array(
+            [[[0, 10, 199, 10]], [[0, 20, 199, 20]], [[0, 30, 199, 30]]], dtype=np.int32
+        )
+        self.assertEqual(self._classify_dark_region(lines), FrameType.TERMINAL)
+
+    def test_classify_region_no_lines_falls_through(self):
+        """Without horizontal lines the same region classifies as OTHER — proving
+        the parsed lines actually drive the TERMINAL classification above."""
+        from skill_seekers.cli.video_models import FrameType
+
+        self.assertEqual(self._classify_dark_region(None), FrameType.OTHER)
+
+    def test_cpu_quantization_non_x86_supported(self):
+        """ARM etc. use QNNPACK — quantization always considered supported."""
+        from unittest.mock import patch
+
+        from skill_seekers.cli.video_visual import _cpu_supports_quantized_ops
+
+        with patch("platform.machine", return_value="aarch64"):
+            self.assertTrue(_cpu_supports_quantized_ops())
+
+    def test_cpu_quantization_x86_with_avx2(self):
+        from unittest.mock import mock_open, patch
+
+        from skill_seekers.cli.video_visual import _cpu_supports_quantized_ops
+
+        cpuinfo = "flags\t\t: fpu vme sse sse2 avx avx2 fma\n"
+        with (
+            patch("platform.machine", return_value="x86_64"),
+            patch("builtins.open", mock_open(read_data=cpuinfo)),
+        ):
+            self.assertTrue(_cpu_supports_quantized_ops())
+
+    def test_cpu_quantization_x86_without_avx2(self):
+        """QEMU-style x86 CPU without AVX2 must disable quantization (SIGILL fix)."""
+        from unittest.mock import mock_open, patch
+
+        from skill_seekers.cli.video_visual import _cpu_supports_quantized_ops
+
+        cpuinfo = "flags\t\t: fpu vme sse sse2 avx\n"
+        with (
+            patch("platform.machine", return_value="x86_64"),
+            patch("builtins.open", mock_open(read_data=cpuinfo)),
+        ):
+            self.assertFalse(_cpu_supports_quantized_ops())
+
+    def test_cpu_quantization_unreadable_cpuinfo_assumes_modern(self):
+        """Non-Linux / unreadable /proc/cpuinfo keeps current behavior."""
+        from unittest.mock import patch
+
+        from skill_seekers.cli.video_visual import _cpu_supports_quantized_ops
+
+        with (
+            patch("platform.machine", return_value="x86_64"),
+            patch("builtins.open", side_effect=OSError),
+        ):
+            self.assertTrue(_cpu_supports_quantized_ops())
+
+
 class TestMultiEngineOCR(unittest.TestCase):
     """Tests for multi-engine OCR ensemble voting."""
 


### PR DESCRIPTION
## Summary

Two independent crashes that both abort `--visual` extraction of an entire video, found while processing a real 83s screen recording on a CPU-only VM.

### 1. `cannot unpack non-iterable numpy.int32 object` in `_classify_region`

Newer OpenCV builds return `HoughLinesP` results shaped `(N, 4)` instead of the older `(N, 1, 4)`, so `x1, y1, x2, y2 = line[0]` unpacks a scalar and raises. The exception propagates up through `extract_visual_data` and kills processing for the whole video.

Fix: `lines.reshape(-1, 4)` handles both layouts.

### 2. SIGILL (exit 132, 'Illegal instruction') in EasyOCR's recognizer

torch's FBGEMM quantized backend requires AVX2. On x86 CPUs without it (e.g. QEMU's default virtual CPU model, common in homelab VMs/CI), EasyOCR's dynamically-quantized recognition LSTM crashes the whole Python process — uncatchable from Python. Faulthandler trace pointed at `torch/ao/nn/quantized/dynamic/modules/rnn.py` via `easyocr/recognition.py`.

Fix: detect AVX2 via `/proc/cpuinfo` (x86-only check; ARM uses QNNPACK and is unaffected; non-Linux keeps current behavior) and pass `quantize=False` to `easyocr.Reader` when missing. Slower fp32 inference, but it completes instead of dying.

## Test plan

- Both crashes reproduced on an x86_64 QEMU VM without AVX2 (OpenCV 4.x, torch 2.12 CPU)
- With both fixes: full `--visual` extraction of an 83s video completes — 30 keyframes, OCR, alignment, SKILL.md
- `tests/test_video_scraper.py` passes (205 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)