### PR TITLE
fix: env-driven CORS origins + Docker metadata hardening

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ FROM python:3.12-slim
 
 LABEL maintainer="Skill Seekers <noreply@skillseekers.dev>"
 LABEL description="Skill Seekers - Convert documentation to AI skills"
-LABEL version="2.9.0"
+LABEL version="3.9.0.dev0"
 
 # Install runtime dependencies only
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/Dockerfile.mcp
+++ b/Dockerfile.mcp
@@ -5,7 +5,7 @@ FROM python:3.12-slim
 
 LABEL maintainer="Skill Seekers <noreply@skillseekers.dev>"
 LABEL description="Skill Seekers MCP Server - 35 tools for AI skills generation"
-LABEL version="3.3.0"
+LABEL version="3.9.0.dev0"
 
 WORKDIR /app
 

--- a/api/main.py
+++ b/api/main.py
@@ -4,6 +4,7 @@ Skill Seekers Config API
 FastAPI backend for listing available skill configs
 """
 
+import os
 from pathlib import Path
 from typing import Any
 
@@ -20,11 +21,20 @@ app = FastAPI(
     redoc_url="/redoc",
 )
 
-# CORS middleware - allow all origins for public API
+# CORS middleware - configure allowed origins via CORS_ORIGINS env var.
+# Use comma-separated list for specific origins, or "*" for public access.
+# Example: CORS_ORIGINS=https://skillseekersweb.com,https://app.skillseekers.dev
+# Note: browsers reject allow_credentials=True with allow_origins=["*"].
+_cors_origins_raw = os.environ.get("CORS_ORIGINS", "*")
+_cors_origins = (
+    ["*"] if _cors_origins_raw == "*" else [o.strip() for o in _cors_origins_raw.split(",") if o.strip()]
+)
+_cors_credentials = _cors_origins != ["*"]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=True,
+    allow_origins=_cors_origins,
+    allow_credentials=_cors_credentials,
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,6 @@
 # Skill Seekers Docker Compose
 # Complete deployment with MCP server and vector databases
 
-version: '3.8'
-
 services:
   # Main Skill Seekers CLI application
   skill-seekers:


### PR DESCRIPTION
## Summary
- Fix invalid CORS combo (`allow_origins=['*']` + `allow_credentials=True`), which browsers reject.
- Make allowed origins configurable via `CORS_ORIGINS` (comma-separated list, or `*` for public). Credentials auto-enable only when a concrete origin list is set.
- Sync `Dockerfile` / `Dockerfile.mcp` `LABEL version` to current `pyproject.toml` (`3.9.0.dev0`).
- Drop obsolete Compose v1 `version:` key from `docker-compose.yml`.

## Why
Starlette/FastAPI (and browsers) disallow credentialed CORS with a wildcard origin. The current `api/main.py` sets both, so credentialed cross-origin requests fail silently in the browser. Env-driven origins also let deployers (Render, Docker, etc.) lock the API to known frontends without a code change.

## Test plan
- [ ] `CORS_ORIGINS` unset or `*` → `allow_origins=['*']`, `allow_credentials=False`
- [ ] `CORS_ORIGINS=https://example.com,https://app.example.com` → those origins, `allow_credentials=True`
- [ ] Hit `/docs` and a simple GET with a browser Origin header; confirm `Access-Control-Allow-Origin` matches config
- [ ] `docker compose config` succeeds without the removed `version` key
- [ ] Image labels show `3.9.0.dev0`

## Notes
Rebased cleanly onto current `development` (fork was 141 commits behind). No junk-file cleanup needed on upstream.