### PR TITLE
fix: extend env-driven CORS hardening to embedding + MCP servers

### DIFF
--- a/Dockerfile.mcp
+++ b/Dockerfile.mcp
@@ -4,7 +4,7 @@
 FROM python:3.12-slim
 
 LABEL maintainer="Skill Seekers <noreply@skillseekers.dev>"
-LABEL description="Skill Seekers MCP Server - 35 tools for AI skills generation"
+LABEL description="Skill Seekers MCP Server - 40 tools for AI skills generation"
 LABEL version="3.9.0.dev0"
 
 WORKDIR /app

--- a/api/main.py
+++ b/api/main.py
@@ -26,10 +26,14 @@ app = FastAPI(
 # Example: CORS_ORIGINS=https://skillseekersweb.com,https://app.skillseekers.dev
 # Note: browsers reject allow_credentials=True with allow_origins=["*"].
 _cors_origins_raw = os.environ.get("CORS_ORIGINS", "*")
-_cors_origins = (
-    ["*"] if _cors_origins_raw == "*" else [o.strip() for o in _cors_origins_raw.split(",") if o.strip()]
-)
-_cors_credentials = _cors_origins != ["*"]
+_cors_origins = [o.strip() for o in _cors_origins_raw.split(",") if o.strip()]
+if not _cors_origins or "*" in _cors_origins:
+    # Public access: a wildcard (even mixed into a list) forces credentials off,
+    # because browsers reject allow_credentials=True with allow_origins=["*"].
+    _cors_origins = ["*"]
+    _cors_credentials = False
+else:
+    _cors_credentials = True
 
 app.add_middleware(
     CORSMiddleware,

--- a/src/skill_seekers/cors_config.py
+++ b/src/skill_seekers/cors_config.py
@@ -1,0 +1,32 @@
+"""Shared CORS configuration resolver.
+
+Browsers reject ``Access-Control-Allow-Credentials: true`` combined with a
+wildcard ``Access-Control-Allow-Origin: *``. This module resolves a safe
+``(allow_origins, allow_credentials)`` pair from the ``CORS_ORIGINS`` env var
+so every FastAPI/Starlette server in the project shares one policy.
+"""
+
+from __future__ import annotations
+
+import os
+
+DEFAULT_CORS_ORIGINS = "*"
+
+
+def resolve_cors_config(raw: str | None = None) -> tuple[list[str], bool]:
+    """Resolve ``(allow_origins, allow_credentials)`` from a CORS_ORIGINS value.
+
+    - unset / empty / ``"*"`` (or any list containing ``"*"``) -> ``(["*"], False)``
+      Public access; credentials are disabled because browsers reject the
+      wildcard-plus-credentials combination.
+    - ``"https://a.com, https://b.com"`` -> ``(["https://a.com", "https://b.com"], True)``
+      Explicit origins; credentials enabled.
+
+    ``raw`` defaults to the ``CORS_ORIGINS`` environment variable.
+    """
+    if raw is None:
+        raw = os.environ.get("CORS_ORIGINS", DEFAULT_CORS_ORIGINS)
+    origins = [o.strip() for o in raw.split(",") if o.strip()]
+    if not origins or "*" in origins:
+        return ["*"], False
+    return origins, True

--- a/src/skill_seekers/embedding/server.py
+++ b/src/skill_seekers/embedding/server.py
@@ -43,6 +43,7 @@ from .models import (
 )
 from .generator import EmbeddingGenerator
 from .cache import EmbeddingCache
+from ..cors_config import resolve_cors_config
 
 
 # Initialize FastAPI app
@@ -55,11 +56,13 @@ if FASTAPI_AVAILABLE:
         redoc_url="/redoc",
     )
 
-    # Add CORS middleware
+    # Add CORS middleware - origins configurable via CORS_ORIGINS env var.
+    # Credentials auto-disable for wildcard origins (browsers reject that combo).
+    _allow_origins, _allow_credentials = resolve_cors_config()
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"],
-        allow_credentials=True,
+        allow_origins=_allow_origins,
+        allow_credentials=_allow_credentials,
         allow_methods=["*"],
         allow_headers=["*"],
     )

--- a/src/skill_seekers/mcp/server_fastmcp.py
+++ b/src/skill_seekers/mcp/server_fastmcp.py
@@ -1680,14 +1680,19 @@ async def run_http_server(host: str, port: int):
         # Get the SSE Starlette app from FastMCP
         app = mcp.sse_app()
 
-        # Add CORS middleware for cross-origin requests
+        # Add CORS middleware for cross-origin requests. Origins are configurable
+        # via CORS_ORIGINS; credentials auto-disable for wildcard origins because
+        # browsers reject allow_credentials=True with allow_origins=["*"].
         try:
             from starlette.middleware.cors import CORSMiddleware
 
+            from ..cors_config import resolve_cors_config
+
+            _allow_origins, _allow_credentials = resolve_cors_config()
             app.add_middleware(
                 CORSMiddleware,
-                allow_origins=["*"],
-                allow_credentials=True,
+                allow_origins=_allow_origins,
+                allow_credentials=_allow_credentials,
                 allow_methods=["*"],
                 allow_headers=["*"],
             )

--- a/tests/test_cors_config.py
+++ b/tests/test_cors_config.py
@@ -1,0 +1,38 @@
+"""Tests for skill_seekers.cors_config.resolve_cors_config."""
+
+import pytest
+
+from skill_seekers.cors_config import resolve_cors_config
+
+
+@pytest.mark.parametrize(
+    "raw, origins, credentials",
+    [
+        # Wildcard / empty -> public, credentials disabled (browsers reject the combo).
+        ("*", ["*"], False),
+        ("", ["*"], False),
+        ("   ", ["*"], False),
+        (" * ", ["*"], False),
+        # A wildcard mixed into a list must still collapse to public, no credentials.
+        ("*,https://a.com", ["*"], False),
+        ("https://a.com, *", ["*"], False),
+        # Explicit origins -> credentials enabled.
+        ("https://a.com", ["https://a.com"], True),
+        ("https://a.com,https://b.com", ["https://a.com", "https://b.com"], True),
+        # Whitespace and empty segments are trimmed/dropped.
+        ("https://a.com, https://b.com", ["https://a.com", "https://b.com"], True),
+        ("https://a.com,,https://b.com", ["https://a.com", "https://b.com"], True),
+    ],
+)
+def test_resolve_cors_config_explicit(raw, origins, credentials):
+    assert resolve_cors_config(raw) == (origins, credentials)
+
+
+def test_resolve_cors_config_env_default(monkeypatch):
+    monkeypatch.delenv("CORS_ORIGINS", raising=False)
+    assert resolve_cors_config() == (["*"], False)
+
+
+def test_resolve_cors_config_env_explicit(monkeypatch):
+    monkeypatch.setenv("CORS_ORIGINS", "https://x.com,https://y.com")
+    assert resolve_cors_config() == (["https://x.com", "https://y.com"], True)


### PR DESCRIPTION
## Summary

Follow-up to #422. That PR fixed the invalid `allow_origins=["*"]` + `allow_credentials=True` CORS combo in `api/main.py`, but the **identical misconfiguration existed in two other servers** that were left untouched:

- `src/skill_seekers/embedding/server.py` (FastAPI embedding API)
- `src/skill_seekers/mcp/server_fastmcp.py` (MCP HTTP/SSE transport)

Both are now fixed via a shared `resolve_cors_config()` helper, so all three FastAPI/Starlette servers share one policy.

## Changes

- **New** `src/skill_seekers/cors_config.py` — `resolve_cors_config(raw=None)` returns a safe `(allow_origins, allow_credentials)` pair from `CORS_ORIGINS`.
- **Fixed** the same wildcard+credentials bug in the embedding server and the MCP HTTP server.
- **Hardened** the `api/main.py` guard: #422 used `_cors_origins != ["*"]`, which meant `CORS_ORIGINS="*,https://a.com"` still enabled credentials alongside a wildcard — re-introducing the exact combo #422 set out to fix. Now any wildcard in the list (or an empty value) collapses to `(["*"], False)`.
- **Tests** — 12 cases covering wildcard, empty/whitespace, wildcard-mixed-into-list, explicit origins, and the env-var path (#422 shipped with a manual-only test plan).
- **Docker metadata** — synced the stale `Dockerfile.mcp` tool count (`35` → `40`, matching README) that #422 left behind while updating the adjacent `LABEL version`.

## Behavior

| `CORS_ORIGINS` | `allow_origins` | `allow_credentials` |
|---|---|---|
| unset / `*` / empty | `["*"]` | `False` |
| `https://a.com,https://b.com` | `["https://a.com","https://b.com"]` | `True` |
| `*,https://a.com` | `["*"]` | `False` (was: creds wrongly enabled) |

## Test plan

- [x] `uvx ruff check` + `ruff format --check` clean
- [x] `pytest tests/test_cors_config.py` — 12/12 pass
- [x] `py_compile` clean on all edited files

🤖 Generated with [Claude Code](https://claude.com/claude-code)