### PR TITLE
fix: token-lean GitHub issue defaults (open-only, small cap, no metadata)

### DIFF
--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -248,10 +248,12 @@ converter = GitHubScraper({
     "local_repo_path": None,          # optional local clone => unlimited analysis, no API limits
     "include_code": True,
     "include_issues": True,
-    "max_issues": 100,
+    "max_issues": 20,                 # token economy: keep issue payload small
     "max_comments": 0,
     "issue_labels": [],               # filter issues by label
-    "issue_state": "all",             # 'open' | 'closed' | 'all'
+    "issue_state": "open",            # 'open' | 'closed' | 'all' (open-only by default)
+    "include_issue_labels": False,    # include per-issue labels (off = less bloat)
+    "include_issue_milestones": False,  # include per-issue milestone
     "include_changelog": True,
     "include_releases": True,
     "output_dir": "output/fastapi",

--- a/docs/reference/CONFIG_FORMAT.md
+++ b/docs/reference/CONFIG_FORMAT.md
@@ -118,8 +118,11 @@ For analyzing GitHub repositories.
       "code_analysis_depth": "deep",
 
       "fetch_issues": true,
-      "max_issues": 100,
+      "issue_state": "open",
+      "max_issues": 20,
       "issue_labels": ["bug", "enhancement"],
+      "include_issue_labels": false,
+      "include_issue_milestones": false,
 
       "fetch_releases": true,
       "max_releases": 20,
@@ -147,8 +150,11 @@ For analyzing GitHub repositories.
 | `enable_codebase_analysis` | boolean | No | true | Analyze source code |
 | `code_analysis_depth` | string | No | "standard" | `surface`, `standard`, `deep` |
 | `fetch_issues` | boolean | No | true | Fetch GitHub issues |
-| `max_issues` | number | No | 100 | Maximum issues to fetch |
+| `issue_state` | string | No | `"open"` | `open`, `closed`, or `all`. Open-only by default to avoid scraping stale closed issues (token bloat). |
+| `max_issues` | number | No | 20 | Maximum issues to fetch |
 | `issue_labels` | array | No | [] | Filter by labels |
+| `include_issue_labels` | boolean | No | false | Include each issue's labels in the skill (off by default; metadata bloat) |
+| `include_issue_milestones` | boolean | No | false | Include each issue's milestone (off by default) |
 | `fetch_releases` | boolean | No | true | Fetch releases |
 | `max_releases` | number | No | 20 | Maximum releases |
 | `fetch_changelog` | boolean | No | true | Extract CHANGELOG |

--- a/src/skill_seekers/cli/config_validator.py
+++ b/src/skill_seekers/cli/config_validator.py
@@ -313,6 +313,11 @@ class UniSkillConfigValidator:
                     f"Must be one of {valid_issue_states}"
                 )
 
+        # Validate issue-metadata opt-in flags if specified (#169)
+        for bool_key in ("include_issue_labels", "include_issue_milestones"):
+            if bool_key in source and not isinstance(source[bool_key], bool):
+                raise ValueError(f"Source {index} (github): '{bool_key}' must be a boolean")
+
         # Validate enable_codebase_analysis if specified (C3.5)
         if "enable_codebase_analysis" in source and not isinstance(
             source["enable_codebase_analysis"], bool

--- a/src/skill_seekers/cli/github_scraper.py
+++ b/src/skill_seekers/cli/github_scraper.py
@@ -254,12 +254,19 @@ class GitHubScraper(SkillConverter):
         self.repo: Repository.Repository | None = None
 
         # Options
+        # Issue defaults favor token economy (#169): open issues only, a small
+        # cap, and label/milestone metadata off. A repo like facebook/react has
+        # 12k+ closed issues — scraping them (and their metadata) bloats every
+        # skill that uses it. Opt back in via issue_state/max_issues/
+        # include_issue_labels/include_issue_milestones.
         self.include_issues = config.get("include_issues", True)
-        self.max_issues = config.get("max_issues", 100)
+        self.max_issues = config.get("max_issues", 20)
         self.max_comments = config.get("max_comments", 0)
         self.issue_since = config.get("issue_since")
         self.issue_labels = config.get("issue_labels", [])
-        self.issue_state = config.get("issue_state", "all")
+        self.issue_state = config.get("issue_state", "open")
+        self.include_issue_labels = config.get("include_issue_labels", False)
+        self.include_issue_milestones = config.get("include_issue_milestones", False)
         self.per_issue_files = config.get("per_issue_files", False)
         self.include_changelog = config.get("include_changelog", True)
         self.include_releases = config.get("include_releases", True)
@@ -849,7 +856,7 @@ class GitHubScraper(SkillConverter):
         try:
             # Build kwargs for get_issues
             kwargs: dict[str, Any] = {
-                "state": self.issue_state or "all",
+                "state": self.issue_state or "open",
                 "sort": "updated",
                 "direction": "desc",
             }
@@ -901,8 +908,17 @@ class GitHubScraper(SkillConverter):
                     "number": issue.number,
                     "title": issue.title,
                     "state": issue.state,
-                    "labels": [label.name for label in issue.labels],
-                    "milestone": issue.milestone.title if issue.milestone else None,
+                    # Label/milestone metadata is off by default (#169) — it's
+                    # bloat for most skills. Empty list / None keep the schema
+                    # stable for downstream consumers.
+                    "labels": (
+                        [label.name for label in issue.labels] if self.include_issue_labels else []
+                    ),
+                    "milestone": (
+                        (issue.milestone.title if issue.milestone else None)
+                        if self.include_issue_milestones
+                        else None
+                    ),
                     "created_at": issue.created_at.isoformat() if issue.created_at else None,
                     "updated_at": issue.updated_at.isoformat() if issue.updated_at else None,
                     "closed_at": issue.closed_at.isoformat() if issue.closed_at else None,
@@ -1405,21 +1421,32 @@ Use this skill when you need to:
         open_issues = [i for i in issues if i["state"] == "open"]
         closed_issues = [i for i in issues if i["state"] == "closed"]
 
-        content += f"## Open Issues ({len(open_issues)})\n\n"
-        for issue in open_issues:
-            labels = ", ".join(issue["labels"]) if issue["labels"] else "No labels"
-            created_at = issue.get("created_at") or "N/A"
-            content += f"### #{issue['number']}: {issue['title']}\n"
-            content += f"**Labels:** {labels} | **Created:** {created_at[:10]}\n"
-            content += f"[View on GitHub]({issue['url']})\n\n"
+        def _meta_line(issue: dict, date_label: str, date_key: str) -> str:
+            # Only surface labels when they were actually collected
+            # (include_issue_labels), so we don't print "No labels" on every
+            # issue by default (#169).
+            parts = []
+            if issue.get("labels"):
+                parts.append(f"**Labels:** {', '.join(issue['labels'])}")
+            date_val = issue.get(date_key) or "N/A"
+            parts.append(f"**{date_label}:** {date_val[:10]}")
+            return " | ".join(parts)
 
-        content += f"\n## Recently Closed Issues ({len(closed_issues)})\n\n"
-        for issue in closed_issues:
-            labels = ", ".join(issue["labels"]) if issue["labels"] else "No labels"
-            closed_at = issue.get("closed_at") or "N/A"
-            content += f"### #{issue['number']}: {issue['title']}\n"
-            content += f"**Labels:** {labels} | **Closed:** {closed_at[:10]}\n"
-            content += f"[View on GitHub]({issue['url']})\n\n"
+        # Only emit a section when it has issues — with the open-only default
+        # (#169) the closed section is otherwise a permanent empty stub.
+        if open_issues:
+            content += f"## Open Issues ({len(open_issues)})\n\n"
+            for issue in open_issues:
+                content += f"### #{issue['number']}: {issue['title']}\n"
+                content += _meta_line(issue, "Created", "created_at") + "\n"
+                content += f"[View on GitHub]({issue['url']})\n\n"
+
+        if closed_issues:
+            content += f"\n## Recently Closed Issues ({len(closed_issues)})\n\n"
+            for issue in closed_issues:
+                content += f"### #{issue['number']}: {issue['title']}\n"
+                content += _meta_line(issue, "Closed", "closed_at") + "\n"
+                content += f"[View on GitHub]({issue['url']})\n\n"
 
         issues_path = f"{self.skill_dir}/references/issues.md"
         with open(issues_path, "w", encoding="utf-8") as f:

--- a/tests/test_github_scraper.py
+++ b/tests/test_github_scraper.py
@@ -288,12 +288,15 @@ class TestIssuesExtraction(unittest.TestCase):
         self.GitHubScraper = GitHubScraper
 
     def test_extract_issues_success(self):
-        """Test successful issues extraction"""
+        """Test successful issues extraction (labels/milestones opted in)"""
         config = {
             "repo": "facebook/react",
             "name": "react",
             "github_token": None,
             "max_issues": 10,
+            # Metadata is off by default (#169) — opt in to assert its capture.
+            "include_issue_labels": True,
+            "include_issue_milestones": True,
         }
 
         # Create mock issues
@@ -1173,7 +1176,7 @@ class TestErrorHandling(unittest.TestCase):
             self.assertEqual(call_kwargs["since"], datetime.fromisoformat("2026-01-01"))
 
     def test_extract_issues_no_filters_by_default(self):
-        """Test that _extract_issues uses defaults when no filters set."""
+        """Default state is 'open' (#169) and no label/since filters are set."""
         config = {
             "repo": "facebook/react",
             "name": "react",
@@ -1189,9 +1192,50 @@ class TestErrorHandling(unittest.TestCase):
             scraper._extract_issues()
 
             call_kwargs = scraper.repo.get_issues.call_args[1]
-            self.assertEqual(call_kwargs["state"], "all")
+            self.assertEqual(call_kwargs["state"], "open")
             self.assertNotIn("labels", call_kwargs)
             self.assertNotIn("since", call_kwargs)
+
+    def test_issue_token_economy_defaults(self):
+        """#169: open-only, small cap, metadata off — unless opted in."""
+        with patch("skill_seekers.cli.github_scraper.Github"):
+            scraper = self.GitHubScraper({"repo": "facebook/react", "name": "react"})
+            self.assertEqual(scraper.issue_state, "open")
+            self.assertEqual(scraper.max_issues, 20)
+            self.assertFalse(scraper.include_issue_labels)
+            self.assertFalse(scraper.include_issue_milestones)
+
+    def test_extract_issues_excludes_metadata_by_default(self):
+        """Labels/milestone are dropped from issue data unless opted in (#169)."""
+        config = {"repo": "facebook/react", "name": "react", "max_issues": 5}
+
+        mock_label = Mock()
+        mock_label.name = "bug"
+        mock_milestone = Mock()
+        mock_milestone.title = "v18.0"
+        mock_issue = Mock()
+        mock_issue.number = 1
+        mock_issue.title = "Something"
+        mock_issue.state = "open"
+        mock_issue.labels = [mock_label]
+        mock_issue.milestone = mock_milestone
+        mock_issue.created_at = datetime(2026, 1, 1)
+        mock_issue.updated_at = datetime(2026, 1, 2)
+        mock_issue.closed_at = None
+        mock_issue.html_url = "https://github.com/facebook/react/issues/1"
+        mock_issue.body = "body"
+        mock_issue.pull_request = None
+        mock_issue.get_comments.return_value = []
+
+        with patch("skill_seekers.cli.github_scraper.Github"):
+            scraper = self.GitHubScraper(config)
+            scraper.repo = Mock()
+            scraper.repo.get_issues.return_value = [mock_issue]
+            scraper._extract_issues()
+
+            issue = scraper.extracted_data["issues"][0]
+            self.assertEqual(issue["labels"], [])
+            self.assertIsNone(issue["milestone"])
 
     def test_issue_filter_args_in_config(self):
         """Test that issue filter config keys are read in __init__."""


### PR DESCRIPTION
## Summary

Fixes #169. GitHub scraping defaulted to `issue_state="all"` + `max_issues=100` with labels and milestones always emitted, so every GitHub-sourced skill carried large amounts of stale closed-issue history — token cost users pay on every skill use. This implements the issue's "Immediate (breaking but necessary)" recommendations.

## New defaults (all overridable)

| Setting | Before | After |
|---|---|---|
| `issue_state` | `"all"` | `"open"` |
| `max_issues` | `100` | `20` |
| per-issue `labels` | always | only if `include_issue_labels: true` |
| per-issue `milestone` | always | only if `include_issue_milestones: true` |

To restore the old behavior: `{"issue_state": "all", "max_issues": 100, "include_issue_labels": true, "include_issue_milestones": true}`.

## Reference output
`references/issues.md` now omits an empty section (the closed section is otherwise a permanent empty stub under open-only) and prints a **Labels:** line only when labels were actually collected — no more `No labels` on every issue.

## Scope
Did the high-impact, endorsed changes. **Kept intentionally**: created/updated/closed timestamps (3 small ISO strings, and the reference builder uses them) and the existing 500-char body-preview handling — the bulk of the bloat is closed-issue *count* × body, which the state+cap change already removes. The issue's more aggressive body-skip / timestamp-drop can follow separately if wanted.

## Tests & docs
- Updated the two tests that pinned old defaults (opt into metadata where they assert it; default state now `open`)
- New tests: token-economy defaults, and metadata excluded-by-default from issue data
- `config_validator` gains bool validation for the two new keys
- `CONFIG_FORMAT.md` + `API_REFERENCE.md` updated
- 187 passed across github/new-source/validator/merge suites; CI-pinned ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)