### PR TITLE
feat: expose word (docx) source in scrape_generic MCP tool

### DIFF
--- a/src/skill_seekers/mcp/server_fastmcp.py
+++ b/src/skill_seekers/mcp/server_fastmcp.py
@@ -794,7 +794,7 @@ async def extract_config_patterns(
 
 
 @safe_tool_decorator(
-    description="Scrape content from new source types: jupyter, html, openapi, asciidoc, pptx, confluence, notion, rss, manpage, chat. A generic entry point that delegates to the appropriate CLI scraper module."
+    description="Scrape content from new source types: jupyter, html, openapi, asciidoc, pptx, word, confluence, notion, rss, manpage, chat. A generic entry point that delegates to the appropriate CLI scraper module."
 )
 async def scrape_generic(
     source_type: str,
@@ -805,16 +805,16 @@ async def scrape_generic(
     """
     Scrape content from various source types and build a skill.
 
-    A generic scraper that supports 10 new source types. It delegates to the
+    A generic scraper that supports 11 new source types. It delegates to the
     corresponding CLI scraper module (e.g., skill_seekers.cli.jupyter_scraper).
 
-    File-based types (jupyter, html, openapi, asciidoc, pptx, manpage, chat)
+    File-based types (jupyter, html, openapi, asciidoc, pptx, word, manpage, chat)
     typically use the 'path' parameter. URL-based types (confluence, notion, rss)
     typically use the 'url' parameter.
 
     Args:
         source_type: Source type to scrape. One of: jupyter, html, openapi,
-            asciidoc, pptx, confluence, notion, rss, manpage, chat.
+            asciidoc, pptx, word, confluence, notion, rss, manpage, chat.
         name: Skill name for the output
         path: File or directory path (for file-based sources like jupyter, html, pptx)
         url: URL (for URL-based sources like confluence, notion, rss)

--- a/src/skill_seekers/mcp/tools/scraping_tools.py
+++ b/src/skill_seekers/mcp/tools/scraping_tools.py
@@ -8,7 +8,7 @@ This module contains all scraping-related MCP tool implementations:
 - scrape_pdf_tool: Scrape PDF documentation
 - scrape_codebase_tool: Analyze local codebase and extract code knowledge
 - scrape_generic_tool: Generic scraper for new source types (jupyter, html,
-  openapi, asciidoc, pptx, confluence, notion, rss, manpage, chat)
+  openapi, asciidoc, pptx, word, confluence, notion, rss, manpage, chat)
 
 Extracted from server.py for better modularity and organization.
 """
@@ -921,6 +921,7 @@ GENERIC_SOURCE_TYPES = (
     "openapi",
     "asciidoc",
     "pptx",
+    "word",
     "confluence",
     "notion",
     "rss",
@@ -939,6 +940,7 @@ _SOURCE_EMOJIS = {
     "openapi": "📡",
     "asciidoc": "📄",
     "pptx": "📊",
+    "word": "📃",
     "confluence": "🏢",
     "notion": "📝",
     "rss": "📰",
@@ -1009,6 +1011,7 @@ async def scrape_generic_tool(args: dict) -> list[TextContent]:
         "openapi": "spec_path",
         "asciidoc": "asciidoc_path",
         "pptx": "pptx_path",
+        "word": "docx_path",
         "manpage": "man_path",
         "confluence": "export_path",
         "notion": "export_path",

--- a/tests/test_mcp_scrape_generic_word.py
+++ b/tests/test_mcp_scrape_generic_word.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Tests for the word (docx) source type in the scrape_generic MCP tool (#41)."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+class TestScrapeGenericWord(unittest.TestCase):
+    def test_word_is_a_generic_source_type(self):
+        from skill_seekers.mcp.tools.scraping_tools import GENERIC_SOURCE_TYPES
+
+        self.assertIn("word", GENERIC_SOURCE_TYPES)
+
+    def test_word_dispatches_to_converter_with_docx_path(self):
+        """scrape_generic(source_type=word) builds a docx_path config and runs
+        the registered word converter."""
+        import asyncio
+
+        from skill_seekers.mcp.tools import scraping_tools
+
+        fake_converter = MagicMock()
+        with (
+            patch(
+                "skill_seekers.cli.skill_converter.get_converter",
+                return_value=fake_converter,
+            ) as get_conv,
+            patch.object(scraping_tools, "_run_converter", return_value=["ok"]) as run_conv,
+        ):
+            result = asyncio.run(
+                scraping_tools.scrape_generic_tool(
+                    {"source_type": "word", "path": "/docs/manual.docx", "name": "manual"}
+                )
+            )
+
+        self.assertEqual(result, ["ok"])
+        source_type, config = get_conv.call_args.args
+        self.assertEqual(source_type, "word")
+        self.assertEqual(config["name"], "manual")
+        self.assertEqual(config["docx_path"], "/docs/manual.docx")
+        run_conv.assert_called_once()
+
+    def test_unknown_type_error_lists_word(self):
+        """The unknown-type error message advertises word as valid."""
+        import asyncio
+
+        from skill_seekers.mcp.tools import scraping_tools
+
+        result = asyncio.run(
+            scraping_tools.scrape_generic_tool({"source_type": "nope", "path": "/x", "name": "x"})
+        )
+        self.assertIn("word", result[0].text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #41 (and covers the closed duplicate #137). The `word` converter has been registered in `CONVERTER_REGISTRY` since the docx scraper landed, but the MCP surface never exposed it — `GENERIC_SOURCE_TYPES` excluded it, so MCP clients could not scrape .docx sources at all.

- Add `word` to `GENERIC_SOURCE_TYPES`, the config-key map (`docx_path`), and the emoji map in `scraping_tools.py`
- Update the `scrape_generic` docstrings/description (10 → 11 types)
- 3 tests: type registered, dispatch builds `docx_path` config via `get_converter`, unknown-type error advertises `word`

🤖 Generated with [Claude Code](https://claude.com/claude-code)