### PR TITLE
feat: retry transient network failures in the doc scraper (#97)

### DIFF
--- a/docs/reference/CONFIG_FORMAT.md
+++ b/docs/reference/CONFIG_FORMAT.md
@@ -95,6 +95,7 @@ For scraping documentation websites.
 | `categories` | object | No | `{}` | Content categorization rules |
 | `rate_limit` | number | No | 0.5 | Seconds between requests |
 | `max_pages` | number | No | 500 | Maximum pages to scrape |
+| `max_retries` | number | No | 3 | Fetch attempts per page; transient failures (connect/timeout/5xx) retry with exponential backoff. `1` disables retrying. |
 | `merge_mode` | string | No | "claude-enhanced" | Merge strategy |
 | `extract_api` | boolean | No | false | Extract API references |
 | `llms_txt_url` | string | No | auto | Path to llms.txt file |

--- a/src/skill_seekers/cli/doc_scraper.py
+++ b/src/skill_seekers/cli/doc_scraper.py
@@ -48,7 +48,12 @@ from skill_seekers.cli.llms_txt_detector import LlmsTxtDetector
 from skill_seekers.cli.llms_txt_downloader import LlmsTxtDownloader
 from skill_seekers.cli.llms_txt_parser import LlmsTxtParser
 from skill_seekers.cli.skill_converter import SkillConverter
-from skill_seekers.cli.utils import sanitize_url, setup_logging
+from skill_seekers.cli.utils import (
+    retry_with_backoff,
+    retry_with_backoff_async,
+    sanitize_url,
+    setup_logging,
+)
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -281,6 +286,10 @@ class DocToSkillConverter(SkillConverter):
         # Parallel scraping config
         self.workers = normalized_config.get("workers") or DEFAULTS["scraping"]["workers"]
         self.async_mode = normalized_config.get("async_mode", DEFAULT_ASYNC_MODE)
+        # Total fetch attempts per page (#97). Transient network failures
+        # (connection/timeout/5xx) previously dropped a page on the first blip;
+        # now they retry with exponential backoff. 1 disables retrying.
+        self.max_retries = max(1, int(normalized_config.get("max_retries", 3)))
 
         # State
         self.visited_urls: set[str] = set()
@@ -957,6 +966,40 @@ class DocToSkillConverter(SkillConverter):
             )
         return self._browser_renderer.render_page(url)
 
+    def _get_with_retry(self, url: str, headers: dict, timeout: float) -> requests.Response:
+        """GET a URL, retrying transient network failures with backoff (#97).
+
+        Retries connection/timeout errors and 5xx responses (self.max_retries
+        attempts total). A 4xx is a definitive answer (missing/forbidden page),
+        so it is returned un-retried and surfaces via the caller's
+        raise_for_status().
+        """
+
+        def _attempt() -> requests.Response:
+            resp = requests.get(url, headers=headers, timeout=timeout)
+            if resp.status_code >= 500:
+                resp.raise_for_status()  # trigger a retry on server errors
+            return resp
+
+        return retry_with_backoff(
+            _attempt, max_attempts=self.max_retries, operation_name=f"fetch {url}"
+        )
+
+    async def _aget_with_retry(
+        self, client: httpx.AsyncClient, url: str, headers: dict, timeout: float
+    ) -> httpx.Response:
+        """Async counterpart of _get_with_retry (#97)."""
+
+        async def _attempt() -> httpx.Response:
+            resp = await client.get(url, headers=headers, timeout=timeout)
+            if resp.status_code >= 500:
+                resp.raise_for_status()
+            return resp
+
+        return await retry_with_backoff_async(
+            _attempt, max_attempts=self.max_retries, operation_name=f"fetch {url}"
+        )
+
     def scrape_page(self, url: str) -> None:
         """Scrape a single page with thread-safe operations.
 
@@ -982,7 +1025,7 @@ class DocToSkillConverter(SkillConverter):
                 page = self.extract_content(soup, url)
             else:
                 headers = {"User-Agent": "Mozilla/5.0 (Documentation Scraper)"}
-                response = requests.get(url, headers=headers, timeout=30)
+                response = self._get_with_retry(url, headers, 30)
                 response.raise_for_status()
 
                 # Check if this is a Markdown file
@@ -1050,7 +1093,7 @@ class DocToSkillConverter(SkillConverter):
                 else:
                     # Async HTTP request
                     headers = {"User-Agent": "Mozilla/5.0 (Documentation Scraper)"}
-                    response = await client.get(url, headers=headers, timeout=30.0)
+                    response = await self._aget_with_retry(client, url, headers, 30.0)
                     response.raise_for_status()
 
                     # Check if this is a Markdown file

--- a/tests/test_scraper_retry.py
+++ b/tests/test_scraper_retry.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Tests for doc_scraper network retry with exponential backoff (#97)."""
+
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import requests
+
+from skill_seekers.cli.doc_scraper import DocToSkillConverter
+
+
+def _resp(status_code: int):
+    resp = MagicMock(spec=requests.Response)
+    resp.status_code = status_code
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = requests.HTTPError(str(status_code))
+    return resp
+
+
+def _hx_resp(status_code: int):
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            str(status_code), request=MagicMock(), response=resp
+        )
+    return resp
+
+
+class TestScraperRetry(unittest.TestCase):
+    def _scraper(self, max_retries=3):
+        return DocToSkillConverter(
+            {
+                "name": "t",
+                "base_url": "https://x.test/",
+                "max_retries": max_retries,
+                "rate_limit": 0,
+            }
+        )
+
+    def test_default_max_retries_is_three(self):
+        self.assertEqual(self._scraper().max_retries, 3)
+
+    def test_max_retries_floor_is_one(self):
+        # 0 or negative would make retry_with_backoff never attempt; clamp to 1.
+        self.assertEqual(self._scraper(max_retries=0).max_retries, 1)
+
+    @patch("time.sleep")
+    def test_transient_errors_are_retried(self, _sleep):
+        s = self._scraper()
+        with patch(
+            "skill_seekers.cli.doc_scraper.requests.get",
+            side_effect=[requests.ConnectionError("boom"), requests.Timeout("slow"), _resp(200)],
+        ) as g:
+            resp = s._get_with_retry("https://x.test/a", {}, 30)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(g.call_count, 3)
+
+    @patch("time.sleep")
+    def test_5xx_is_retried(self, _sleep):
+        s = self._scraper()
+        with patch(
+            "skill_seekers.cli.doc_scraper.requests.get",
+            side_effect=[_resp(503), _resp(200)],
+        ) as g:
+            resp = s._get_with_retry("https://x.test/a", {}, 30)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(g.call_count, 2)
+
+    @patch("time.sleep")
+    def test_4xx_is_not_retried(self, _sleep):
+        s = self._scraper()
+        with patch("skill_seekers.cli.doc_scraper.requests.get", return_value=_resp(404)) as g:
+            resp = s._get_with_retry("https://x.test/a", {}, 30)
+        self.assertEqual(resp.status_code, 404)
+        self.assertEqual(g.call_count, 1)
+
+    @patch("time.sleep")
+    def test_persistent_failure_raises_after_max_attempts(self, _sleep):
+        s = self._scraper(max_retries=3)
+        with (
+            patch(
+                "skill_seekers.cli.doc_scraper.requests.get",
+                side_effect=requests.ConnectionError("down"),
+            ) as g,
+            self.assertRaises(requests.ConnectionError),
+        ):
+            s._get_with_retry("https://x.test/a", {}, 30)
+        self.assertEqual(g.call_count, 3)
+
+    @patch("time.sleep")
+    def test_max_retries_one_disables_retry(self, _sleep):
+        s = self._scraper(max_retries=1)
+        with (
+            patch(
+                "skill_seekers.cli.doc_scraper.requests.get",
+                side_effect=requests.ConnectionError("x"),
+            ) as g,
+            self.assertRaises(requests.ConnectionError),
+        ):
+            s._get_with_retry("https://x.test/a", {}, 30)
+        self.assertEqual(g.call_count, 1)
+
+    def test_async_transient_error_is_retried(self):
+        s = self._scraper()
+        client = MagicMock()
+        client.get = AsyncMock(side_effect=[httpx.ConnectError("boom"), _hx_resp(200)])
+        with patch("asyncio.sleep", new=AsyncMock()):
+            resp = asyncio.run(s._aget_with_retry(client, "https://x.test/a", {}, 30.0))
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(client.get.await_count, 2)
+
+    def test_async_4xx_not_retried(self):
+        s = self._scraper()
+        client = MagicMock()
+        client.get = AsyncMock(return_value=_hx_resp(404))
+        with patch("asyncio.sleep", new=AsyncMock()):
+            resp = asyncio.run(s._aget_with_retry(client, "https://x.test/a", {}, 30.0))
+        self.assertEqual(resp.status_code, 404)
+        self.assertEqual(client.get.await_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #97. `scrape_page` (and `scrape_page_async`) did a single-shot `requests.get` / `client.get`; any exception logged and dropped the page — so one transient connection blip or 5xx during a large scrape silently produced an **incomplete skill with no indication** which pages were lost.

Both fetch paths now go through `retry_with_backoff` / `retry_with_backoff_async` — utilities that already existed with tests but had **zero callers** (same "utilities ready, integration pending" state as #92).

## Behavior

- Retries **transient** faults only: connection/timeout errors and **5xx** responses (exponential backoff, 1s/2s).
- **4xx is not retried** — a 404/403 is a definitive answer; it's returned so the caller's `raise_for_status()` surfaces it, without wasting backoff on a correct response.
- Attempts configurable via `max_retries` (default **3**, floored at 1 so `max_retries: 1` restores the old single-shot behavior).

## Tests

9 new tests (sync + async): transient-then-success, 5xx retried, 4xx not retried, exhaustion raises after N, `max_retries=1` disables, default/floor. Existing scrape suites unaffected (99 passed across retry/features/async/llms). CI-pinned ruff clean. `CONFIG_FORMAT.md` documents the option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)