### PR TITLE
fix(sponsors): give the bottom sponsor grid a heading

### DIFF
--- a/README.ar.md
+++ b/README.ar.md
@@ -416,6 +416,8 @@ MIT — راجع [LICENSE](LICENSE).
 
 ---
 
+## 💜 رعاة إضافيون
+
 <!-- SPONSORS:BOTTOM:START -->
 **Silver Sponsors**
 

--- a/README.de.md
+++ b/README.de.md
@@ -418,6 +418,8 @@ MIT — siehe [LICENSE](LICENSE).
 
 ---
 
+## 💜 Weitere Sponsoren
+
 <!-- SPONSORS:BOTTOM:START -->
 **Silver Sponsors**
 

--- a/README.es.md
+++ b/README.es.md
@@ -418,6 +418,8 @@ MIT — consulte [LICENSE](LICENSE).
 
 ---
 
+## 💜 Más patrocinadores
+
 <!-- SPONSORS:BOTTOM:START -->
 **Silver Sponsors**
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -418,6 +418,8 @@ MIT — voir [LICENSE](LICENSE).
 
 ---
 
+## 💜 Autres sponsors
+
 <!-- SPONSORS:BOTTOM:START -->
 **Silver Sponsors**
 

--- a/README.hi.md
+++ b/README.hi.md
@@ -418,6 +418,8 @@ MIT — देखें [LICENSE](LICENSE)।
 
 ---
 
+## 💜 अधिक प्रायोजक
+
 <!-- SPONSORS:BOTTOM:START -->
 **Silver Sponsors**
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -418,6 +418,8 @@ MIT — [LICENSE](LICENSE) をご覧ください。
 
 ---
 
+## 💜 その他のスポンサー
+
 <!-- SPONSORS:BOTTOM:START -->
 **Silver Sponsors**
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -418,6 +418,8 @@ MIT — [LICENSE](LICENSE)를 참고하세요.
 
 ---
 
+## 💜 추가 스폰서
+
 <!-- SPONSORS:BOTTOM:START -->
 **Silver Sponsors**
 

--- a/README.md
+++ b/README.md
@@ -412,6 +412,8 @@ MIT — see [LICENSE](LICENSE).
 
 ---
 
+## 💜 More Sponsors
+
 <!-- SPONSORS:BOTTOM:START -->
 **Silver Sponsors**
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -418,6 +418,8 @@ MIT — veja [LICENSE](LICENSE).
 
 ---
 
+## 💜 Mais patrocinadores
+
 <!-- SPONSORS:BOTTOM:START -->
 **Silver Sponsors**
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -416,6 +416,8 @@ MIT — см. [LICENSE](LICENSE).
 
 ---
 
+## 💜 Другие спонсоры
+
 <!-- SPONSORS:BOTTOM:START -->
 **Silver Sponsors**
 

--- a/README.tr.md
+++ b/README.tr.md
@@ -418,6 +418,8 @@ MIT — bkz. [LICENSE](LICENSE).
 
 ---
 
+## 💜 Diğer sponsorlar
+
 <!-- SPONSORS:BOTTOM:START -->
 **Silver Sponsors**
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -418,6 +418,8 @@ MIT —— 详见 [LICENSE](LICENSE)。
 
 ---
 
+## 💜 更多赞助商
+
 <!-- SPONSORS:BOTTOM:START -->
 **Silver Sponsors**
 


### PR DESCRIPTION
The Silver/Bronze grid had **no heading**, so it rendered orphaned:

```
## 🔒 Security
[badge]
---
        [RapidProxy logo]      ← no context
        Sponsor — Silver
## 🌐 Ecosystem
```

RapidProxy's placement looked accidental rather than deliberate — not what a Silver sponsor paid for. My miss when I inserted the markers.

## Fix

Adds a translated **💜 More Sponsors** heading above the block in all 12 READMEs.

## Why two zones stay

The tier table sells *"near the top of the README sponsor section"* as a **Gold** perk — that's what justifies $400 over Silver's $150. Position is the product, so collapsing to one section would quietly devalue Gold.

## Why not a second "Sponsors"

A literal `## 💜 Sponsors` would collide with the top section's anchor (`#-sponsors` / `#-sponsors-1`) — the same defect fixed earlier in the two duplicate "Documentation" sections. Distinct wording keeps anchors unique.

Verified across all 12: top marker, bottom marker, 💜 heading present, **zero duplicate anchors**. Generator `--check` still clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)