### PR TITLE
feat: retry transient network failures in MCP fetch_config (E2.6)

### DIFF
--- a/src/skill_seekers/mcp/tools/source_tools.py
+++ b/src/skill_seekers/mcp/tools/source_tools.py
@@ -27,6 +27,32 @@ from skill_seekers.services.source_manager import (
 
 import httpx
 
+from skill_seekers.cli.utils import retry_with_backoff_async
+
+
+async def _get_with_retry(
+    client: httpx.AsyncClient,
+    url: str,
+    params: dict | None = None,
+    base_delay: float = 1.0,
+) -> httpx.Response:
+    """GET with exponential backoff on transient failures (E2.6, #92).
+
+    Retries connection/timeout errors and 5xx responses (3 attempts, then
+    1s/2s waits). 4xx responses are returned un-retried — a 404 is a real
+    answer the caller handles (e.g. "config not found"), not a fault.
+    """
+
+    async def _attempt() -> httpx.Response:
+        response = await client.get(url, params=params)
+        if response.status_code >= 500:
+            response.raise_for_status()
+        return response
+
+    return await retry_with_backoff_async(
+        _attempt, base_delay=base_delay, operation_name=f"GET {url}"
+    )
+
 
 async def fetch_config_tool(args: dict) -> list[TextContent]:
     """
@@ -213,7 +239,7 @@ Next steps:
                     if category:
                         params["category"] = category
 
-                    response = await client.get(list_url, params=params)
+                    response = await _get_with_retry(client, list_url, params=params)
                     response.raise_for_status()
                     data = response.json()
 
@@ -264,7 +290,7 @@ Next steps:
 
                 # Get config details first
                 detail_url = f"{API_BASE_URL}/api/configs/{config_name}"
-                detail_response = await client.get(detail_url)
+                detail_response = await _get_with_retry(client, detail_url)
 
                 if detail_response.status_code == 404:
                     return [
@@ -287,7 +313,7 @@ Next steps:
                         )
                     ]
 
-                download_response = await client.get(download_url)
+                download_response = await _get_with_retry(client, download_url)
                 download_response.raise_for_status()
                 config_data = download_response.json()
 

--- a/tests/test_mcp_fastmcp.py
+++ b/tests/test_mcp_fastmcp.py
@@ -603,6 +603,7 @@ class TestSourceTools:
         """Test fetching config list from API."""
         with patch("skill_seekers.mcp.tools.source_tools.httpx.AsyncClient") as mock_client:
             mock_response = MagicMock()
+            mock_response.status_code = 200
             mock_response.json.return_value = {
                 "configs": [
                     {"name": "react", "category": "web-frameworks"},

--- a/tests/test_mcp_fetch_retry.py
+++ b/tests/test_mcp_fetch_retry.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Tests for the MCP fetch retry helper (E2.6, #92)."""
+
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+
+from skill_seekers.mcp.tools.source_tools import _get_with_retry
+
+
+def _response(status_code: int) -> MagicMock:
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            f"{status_code}", request=MagicMock(), response=resp
+        )
+    return resp
+
+
+class TestGetWithRetry(unittest.TestCase):
+    def test_transient_connect_errors_are_retried(self):
+        """Two connection failures then success -> returns the response."""
+        ok = _response(200)
+        client = MagicMock()
+        client.get = AsyncMock(
+            side_effect=[httpx.ConnectError("boom"), httpx.ReadTimeout("slow"), ok]
+        )
+
+        result = asyncio.run(_get_with_retry(client, "https://x.test/a", base_delay=0.01))
+
+        self.assertIs(result, ok)
+        self.assertEqual(client.get.await_count, 3)
+
+    def test_5xx_is_retried(self):
+        """A 500 then success -> retried and returns the good response."""
+        ok = _response(200)
+        client = MagicMock()
+        client.get = AsyncMock(side_effect=[_response(500), ok])
+
+        result = asyncio.run(_get_with_retry(client, "https://x.test/a", base_delay=0.01))
+
+        self.assertIs(result, ok)
+        self.assertEqual(client.get.await_count, 2)
+
+    def test_404_is_not_retried(self):
+        """4xx is a real answer (e.g. config not found) — returned after one call."""
+        not_found = _response(404)
+        client = MagicMock()
+        client.get = AsyncMock(return_value=not_found)
+
+        result = asyncio.run(_get_with_retry(client, "https://x.test/a", base_delay=0.01))
+
+        self.assertIs(result, not_found)
+        self.assertEqual(client.get.await_count, 1)
+
+    def test_persistent_failure_raises_after_three_attempts(self):
+        client = MagicMock()
+        client.get = AsyncMock(side_effect=httpx.ConnectError("down"))
+
+        with self.assertRaises(httpx.ConnectError):
+            asyncio.run(_get_with_retry(client, "https://x.test/a", base_delay=0.01))
+
+        self.assertEqual(client.get.await_count, 3)
+
+    def test_params_are_passed_through(self):
+        ok = _response(200)
+        client = MagicMock()
+        client.get = AsyncMock(return_value=ok)
+
+        asyncio.run(_get_with_retry(client, "https://x.test/a", params={"category": "web"}))
+
+        client.get.assert_awaited_once_with("https://x.test/a", params={"category": "web"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mcp_git_sources.py
+++ b/tests/test_mcp_git_sources.py
@@ -69,6 +69,7 @@ class TestFetchConfigModes:
         with patch("skill_seekers.mcp.tools.source_tools.httpx.AsyncClient") as mock_client:
             # Mock API response
             mock_response = MagicMock()
+            mock_response.status_code = 200
             mock_response.json.return_value = {
                 "configs": [
                     {
@@ -103,6 +104,7 @@ class TestFetchConfigModes:
         with patch("skill_seekers.mcp.tools.source_tools.httpx.AsyncClient") as mock_client:
             # Mock API responses
             mock_detail_response = MagicMock()
+            mock_detail_response.status_code = 200
             mock_detail_response.json.return_value = {
                 "name": "react",
                 "category": "web-frameworks",
@@ -111,6 +113,7 @@ class TestFetchConfigModes:
             }
 
             mock_download_response = MagicMock()
+            mock_download_response.status_code = 200
             mock_download_response.json.return_value = {
                 "name": "react",
                 "base_url": "https://react.dev/",


### PR DESCRIPTION
## Summary

Fixes #92. The `retry_with_backoff_async` utility has existed (tested) since E2.6's first half, but had **zero callers** — the MCP `fetch_config` API path did single-shot httpx GETs, so one transient connection blip failed the whole tool call.

- New `_get_with_retry` helper in `source_tools.py`: 3 attempts, exponential backoff (1s/2s)
- Routes all three `fetch_config` API GETs (list / detail / download) through it
- **Only transient faults retry**: connect/timeout errors and 5xx. 4xx responses are returned un-retried — the existing 404 → "Config not found" handling is preserved (retrying a 404 would just add 3s of latency to a correct answer)

## Test plan

- 5 tests: transient-then-success (3 calls), 5xx retried, 404 NOT retried (1 call), persistent failure raises after 3 attempts, params passthrough
- `tests/test_source_manager.py` unaffected (53 passed)
- CI-pinned ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)