### PR TITLE
Implement Whisper transcription fallback (Tier 2)

### DIFF
--- a/src/skill_seekers/cli/video_transcript.py
+++ b/src/skill_seekers/cli/video_transcript.py
@@ -301,19 +301,24 @@ def parse_vtt(path: str) -> list[TranscriptSegment]:
 
 
 # =============================================================================
-# Whisper Stub (Tier 2)
+# Whisper (Tier 2)
 # =============================================================================
 
 
 def transcribe_with_whisper(
-    audio_path: str,  # noqa: ARG001
-    model: str = "base",  # noqa: ARG001
-    language: str | None = None,  # noqa: ARG001
+    audio_path: str,
+    model: str = "base",
+    language: str | None = None,
 ) -> list[TranscriptSegment]:
     """Transcribe audio using faster-whisper (Tier 2).
 
+    Args:
+        audio_path: Path to an audio or video file (decoded via PyAV/ffmpeg).
+        model: Whisper model size (tiny, base, small, medium, large-v3, ...).
+        language: Language hint (e.g. "en"), or None for auto-detection.
+
     Raises:
-        RuntimeError: Always, unless faster-whisper is installed.
+        RuntimeError: If faster-whisper is not installed.
     """
     if not HAS_WHISPER:
         raise RuntimeError(
@@ -322,8 +327,32 @@ def transcribe_with_whisper(
             "Or: pip install faster-whisper"
         )
 
-    # Tier 2 implementation placeholder
-    raise NotImplementedError("Whisper transcription will be implemented in Tier 2")
+    import math
+
+    from faster_whisper import WhisperModel
+
+    logger.info(f"Transcribing with faster-whisper (model={model})...")
+    whisper_model = WhisperModel(model, device="auto", compute_type="default")
+    raw_segments, info = whisper_model.transcribe(audio_path, language=language or None)
+
+    segments = [
+        TranscriptSegment(
+            text=seg.text.strip(),
+            start=float(seg.start),
+            end=float(seg.end),
+            # avg_logprob is a mean token log-probability; exp() maps it
+            # to an approximate 0..1 confidence.
+            confidence=min(1.0, math.exp(seg.avg_logprob)),
+            source=TranscriptSource.WHISPER,
+        )
+        for seg in raw_segments
+        if seg.text.strip()
+    ]
+    logger.info(
+        f"Whisper produced {len(segments)} segments "
+        f"(language={info.language}, probability={info.language_probability:.2f})"
+    )
+    return segments
 
 
 # =============================================================================
@@ -388,8 +417,8 @@ def get_transcript(
             )
             if segments:
                 return segments, TranscriptSource.WHISPER
-        except (RuntimeError, NotImplementedError):
-            pass
+        except Exception as e:
+            logger.warning(f"Whisper transcription failed: {e}")
 
     # 4. No transcript available
     logger.warning(f"No transcript available for '{video_info.title}'")

--- a/src/skill_seekers/cli/video_transcript.py
+++ b/src/skill_seekers/cli/video_transcript.py
@@ -3,7 +3,7 @@
 Handles all transcript acquisition:
 - YouTube captions via youtube-transcript-api (Tier 1)
 - Subtitle file parsing: SRT and VTT (Tier 1)
-- Whisper ASR stub (Tier 2 — raises ImportError with install instructions)
+- Whisper ASR via faster-whisper (Tier 2 — optional [video-full] dependency)
 """
 
 import logging

--- a/tests/test_video_scraper.py
+++ b/tests/test_video_scraper.py
@@ -466,13 +466,52 @@ class TestVideoTranscript(unittest.TestCase):
         finally:
             os.unlink(tmp_name)
 
-    def test_whisper_stub_raises(self):
+    def test_whisper_missing_raises(self):
         from skill_seekers.cli.video_transcript import transcribe_with_whisper, HAS_WHISPER
 
         if not HAS_WHISPER:
             with self.assertRaises(RuntimeError) as ctx:
                 transcribe_with_whisper("test.wav")
             self.assertIn("faster-whisper", str(ctx.exception))
+
+    def test_whisper_transcription(self):
+        """transcribe_with_whisper converts faster-whisper segments to TranscriptSegments."""
+        import sys
+        from unittest.mock import MagicMock, patch
+
+        from skill_seekers.cli.video_models import TranscriptSource
+
+        fake_seg = MagicMock()
+        fake_seg.text = " Hello world. "
+        fake_seg.start = 0.0
+        fake_seg.end = 2.5
+        fake_seg.avg_logprob = -0.1
+        fake_empty = MagicMock()
+        fake_empty.text = "   "
+        fake_info = MagicMock()
+        fake_info.language = "en"
+        fake_info.language_probability = 0.99
+
+        fake_model = MagicMock()
+        fake_model.transcribe.return_value = ([fake_seg, fake_empty], fake_info)
+        fake_module = MagicMock()
+        fake_module.WhisperModel.return_value = fake_model
+
+        with (
+            patch.dict(sys.modules, {"faster_whisper": fake_module}),
+            patch("skill_seekers.cli.video_transcript.HAS_WHISPER", True),
+        ):
+            from skill_seekers.cli.video_transcript import transcribe_with_whisper
+
+            segments = transcribe_with_whisper("video.mp4", model="base", language="en")
+
+        self.assertEqual(len(segments), 1)  # empty segment filtered out
+        self.assertEqual(segments[0].text, "Hello world.")
+        self.assertEqual(segments[0].start, 0.0)
+        self.assertEqual(segments[0].end, 2.5)
+        self.assertEqual(segments[0].source, TranscriptSource.WHISPER)
+        self.assertGreater(segments[0].confidence, 0.8)
+        fake_model.transcribe.assert_called_once_with("video.mp4", language="en")
 
     def test_get_transcript_fallback_to_subtitle(self):
         """Test that get_transcript falls back to subtitle files."""


### PR DESCRIPTION
## Summary

`transcribe_with_whisper()` is currently a placeholder that always raises `NotImplementedError`, and `get_transcript()` silently swallows it (`except ... : pass`). The net effect: local video files without subtitle files produce **no transcript at all**, even though:

- `docs/VIDEO_GUIDE.md` documents the 3-tier fallback with Whisper as tier 3
- the `[video-full]` extras install `faster-whisper` specifically for this
- `--setup` verifies `faster-whisper: OK`

The only user-visible signal is a generic "No transcript available" warning, which reads like the video's fault rather than a missing feature.

## Changes

- Implement `transcribe_with_whisper()` with faster-whisper: `device="auto"`, model size from `--whisper-model`, language hint honored, per-segment confidence derived from `avg_logprob`, empty segments filtered
- `get_transcript()` now logs a warning with the actual error instead of silently swallowing transcription failures
- Add a unit test with a mocked `WhisperModel` (no model download in CI); the existing not-installed `RuntimeError` behavior is preserved and still tested

## Test plan

- `tests/test_video_scraper.py`: 205 passed
- End-to-end on a real 83s screen recording (CPU-only VM): 19 accurate segments with correct timestamps, flowing through to the reference file and audio-visual alignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)