### PR TITLE
fix: pattern-detector precision — getters are not factories, Java Singletons detectable

### DIFF
--- a/src/skill_seekers/cli/codebase_scraper.py
+++ b/src/skill_seekers/cli/codebase_scraper.py
@@ -1137,8 +1137,11 @@ def analyze_codebase(
                 language = detect_language(file_path)
 
                 if language != "Unknown":
-                    # Use relative path from directory for better graph readability
-                    rel_path = str(file_path.relative_to(directory))
+                    # Use relative path from directory for better graph
+                    # readability. as_posix() keeps node keys '/'-separated on
+                    # Windows too — import resolution matches on '/' suffixes,
+                    # so backslash keys would silently produce zero edges (#425).
+                    rel_path = file_path.relative_to(directory).as_posix()
                     dep_analyzer.analyze_file(rel_path, content, language)
             except Exception as e:
                 logger.warning(f"Error analyzing dependencies for {file_path}: {e}")
@@ -1146,6 +1149,33 @@ def analyze_codebase(
 
         # Build the graph
         graph = dep_analyzer.build_graph()
+
+        # An empty edge set on a multi-file codebase usually means import
+        # RESOLUTION failed (imports were extracted but none mapped to a file
+        # node), not that the code has no internal dependencies. A relative
+        # import is internal by definition, so "relative imports extracted but
+        # zero edges" is proof of breakage; without one, stay neutral — a
+        # directory of independent scripts legitimately has no edges (#425).
+        all_deps = [d for deps in dep_analyzer.file_dependencies.values() for d in deps]
+        if graph.number_of_nodes() > 1 and graph.number_of_edges() == 0 and all_deps:
+            if any(d.is_relative for d in all_deps):
+                logger.warning(
+                    "⚠️  Dependency graph has %d files but 0 edges even though "
+                    "relative (internal) imports were extracted — import "
+                    "resolution failed. Please report this with your OS and "
+                    "project layout: "
+                    "https://github.com/yusufkaraaslan/Skill_Seekers/issues",
+                    graph.number_of_nodes(),
+                )
+            else:
+                logger.warning(
+                    "⚠️  Dependency graph has %d files but 0 edges (%d imports "
+                    "extracted, none resolved to project files). If this "
+                    "project's modules import each other, resolution failed — "
+                    "please report it.",
+                    graph.number_of_nodes(),
+                    len(all_deps),
+                )
 
         # Detect circular dependencies
         cycles = dep_analyzer.detect_cycles()

--- a/src/skill_seekers/cli/pattern_recognizer.py
+++ b/src/skill_seekers/cli/pattern_recognizer.py
@@ -456,13 +456,24 @@ class SingletonDetector(BasePatternDetector):
         # Check for private/protected constructor-like methods
         has_init_control = False
         for method in class_sig.methods:
-            # Python: __init__ or __new__
-            # Java/C#: private constructor (detected by naming)
-            # Check if it has logic (not just pass)
-            if method.name in ["__new__", "__init__", "constructor"] and (
-                method.docstring or len(method.parameters) > 1
+            # Python: an overridden __new__ is controlled initialization by
+            # itself (it exists precisely to intercept instance creation);
+            # __init__/constructor only count with logic (docstring or params)
+            # so trivial initializers don't fire.
+            if method.name == "__new__" or (
+                method.name in ["__init__", "constructor"]
+                and (method.docstring or len(method.parameters) > 1)
             ):
                 evidence.append(f"Controlled initialization: {method.name}")
+                confidence += 0.3
+                has_init_control = True
+                break
+            # Java/C#/C++: constructors are named after the class. Before this
+            # check, has_init_control was unreachable in those languages, so a
+            # canonical Java Singleton capped at 0.4 — permanently below the
+            # 0.5 threshold — and never fired (#425).
+            if method.name == class_sig.name:
+                evidence.append(f"Controlled initialization: {method.name} (constructor)")
                 confidence += 0.3
                 has_init_control = True
                 break
@@ -544,6 +555,32 @@ class FactoryDetector(BasePatternDetector):
     - ProductFactory with createProductA(), createProductB()
     """
 
+    # Creation verbs that indicate a factory method, matched as a PREFIX at a
+    # word boundary (camelCase hump, '_', digit, or end of name) — so renew()
+    # or getNewsFeed() never match "new". Accessor prefixes are excluded
+    # outright: a getX()/setX()/isX()/hasX() is property access, not object
+    # creation. The old bare-"get" substring match reported every Java getter
+    # as a Factory and misclassified getInstance() Singletons (#425).
+    CREATION_PREFIXES = ("create", "make", "build", "new", "construct")
+    ACCESSOR_PREFIXES = ("get", "set", "is", "has")
+
+    @staticmethod
+    def _prefix_at_word_boundary(name: str, prefix: str) -> bool:
+        """True if name starts with prefix followed by a word boundary."""
+        if not name.lower().startswith(prefix):
+            return False
+        if len(name) == len(prefix):
+            return True
+        nxt = name[len(prefix)]
+        return nxt.isupper() or nxt == "_" or nxt.isdigit()
+
+    @classmethod
+    def _is_creation_method(cls, name: str) -> bool:
+        """Whether a method name follows an object-creation convention."""
+        if any(cls._prefix_at_word_boundary(name, p) for p in cls.ACCESSOR_PREFIXES):
+            return False
+        return any(cls._prefix_at_word_boundary(name, p) for p in cls.CREATION_PREFIXES)
+
     def __init__(self, depth: str = "deep"):
         super().__init__(depth)
         self.pattern_type = "Factory"
@@ -563,13 +600,12 @@ class FactoryDetector(BasePatternDetector):
                 evidence=['Class name contains "Factory"'],
             )
 
-        # Check for factory methods
-        factory_method_names = ["create", "make", "build", "new", "get"]
+        # Check for factory methods (creation-verb prefix, accessors excluded)
         for method in class_sig.methods:
             method_lower = method.name.lower()
             # Check if method returns something (has return type or is not void)
-            if any(name in method_lower for name in factory_method_names) and (
-                method.return_type or "create" in method_lower
+            if self._is_creation_method(method.name) and (
+                method.return_type or method_lower.startswith("create")
             ):
                 return PatternInstance(
                     pattern_type=self.pattern_type,
@@ -590,14 +626,11 @@ class FactoryDetector(BasePatternDetector):
         confidence = 0.0
         factory_methods = []
 
-        # Look for methods that create objects
-        creation_keywords = ["create", "make", "build", "new", "construct", "get"]
-
+        # Look for methods that create objects (creation-verb prefix at a word
+        # boundary; getters/setters excluded — see _is_creation_method, #425)
         for method in class_sig.methods:
-            method_lower = method.name.lower()
-
             # Check if method name suggests object creation
-            if any(keyword in method_lower for keyword in creation_keywords):
+            if self._is_creation_method(method.name):
                 factory_methods.append(method.name)
                 confidence += 0.3
 

--- a/tests/test_pattern_recognizer.py
+++ b/tests/test_pattern_recognizer.py
@@ -285,7 +285,9 @@ class ConfigManager:
 
         self.assertEqual(report.file_path, "config.py")
         self.assertEqual(report.language, "Python")
-        self.assertGreater(len(report.patterns), 0)
+        # Must be detected AS Singleton — before #425 this assertion held only
+        # because FactoryDetector's substring bug matched getInstance().
+        self.assertIn("Singleton", {p.pattern_type for p in report.patterns})
         self.assertGreater(report.total_classes, 0)
 
     def test_analyze_factory_code(self):
@@ -702,6 +704,98 @@ class TestBaseClassMatching(unittest.TestCase):
         self.assertTrue(_matches_base("BaseStrategy", ["BaseStrategy<Foo>"]))
         self.assertTrue(_matches_base("Base", ["ns.Base"]))
         self.assertFalse(_matches_base("BaseStrategy", ["OtherBase"]))
+
+
+class TestDetectorPrecisionJava(unittest.TestCase):
+    """Regression tests for #425: getter/Factory false positives and the
+    structurally-unreachable Singleton detection in class-named-constructor
+    languages (Java/C#/C++)."""
+
+    def setUp(self):
+        self.recognizer = PatternRecognizer(depth="deep", enhance_with_ai=False)
+
+    def test_plain_pojo_is_not_a_factory(self):
+        """A data class with getters/setters must report NO patterns."""
+        code = """
+public class Person {
+    private String name;
+    private int age;
+    public String getName() { return name; }
+    public void setName(String n) { this.name = n; }
+    public int getAge() { return age; }
+}"""
+        report = self.recognizer.analyze_file("Person.java", code, "Java")
+        self.assertEqual(
+            [(p.pattern_type, p.confidence) for p in report.patterns],
+            [],
+            "plain POJO must not be reported as any pattern",
+        )
+
+    def test_single_getter_is_not_a_factory(self):
+        code = """
+public class Box {
+    private String v;
+    public String getValue() { return v; }
+}"""
+        report = self.recognizer.analyze_file("Box.java", code, "Java")
+        factories = [p for p in report.patterns if p.pattern_type == "Factory"]
+        self.assertEqual(factories, [])
+
+    def test_java_singleton_with_normal_class_name(self):
+        """Canonical Java Singleton (class NOT named *Singleton*) must be
+        detected as Singleton, not misclassified as Factory."""
+        code = """
+public class Config {
+    private static Config instance;
+    private Config() {}
+    public static Config getInstance() {
+        if (instance == null) { instance = new Config(); }
+        return instance;
+    }
+}"""
+        report = self.recognizer.analyze_file("Config.java", code, "Java")
+        types = {p.pattern_type for p in report.patterns}
+        self.assertIn("Singleton", types)
+        self.assertNotIn("Factory", types)
+        singleton = next(p for p in report.patterns if p.pattern_type == "Singleton")
+        self.assertGreaterEqual(singleton.confidence, 0.5)
+
+    def test_real_java_factory_still_detected(self):
+        code = """
+public class VehicleMaker {
+    public Vehicle createVehicle(String type) { return null; }
+    public Engine buildEngine(String spec) { return null; }
+}"""
+        report = self.recognizer.analyze_file("VehicleMaker.java", code, "Java")
+        factories = [p for p in report.patterns if p.pattern_type == "Factory"]
+        self.assertGreater(len(factories), 0)
+
+    def test_creation_method_word_boundaries(self):
+        """Creation verbs match only at word boundaries; accessors never match."""
+        cases = {
+            # accessors / boundary traps -> not creation methods
+            "getName": False,
+            "getInstance": False,
+            "getNewsFeed": False,
+            "setName": False,
+            "isEmpty": False,
+            "hasNext": False,
+            "renew": False,
+            "setup": False,
+            "newsfeed": False,
+            # genuine creation conventions
+            "create": True,
+            "createProduct": True,
+            "create_user": True,
+            "make_vehicle": True,
+            "buildEngine": True,
+            "newInstance": True,
+            "construct": True,
+            "CreateWindow": True,  # C# PascalCase
+        }
+        for name, expected in cases.items():
+            with self.subTest(method=name):
+                self.assertEqual(FactoryDetector._is_creation_method(name), expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes #425 — both root causes verified by reproducing every case in the report exactly.

### 1. FactoryDetector: convention matching, not substring containment
Creation verbs (`create`/`make`/`build`/`new`/`construct`) now match as **prefixes at a word boundary** (camelCase hump, `_`, digit, or end); accessor prefixes (`get`/`set`/`is`/`has`) are excluded outright.

| case | before | after |
|---|---|---|
| Java POJO (3 getters) | `Factory(0.80)` | `[]` |
| single getter | `Factory(0.60)` | `[]` |
| `renew()` / `getNewsFeed()` | matched `new`/`get` | no match |
| genuine factory (`createVehicle` + `buildEngine`) | `Factory(0.80)` | `Factory(0.80)` ✓ |

### 2. SingletonDetector: reachable in class-named-constructor languages
- `method.name == class_sig.name` counts as the constructor (Java/C#/C++)
- an overridden `__new__` counts by itself — it exists precisely to intercept instance creation (the old docstring/params guard kept genuine Python `__new__` singletons at 0.4)

Canonical `Config.java` Singleton: **`Factory(0.60)` → `Singleton(0.70)`**. The reporter's suggested fix #4 (detector precedence) became unnecessary — fixes 1+2 resolve the `getInstance` conflict naturally.

### 3. Dependency graph (bonus report)
The 0-edges result on RAG-Anything **did not reproduce**: I cloned the repo and ran the exact reported command on current code — 41 nodes / **51 edges** — and `dependency_analyzer.py` is unchanged since v3.8.0. Two hardenings anyway:
- node keys use `as_posix()` (Windows backslash keys would silently zero the `/`-suffix-based resolution — the most plausible path to the reported state)
- a multi-file graph with extracted imports but zero edges now **warns** — loudly with a report link when relative imports prove resolution breakage, neutrally otherwise (independent-script dirs legitimately have no edges)

@saitrsh if the 0-edges persists for you on this build, your OS + project layout on #425 would pin it down.

### Scoped out
The instance-field check (report's fix #3) needs the analyzer to extract class attributes — plumbing that doesn't exist today; worth its own issue if Singleton recall needs another signal.

### Tests
- New `TestDetectorPrecisionJava`: POJO → no patterns, 1-getter → no Factory, canonical Java Singleton (normal class name) → Singleton ≥0.5 and NOT Factory, real factory still detected, 17-subtest word-boundary table
- `test_analyze_singleton_code` now asserts **Singleton** specifically — it previously passed only because the Factory substring bug emitted a bogus pattern for that fixture (exactly the test-suite gap the report called out)
- Full `test_pattern_recognizer.py` + `test_dependency_analyzer.py`: 89 passed
- CI-pinned ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)