### PR TITLE
fix: exclude code blocks from completeness pattern matching

### DIFF
--- a/src/skill_seekers/cli/quality_checker.py
+++ b/src/skill_seekers/cli/quality_checker.py
@@ -13,6 +13,22 @@ import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
+# Fenced code blocks (``` or ~~~) and inline code spans. Stripped before
+# completeness pattern matching so code examples don't trigger prose heuristics.
+_FENCED_CODE_RE = re.compile(r"(?ms)^[ \t]*(```|~~~).*?^[ \t]*\1[ \t]*$")
+_INLINE_CODE_RE = re.compile(r"`[^`\n]+`")
+
+
+def _strip_code(text: str) -> str:
+    """Return ``text`` with fenced code blocks and inline code removed.
+
+    Completeness heuristics (workflow steps, prerequisites, error handling) are
+    about the skill's prose guidance, not its code samples — a ``# Step 1:``
+    comment inside a ```python block is not a workflow step (#229).
+    """
+    without_fenced = _FENCED_CODE_RE.sub("", text)
+    return _INLINE_CODE_RE.sub("", without_fenced)
+
 
 @dataclass
 class QualityIssue:
@@ -326,11 +342,16 @@ class SkillQualityChecker:
 
         Validates that skills include verification/prerequisites sections,
         error handling guidance, and clear workflow steps.
+
+        Pattern matching runs against prose only (fenced code blocks and inline
+        code are stripped first) so a ``# Step 1:`` comment inside a code
+        example is not mistaken for real workflow guidance (#229).
         """
         if not self.skill_md_path.exists():
             return
 
-        content = self.skill_md_path.read_text(encoding="utf-8")
+        raw = self.skill_md_path.read_text(encoding="utf-8")
+        content = _strip_code(raw)
 
         # Check for grounding/verification section (prerequisites)
         grounding_patterns = [

--- a/tests/test_quality_checker.py
+++ b/tests/test_quality_checker.py
@@ -379,6 +379,87 @@ Finally, verify the installation.
                 )
             )
 
+    def test_ignores_workflow_steps_inside_code_blocks(self):
+        """Step comments in a code example must NOT count as workflow guidance (#229)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_md = """# Test Skill
+
+Widgets library.
+
+## Code Example
+
+```python
+# Step 1: Initialize the client
+# Step 2: Configure options
+# Step 3: Run the query
+client = APIClient()
+```
+"""
+            skill_dir = self.create_test_skill(tmpdir, skill_md)
+            report = SkillQualityChecker(skill_dir).check_all()
+
+            completeness_infos = [i for i in report.info if i.category == "completeness"]
+            # No POSITIVE workflow finding (✓ / "markers"); only the suggestion is allowed.
+            self.assertFalse(
+                any(
+                    "✓" in i.message and "workflow" in i.message.lower() for i in completeness_infos
+                )
+            )
+            self.assertFalse(any("markers)" in i.message for i in completeness_infos))
+
+    def test_ignores_grounding_and_error_hints_inside_code_blocks(self):
+        """`verify that` / `if it fails` in code comments must not satisfy the
+        grounding/error-handling checks (#229)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_md = """# Test Skill
+
+## Example
+
+```python
+# prerequisites: none, but verify that the token is set
+# if the request fails, retry with backoff
+do_thing()
+```
+"""
+            skill_dir = self.create_test_skill(tmpdir, skill_md)
+            report = SkillQualityChecker(skill_dir).check_all()
+
+            completeness_infos = [i for i in report.info if i.category == "completeness"]
+            # Both should be reported as MISSING (suggestion), not found.
+            self.assertTrue(
+                any("Consider adding prerequisites" in i.message for i in completeness_infos)
+            )
+            self.assertTrue(
+                any("Consider adding troubleshooting" in i.message for i in completeness_infos)
+            )
+
+    def test_ignores_inline_code_markers(self):
+        """Workflow markers that appear only inside inline code are ignored (#229).
+
+        The surrounding prose deliberately contains no step markers, so any
+        detection would come solely from the inline `step N` spans.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_md = "# Test Skill\n\nInvoke `step 1` and `step 2` on the `first, item`.\n"
+            skill_dir = self.create_test_skill(tmpdir, skill_md)
+            report = SkillQualityChecker(skill_dir).check_all()
+
+            completeness_infos = [i for i in report.info if i.category == "completeness"]
+            self.assertFalse(any("markers)" in i.message for i in completeness_infos))
+
+    def test_strip_code_removes_fenced_and_inline(self):
+        from skill_seekers.cli.quality_checker import _strip_code
+
+        text = (
+            "before `inline` mid\n```python\nhidden step 1\n```\nafter\n~~~\nalso hidden\n~~~\nend"
+        )
+        stripped = _strip_code(text)
+        self.assertNotIn("hidden", stripped)
+        self.assertNotIn("inline", stripped)
+        self.assertIn("before", stripped)
+        self.assertIn("after", stripped)
+        self.assertIn("end", stripped)
+
     def test_checker_suggests_adding_prerequisites(self):
         """Test that checker suggests adding prerequisites when missing"""
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

Fixes #229. `SkillQualityChecker._check_skill_completeness` matched its workflow-step / prerequisites / error-handling regexes against the **raw** SKILL.md, so code examples triggered the prose heuristics. Confirmed on current `development`:

```python
# a skill whose only "steps" are code comments:
## Code Example
```python
# Step 1: Initialize
# Step 2: Configure
```
```
→ reported *"Some workflow guidance found"*. `verify that` / `if ... fails` in a code comment likewise satisfied the grounding/error checks.

## Fix

New module helper `_strip_code()` removes fenced code blocks (``` and `~~~`) and inline code spans; the three completeness pattern groups now match the stripped prose. Real prose detection is unchanged — the existing `test_checker_detects_workflow_steps` (First/Then/Next/Finally) still passes.

## Scope

Did the confirmed, regression-safe part of the issue's acceptance criteria: exclude fenced **and** inline code, add false-positive tests, keep existing tests green. Deliberately left the two **optional** items (section-based scoping, configurable `--workflow-threshold`) out — the first risks false negatives by over-anchoring, the second is a new CLI surface better decided separately.

## Tests

- `test_ignores_workflow_steps_inside_code_blocks`, `test_ignores_grounding_and_error_hints_inside_code_blocks`, `test_ignores_inline_code_markers`, `test_strip_code_removes_fenced_and_inline`
- Full `test_quality_checker.py`: 20 passed; CI-pinned ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)