### PR TITLE
refactor(sponsors): one sponsor section, tiers as subheadings

### DIFF
--- a/README.ar.md
+++ b/README.ar.md
@@ -27,15 +27,21 @@
 
 ## 💛 الرعاة
 
-<!-- SPONSORS:TOP:START -->
-**Launch Partner**
+<!-- SPONSORS:START -->
+### Launch Partner
 
 <p align="center">
   <a href="https://www.atlascloud.ai/"><img src="docs/assets/sponsors/atlas-cloud.png" alt="Atlas Cloud" width="200"></a><br/><sub><b>Launch Partner</b></sub>
 </p>
 
 [Atlas Cloud](https://www.atlascloud.ai/) — A full-modal, OpenAI-compatible AI inference platform. Skill Seekers supports it as a packaging/enhancement target via `--target atlas` with `ATLAS_API_KEY`.
-<!-- SPONSORS:TOP:END -->
+
+### Silver Sponsors
+
+<p align="center">
+  <a href="https://www.rapidproxy.io/?utm_source=skillseekers&utm_medium=sponsor"><img src="docs/assets/sponsors/rapidproxy.png" alt="RapidProxy" width="140"></a><br/><sub><b>Sponsor — Silver</b></sub>
+</p>
+<!-- SPONSORS:END -->
 
 **[كن راعيًا](SPONSORSHIP.md)** · [GitHub Sponsors](https://github.com/sponsors/yusufkaraaslan)
 
@@ -415,14 +421,6 @@ MIT — راجع [LICENSE](LICENSE).
 [![MseeP.ai Security Assessment Badge](https://mseep.net/pr/yusufkaraaslan-skill-seekers-badge.png)](https://mseep.ai/app/yusufkaraaslan-skill-seekers)
 
 ---
-
-<!-- SPONSORS:BOTTOM:START -->
-**Silver Sponsors**
-
-<p align="center">
-  <a href="https://www.rapidproxy.io/?utm_source=skillseekers&utm_medium=sponsor"><img src="docs/assets/sponsors/rapidproxy.png" alt="RapidProxy" width="140"></a><br/><sub><b>Sponsor — Silver</b></sub>
-</p>
-<!-- SPONSORS:BOTTOM:END -->
 
 ## 🌐 المنظومة
 

--- a/README.de.md
+++ b/README.de.md
@@ -29,15 +29,21 @@
 
 ## 💛 Sponsoren
 
-<!-- SPONSORS:TOP:START -->
-**Launch Partner**
+<!-- SPONSORS:START -->
+### Launch Partner
 
 <p align="center">
   <a href="https://www.atlascloud.ai/"><img src="docs/assets/sponsors/atlas-cloud.png" alt="Atlas Cloud" width="200"></a><br/><sub><b>Launch Partner</b></sub>
 </p>
 
 [Atlas Cloud](https://www.atlascloud.ai/) — A full-modal, OpenAI-compatible AI inference platform. Skill Seekers supports it as a packaging/enhancement target via `--target atlas` with `ATLAS_API_KEY`.
-<!-- SPONSORS:TOP:END -->
+
+### Silver Sponsors
+
+<p align="center">
+  <a href="https://www.rapidproxy.io/?utm_source=skillseekers&utm_medium=sponsor"><img src="docs/assets/sponsors/rapidproxy.png" alt="RapidProxy" width="140"></a><br/><sub><b>Sponsor — Silver</b></sub>
+</p>
+<!-- SPONSORS:END -->
 
 **[Sponsor werden](SPONSORSHIP.md)** · [GitHub Sponsors](https://github.com/sponsors/yusufkaraaslan)
 
@@ -417,14 +423,6 @@ MIT — siehe [LICENSE](LICENSE).
 [![MseeP.ai Security Assessment Badge](https://mseep.net/pr/yusufkaraaslan-skill-seekers-badge.png)](https://mseep.ai/app/yusufkaraaslan-skill-seekers)
 
 ---
-
-<!-- SPONSORS:BOTTOM:START -->
-**Silver Sponsors**
-
-<p align="center">
-  <a href="https://www.rapidproxy.io/?utm_source=skillseekers&utm_medium=sponsor"><img src="docs/assets/sponsors/rapidproxy.png" alt="RapidProxy" width="140"></a><br/><sub><b>Sponsor — Silver</b></sub>
-</p>
-<!-- SPONSORS:BOTTOM:END -->
 
 ## 🌐 Ökosystem
 

--- a/README.es.md
+++ b/README.es.md
@@ -29,15 +29,21 @@
 
 ## 💛 Patrocinadores
 
-<!-- SPONSORS:TOP:START -->
-**Launch Partner**
+<!-- SPONSORS:START -->
+### Launch Partner
 
 <p align="center">
   <a href="https://www.atlascloud.ai/"><img src="docs/assets/sponsors/atlas-cloud.png" alt="Atlas Cloud" width="200"></a><br/><sub><b>Launch Partner</b></sub>
 </p>
 
 [Atlas Cloud](https://www.atlascloud.ai/) — A full-modal, OpenAI-compatible AI inference platform. Skill Seekers supports it as a packaging/enhancement target via `--target atlas` with `ATLAS_API_KEY`.
-<!-- SPONSORS:TOP:END -->
+
+### Silver Sponsors
+
+<p align="center">
+  <a href="https://www.rapidproxy.io/?utm_source=skillseekers&utm_medium=sponsor"><img src="docs/assets/sponsors/rapidproxy.png" alt="RapidProxy" width="140"></a><br/><sub><b>Sponsor — Silver</b></sub>
+</p>
+<!-- SPONSORS:END -->
 
 **[Conviértete en patrocinador](SPONSORSHIP.md)** · [GitHub Sponsors](https://github.com/sponsors/yusufkaraaslan)
 
@@ -417,14 +423,6 @@ MIT — consulte [LICENSE](LICENSE).
 [![MseeP.ai Security Assessment Badge](https://mseep.net/pr/yusufkaraaslan-skill-seekers-badge.png)](https://mseep.ai/app/yusufkaraaslan-skill-seekers)
 
 ---
-
-<!-- SPONSORS:BOTTOM:START -->
-**Silver Sponsors**
-
-<p align="center">
-  <a href="https://www.rapidproxy.io/?utm_source=skillseekers&utm_medium=sponsor"><img src="docs/assets/sponsors/rapidproxy.png" alt="RapidProxy" width="140"></a><br/><sub><b>Sponsor — Silver</b></sub>
-</p>
-<!-- SPONSORS:BOTTOM:END -->
 
 ## 🌐 Ecosistema
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -29,15 +29,21 @@
 
 ## 💛 Sponsors
 
-<!-- SPONSORS:TOP:START -->
-**Launch Partner**
+<!-- SPONSORS:START -->
+### Launch Partner
 
 <p align="center">
   <a href="https://www.atlascloud.ai/"><img src="docs/assets/sponsors/atlas-cloud.png" alt="Atlas Cloud" width="200"></a><br/><sub><b>Launch Partner</b></sub>
 </p>
 
 [Atlas Cloud](https://www.atlascloud.ai/) — A full-modal, OpenAI-compatible AI inference platform. Skill Seekers supports it as a packaging/enhancement target via `--target atlas` with `ATLAS_API_KEY`.
-<!-- SPONSORS:TOP:END -->
+
+### Silver Sponsors
+
+<p align="center">
+  <a href="https://www.rapidproxy.io/?utm_source=skillseekers&utm_medium=sponsor"><img src="docs/assets/sponsors/rapidproxy.png" alt="RapidProxy" width="140"></a><br/><sub><b>Sponsor — Silver</b></sub>
+</p>
+<!-- SPONSORS:END -->
 
 **[Devenir sponsor](SPONSORSHIP.md)** · [GitHub Sponsors](https://github.com/sponsors/yusufkaraaslan)
 
@@ -417,14 +423,6 @@ MIT — voir [LICENSE](LICENSE).
 [![MseeP.ai Security Assessment Badge](https://mseep.net/pr/yusufkaraaslan-skill-seekers-badge.png)](https://mseep.ai/app/yusufkaraaslan-skill-seekers)
 
 ---
-
-<!-- SPONSORS:BOTTOM:START -->
-**Silver Sponsors**
-
-<p align="center">
-  <a href="https://www.rapidproxy.io/?utm_source=skillseekers&utm_medium=sponsor"><img src="docs/assets/sponsors/rapidproxy.png" alt="RapidProxy" width="140"></a><br/><sub><b>Sponsor — Silver</b></sub>
-</p>
-<!-- SPONSORS:BOTTOM:END -->
 
 ## 🌐 Écosystème
 

--- a/README.hi.md
+++ b/README.hi.md
@@ -29,15 +29,21 @@
 
 ## 💛 प्रायोजक
 
-<!-- SPONSORS:TOP:START -->
-**Launch Partner**
+<!-- SPONSORS:START -->
+### Launch Partner
 
 <p align="center">
   <a href="https://www.atlascloud.ai/"><img src="docs/assets/sponsors/atlas-cloud.png" alt="Atlas Cloud" width="200"></a><br/><sub><b>Launch Partner</b></sub>
 </p>
 
 [Atlas Cloud](https://www.atlascloud.ai/) — A full-modal, OpenAI-compatible AI inference platform. Skill Seekers supports it as a packaging/enhancement target via `--target atlas` with `ATLAS_API_KEY`.
-<!-- SPONSORS:TOP:END -->
+
+### Silver Sponsors
+
+<p align="center">
+  <a href="https://www.rapidproxy.io/?utm_source=skillseekers&utm_medium=sponsor"><img src="docs/assets/sponsors/rapidproxy.png" alt="RapidProxy" width="140"></a><br/><sub><b>Sponsor — Silver</b></sub>
+</p>
+<!-- SPONSORS:END -->
 
 **[प्रायोजक बनें](SPONSORSHIP.md)** · [GitHub Sponsors](https://github.com/sponsors/yusufkaraaslan)
 
@@ -417,14 +423,6 @@ MIT — देखें [LICENSE](LICENSE)।
 [![MseeP.ai Security Assessment Badge](https://mseep.net/pr/yusufkaraaslan-skill-seekers-badge.png)](https://mseep.ai/app/yusufkaraaslan-skill-seekers)
 
 ---
-
-<!-- SPONSORS:BOTTOM:START -->
-**Silver Sponsors**
-
-<p align="center">
-  <a href="https://www.rapidproxy.io/?utm_source=skillseekers&utm_medium=sponsor"><img src="docs/assets/sponsors/rapidproxy.png" alt="RapidProxy" width="140"></a><br/><sub><b>Sponsor — Silver</b></sub>
-</p>
-<!-- SPONSORS:BOTTOM:END -->
 
 ## 🌐 इकोसिस्टम
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -29,15 +29,21 @@
 
 ## 💛 スポンサー
 
-<!-- SPONSORS:TOP:START -->
-**Launch Partner**
+<!-- SPONSORS:START -->
+### Launch Partner
 
 <p align="center">
   <a href="https://www.atlascloud.ai/"><img src="docs/assets/sponsors/atlas-cloud.png" alt="Atlas Cloud" width="200"></a><br/><sub><b>Launch Partner</b></sub>
 </p>
 
 [Atlas Cloud](https://www.atlascloud.ai/) — A full-modal, OpenAI-compatible AI inference platform. Skill Seekers supports it as a packaging/enhancement target via `--target atlas` with `ATLAS_API_KEY`.
-<!-- SPONSORS:TOP:END -->
+
+### Silver Sponsors
+
+<p align="center">
+  <a href="https://www.rapidproxy.io/?utm_source=skillseekers&utm_medium=sponsor"><img src="docs/assets/sponsors/rapidproxy.png" alt="RapidProxy" width="140"></a><br/><sub><b>Sponsor — Silver</b></sub>
+</p>
+<!-- SPONSORS:END -->
 
 **[スポンサーになる](SPONSORSHIP.md)** · [GitHub Sponsors](https://github.com/sponsors/yusufkaraaslan)
 
@@ -417,14 +423,6 @@ MIT — [LICENSE](LICENSE) をご覧ください。
 [![MseeP.ai Security Assessment Badge](https://mseep.net/pr/yusufkaraaslan-skill-seekers-badge.png)](https://mseep.ai/app/yusufkaraaslan-skill-seekers)
 
 ---
-
-<!-- SPONSORS:BOTTOM:START -->
-**Silver Sponsors**
-
-<p align="center">
-  <a href="https://www.rapidproxy.io/?utm_source=skillseekers&utm_medium=sponsor"><img src="docs/assets/sponsors/rapidproxy.png" alt="RapidProxy" width="140"></a><br/><sub><b>Sponsor — Silver</b></sub>
-</p>
-<!-- SPONSORS:BOTTOM:END -->
 
 ## 🌐 エコシステム
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -29,15 +29,21 @@
 
 ## 💛 스폰서
 
-<!-- SPONSORS:TOP:START -->
-**Launch Partner**
+<!-- SPONSORS:START -->
+### Launch Partner
 
 <p align="center">
   <a href="https://www.atlascloud.ai/"><img src="docs/assets/sponsors/atlas-cloud.png" alt="Atlas Cloud" width="200"></a><br/><sub><b>Launch Partner</b></sub>
 </p>
 
 [Atlas Cloud](https://www.atlascloud.ai/) — A full-modal, OpenAI-compatible AI inference platform. Skill Seekers supports it as a packaging/enhancement target via `--target atlas` with `ATLAS_API_KEY`.
-<!-- SPONSORS:TOP:END -->
+
+### Silver Sponsors
+
+<p align="center">
+  <a href="https://www.rapidproxy.io/?utm_source=skillseekers&utm_medium=sponsor"><img src="docs/assets/sponsors/rapidproxy.png" alt="RapidProxy" width="140"></a><br/><sub><b>Sponsor — Silver</b></sub>
+</p>
+<!-- SPONSORS:END -->
 
 **[스폰서 되기](SPONSORSHIP.md)** · [GitHub Sponsors](https://github.com/sponsors/yusufkaraaslan)
 
@@ -417,14 +423,6 @@ MIT — [LICENSE](LICENSE)를 참고하세요.
 [![MseeP.ai Security Assessment Badge](https://mseep.net/pr/yusufkaraaslan-skill-seekers-badge.png)](https://mseep.ai/app/yusufkaraaslan-skill-seekers)
 
 ---
-
-<!-- SPONSORS:BOTTOM:START -->
-**Silver Sponsors**
-
-<p align="center">
-  <a href="https://www.rapidproxy.io/?utm_source=skillseekers&utm_medium=sponsor"><img src="docs/assets/sponsors/rapidproxy.png" alt="RapidProxy" width="140"></a><br/><sub><b>Sponsor — Silver</b></sub>
-</p>
-<!-- SPONSORS:BOTTOM:END -->
 
 ## 🌐 에코시스템
 

--- a/README.md
+++ b/README.md
@@ -23,15 +23,21 @@ English | [简体中文](README.zh-CN.md) | [日本語](README.ja.md) | [한국�
 
 ## 💛 Sponsors
 
-<!-- SPONSORS:TOP:START -->
-**Launch Partner**
+<!-- SPONSORS:START -->
+### Launch Partner
 
 <p align="center">
   <a href="https://www.atlascloud.ai/"><img src="docs/assets/sponsors/atlas-cloud.png" alt="Atlas Cloud" width="200"></a><br/><sub><b>Launch Partner</b></sub>
 </p>
 
 [Atlas Cloud](https://www.atlascloud.ai/) — A full-modal, OpenAI-compatible AI inference platform. Skill Seekers supports it as a packaging/enhancement target via `--target atlas` with `ATLAS_API_KEY`.
-<!-- SPONSORS:TOP:END -->
+
+### Silver Sponsors
+
+<p align="center">
+  <a href="https://www.rapidproxy.io/?utm_source=skillseekers&utm_medium=sponsor"><img src="docs/assets/sponsors/rapidproxy.png" alt="RapidProxy" width="140"></a><br/><sub><b>Sponsor — Silver</b></sub>
+</p>
+<!-- SPONSORS:END -->
 
 **[Become a sponsor](SPONSORSHIP.md)** · [GitHub Sponsors](https://github.com/sponsors/yusufkaraaslan)
 
@@ -411,14 +417,6 @@ MIT — see [LICENSE](LICENSE).
 [![MseeP.ai Security Assessment Badge](https://mseep.net/pr/yusufkaraaslan-skill-seekers-badge.png)](https://mseep.ai/app/yusufkaraaslan-skill-seekers)
 
 ---
-
-<!-- SPONSORS:BOTTOM:START -->
-**Silver Sponsors**
-
-<p align="center">
-  <a href="https://www.rapidproxy.io/?utm_source=skillseekers&utm_medium=sponsor"><img src="docs/assets/sponsors/rapidproxy.png" alt="RapidProxy" width="140"></a><br/><sub><b>Sponsor — Silver</b></sub>
-</p>
-<!-- SPONSORS:BOTTOM:END -->
 
 ## 🌐 Ecosystem
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -29,15 +29,21 @@
 
 ## 💛 Patrocinadores
 
-<!-- SPONSORS:TOP:START -->
-**Launch Partner**
+<!-- SPONSORS:START -->
+### Launch Partner
 
 <p align="center">
   <a href="https://www.atlascloud.ai/"><img src="docs/assets/sponsors/atlas-cloud.png" alt="Atlas Cloud" width="200"></a><br/><sub><b>Launch Partner</b></sub>
 </p>
 
 [Atlas Cloud](https://www.atlascloud.ai/) — A full-modal, OpenAI-compatible AI inference platform. Skill Seekers supports it as a packaging/enhancement target via `--target atlas` with `ATLAS_API_KEY`.
-<!-- SPONSORS:TOP:END -->
+
+### Silver Sponsors
+
+<p align="center">
+  <a href="https://www.rapidproxy.io/?utm_source=skillseekers&utm_medium=sponsor"><img src="docs/assets/sponsors/rapidproxy.png" alt="RapidProxy" width="140"></a><br/><sub><b>Sponsor — Silver</b></sub>
+</p>
+<!-- SPONSORS:END -->
 
 **[Torne-se um patrocinador](SPONSORSHIP.md)** · [GitHub Sponsors](https://github.com/sponsors/yusufkaraaslan)
 
@@ -417,14 +423,6 @@ MIT — veja [LICENSE](LICENSE).
 [![MseeP.ai Security Assessment Badge](https://mseep.net/pr/yusufkaraaslan-skill-seekers-badge.png)](https://mseep.ai/app/yusufkaraaslan-skill-seekers)
 
 ---
-
-<!-- SPONSORS:BOTTOM:START -->
-**Silver Sponsors**
-
-<p align="center">
-  <a href="https://www.rapidproxy.io/?utm_source=skillseekers&utm_medium=sponsor"><img src="docs/assets/sponsors/rapidproxy.png" alt="RapidProxy" width="140"></a><br/><sub><b>Sponsor — Silver</b></sub>
-</p>
-<!-- SPONSORS:BOTTOM:END -->
 
 ## 🌐 Ecossistema
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -27,15 +27,21 @@
 
 ## 💛 Спонсоры
 
-<!-- SPONSORS:TOP:START -->
-**Launch Partner**
+<!-- SPONSORS:START -->
+### Launch Partner
 
 <p align="center">
   <a href="https://www.atlascloud.ai/"><img src="docs/assets/sponsors/atlas-cloud.png" alt="Atlas Cloud" width="200"></a><br/><sub><b>Launch Partner</b></sub>
 </p>
 
 [Atlas Cloud](https://www.atlascloud.ai/) — A full-modal, OpenAI-compatible AI inference platform. Skill Seekers supports it as a packaging/enhancement target via `--target atlas` with `ATLAS_API_KEY`.
-<!-- SPONSORS:TOP:END -->
+
+### Silver Sponsors
+
+<p align="center">
+  <a href="https://www.rapidproxy.io/?utm_source=skillseekers&utm_medium=sponsor"><img src="docs/assets/sponsors/rapidproxy.png" alt="RapidProxy" width="140"></a><br/><sub><b>Sponsor — Silver</b></sub>
+</p>
+<!-- SPONSORS:END -->
 
 **[Стать спонсором](SPONSORSHIP.md)** · [GitHub Sponsors](https://github.com/sponsors/yusufkaraaslan)
 
@@ -415,14 +421,6 @@ MIT — см. [LICENSE](LICENSE).
 [![MseeP.ai Security Assessment Badge](https://mseep.net/pr/yusufkaraaslan-skill-seekers-badge.png)](https://mseep.ai/app/yusufkaraaslan-skill-seekers)
 
 ---
-
-<!-- SPONSORS:BOTTOM:START -->
-**Silver Sponsors**
-
-<p align="center">
-  <a href="https://www.rapidproxy.io/?utm_source=skillseekers&utm_medium=sponsor"><img src="docs/assets/sponsors/rapidproxy.png" alt="RapidProxy" width="140"></a><br/><sub><b>Sponsor — Silver</b></sub>
-</p>
-<!-- SPONSORS:BOTTOM:END -->
 
 ## 🌐 Экосистема
 

--- a/README.tr.md
+++ b/README.tr.md
@@ -29,15 +29,21 @@
 
 ## 💛 Sponsorlar
 
-<!-- SPONSORS:TOP:START -->
-**Launch Partner**
+<!-- SPONSORS:START -->
+### Launch Partner
 
 <p align="center">
   <a href="https://www.atlascloud.ai/"><img src="docs/assets/sponsors/atlas-cloud.png" alt="Atlas Cloud" width="200"></a><br/><sub><b>Launch Partner</b></sub>
 </p>
 
 [Atlas Cloud](https://www.atlascloud.ai/) — A full-modal, OpenAI-compatible AI inference platform. Skill Seekers supports it as a packaging/enhancement target via `--target atlas` with `ATLAS_API_KEY`.
-<!-- SPONSORS:TOP:END -->
+
+### Silver Sponsors
+
+<p align="center">
+  <a href="https://www.rapidproxy.io/?utm_source=skillseekers&utm_medium=sponsor"><img src="docs/assets/sponsors/rapidproxy.png" alt="RapidProxy" width="140"></a><br/><sub><b>Sponsor — Silver</b></sub>
+</p>
+<!-- SPONSORS:END -->
 
 **[Sponsor ol](SPONSORSHIP.md)** · [GitHub Sponsors](https://github.com/sponsors/yusufkaraaslan)
 
@@ -417,14 +423,6 @@ MIT — bkz. [LICENSE](LICENSE).
 [![MseeP.ai Security Assessment Badge](https://mseep.net/pr/yusufkaraaslan-skill-seekers-badge.png)](https://mseep.ai/app/yusufkaraaslan-skill-seekers)
 
 ---
-
-<!-- SPONSORS:BOTTOM:START -->
-**Silver Sponsors**
-
-<p align="center">
-  <a href="https://www.rapidproxy.io/?utm_source=skillseekers&utm_medium=sponsor"><img src="docs/assets/sponsors/rapidproxy.png" alt="RapidProxy" width="140"></a><br/><sub><b>Sponsor — Silver</b></sub>
-</p>
-<!-- SPONSORS:BOTTOM:END -->
 
 ## 🌐 Ekosistem
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -29,15 +29,21 @@
 
 ## 💛 赞助商
 
-<!-- SPONSORS:TOP:START -->
-**Launch Partner**
+<!-- SPONSORS:START -->
+### Launch Partner
 
 <p align="center">
   <a href="https://www.atlascloud.ai/"><img src="docs/assets/sponsors/atlas-cloud.png" alt="Atlas Cloud" width="200"></a><br/><sub><b>Launch Partner</b></sub>
 </p>
 
 [Atlas Cloud](https://www.atlascloud.ai/) — A full-modal, OpenAI-compatible AI inference platform. Skill Seekers supports it as a packaging/enhancement target via `--target atlas` with `ATLAS_API_KEY`.
-<!-- SPONSORS:TOP:END -->
+
+### Silver Sponsors
+
+<p align="center">
+  <a href="https://www.rapidproxy.io/?utm_source=skillseekers&utm_medium=sponsor"><img src="docs/assets/sponsors/rapidproxy.png" alt="RapidProxy" width="140"></a><br/><sub><b>Sponsor — Silver</b></sub>
+</p>
+<!-- SPONSORS:END -->
 
 **[成为赞助商](SPONSORSHIP.md)** · [GitHub Sponsors](https://github.com/sponsors/yusufkaraaslan)
 
@@ -417,14 +423,6 @@ MIT —— 详见 [LICENSE](LICENSE)。
 [![MseeP.ai Security Assessment Badge](https://mseep.net/pr/yusufkaraaslan-skill-seekers-badge.png)](https://mseep.ai/app/yusufkaraaslan-skill-seekers)
 
 ---
-
-<!-- SPONSORS:BOTTOM:START -->
-**Silver Sponsors**
-
-<p align="center">
-  <a href="https://www.rapidproxy.io/?utm_source=skillseekers&utm_medium=sponsor"><img src="docs/assets/sponsors/rapidproxy.png" alt="RapidProxy" width="140"></a><br/><sub><b>Sponsor — Silver</b></sub>
-</p>
-<!-- SPONSORS:BOTTOM:END -->
 
 ## 🌐 生态项目
 

--- a/SPONSORSHIP.md
+++ b/SPONSORSHIP.md
@@ -11,10 +11,10 @@ All sponsorships run through [GitHub Sponsors](https://github.com/sponsors/yusuf
 | Tier | Price | What you get |
 |------|-------|--------------|
 | **Supporter** | $10/mo | Name in [SPONSORS.md](SPONSORS.md) |
-| **Bronze** | $50/mo | Small logo in the README bottom sponsor grid |
-| **Silver** | $150/mo | Medium logo in the README sponsor grid + logo on the [SkillSeekersWeb.com](https://skillseekersweb.com/) sponsors page |
-| **Gold** | $400/mo | Large logo near the top of the README sponsor section + website placement + mention in release notes |
-| **Platinum** | $1,000/mo | Everything in Gold + a short "Sponsored" blurb (1–2 sentences, your copy, my approval) in the README + priority issue triage |
+| **Bronze** | $50/mo | Small logo in the README sponsor section |
+| **Silver** | $150/mo | Medium logo in the README sponsor section, above Bronze + logo on the [SkillSeekersWeb.com](https://skillseekersweb.com/) sponsors page |
+| **Gold** | $400/mo | Large logo listed above Silver and Bronze in the README sponsor section + website placement + mention in release notes |
+| **Platinum** | $1,000/mo | Everything in Gold, listed first + a short "Sponsored" blurb (1–2 sentences, your copy, my approval) in the README + priority issue triage |
 
 One-time options are available on the Sponsors page. Custom arrangements (integrations, co-marketing, content) are quoted case by case.
 
@@ -65,4 +65,4 @@ python scripts/render_sponsors.py --write
 python scripts/render_sponsors.py --check
 ```
 
-Never edit the content between the `<!-- SPONSORS:TOP:START -->` / `<!-- SPONSORS:BOTTOM:START -->` markers by hand — it is overwritten on the next render.
+Never edit the content between the `<!-- SPONSORS:START -->` / `<!-- SPONSORS:END -->` markers by hand — it is overwritten on the next render.

--- a/scripts/render_sponsors.py
+++ b/scripts/render_sponsors.py
@@ -7,8 +7,12 @@ so adding a sponsor is a one-file edit instead of 13 hand edits.
 
 Markers (already present in each README)::
 
-    <!-- SPONSORS:TOP:START -->    ... generated ...  <!-- SPONSORS:TOP:END -->
-    <!-- SPONSORS:BOTTOM:START --> ... generated ...  <!-- SPONSORS:BOTTOM:END -->
+    <!-- SPONSORS:START -->  ... generated ...  <!-- SPONSORS:END -->
+
+All tiers render in that single block as ``###`` subheadings, ordered from the
+highest tier down - the layout used by FastAPI and every comparable project.
+Tier value is expressed by order and logo size, not by scattering placements
+across the page.
 
 Only logos/links are generated; the surrounding prose stays hand-maintained so the
 translated READMEs keep their own wording.
@@ -32,9 +36,8 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 SPONSORS_FILE = REPO_ROOT / "sponsors.json"
 SPONSORS_MD = REPO_ROOT / "SPONSORS.md"
 
-# Tiers rendered near the top of the README vs in the bottom grid.
-TOP_TIERS = ("partners", "platinum", "gold")
-BOTTOM_TIERS = ("silver", "bronze")
+# Tier render order, highest first. Order and logo size carry the hierarchy.
+TIERS = ("partners", "platinum", "gold", "silver", "bronze")
 
 # Logo width (px) per tier - Gold "large", Silver "medium", Bronze "small".
 TIER_WIDTH = {
@@ -104,7 +107,7 @@ def _assert_clean_url(name: str, url: str) -> None:
 def load_sponsors() -> dict:
     """Load and validate sponsors.json."""
     data = json.loads(SPONSORS_FILE.read_text(encoding="utf-8"))
-    for tier in (*TOP_TIERS, *BOTTOM_TIERS):
+    for tier in TIERS:
         for entry in data.get(tier, []):
             _assert_clean_url(entry["name"], entry["url"])
             for key in ("logo", "logo_svg"):
@@ -130,14 +133,14 @@ def _logo_html(entry: dict, tier: str) -> str:
     )
 
 
-def render_top(data: dict) -> str:
-    """Large placements: launch partners, Platinum and Gold."""
+def render_sponsors(data: dict) -> str:
+    """Render every tier into one block, highest tier first."""
     out: list[str] = []
-    for tier in TOP_TIERS:
+    for tier in TIERS:
         entries = data.get(tier, [])
         if not entries:
             continue
-        out.append(f"**{TIER_LABEL[tier]}**\n")
+        out.append(f"### {TIER_LABEL[tier]}\n")
         out.append('<p align="center">')
         out.extend(_logo_html(e, tier) for e in entries)
         out.append("</p>\n")
@@ -148,29 +151,15 @@ def render_top(data: dict) -> str:
     return "\n".join(out).rstrip() if out else ""
 
 
-def render_bottom(data: dict) -> str:
-    """Grid placements: Silver (medium) and Bronze (small)."""
-    out: list[str] = []
-    for tier in BOTTOM_TIERS:
-        entries = data.get(tier, [])
-        if not entries:
-            continue
-        out.append(f"**{TIER_LABEL[tier]}**\n")
-        out.append('<p align="center">')
-        out.extend(_logo_html(e, tier) for e in entries)
-        out.append("</p>\n")
-    return "\n".join(out).rstrip() if out else ""
-
-
 def _replace_block(text: str, marker: str, body: str) -> str:
     """Replace everything between the ``START``/``END`` markers for ``marker``."""
     pattern = re.compile(
-        rf"<!-- SPONSORS:{marker}:START -->.*?<!-- SPONSORS:{marker}:END -->",
+        rf"<!-- {marker}:START -->.*?<!-- {marker}:END -->",
         re.DOTALL,
     )
     if not pattern.search(text):
         return text
-    rendered = f"<!-- SPONSORS:{marker}:START -->\n{body}\n<!-- SPONSORS:{marker}:END -->"
+    rendered = f"<!-- {marker}:START -->\n{body}\n<!-- {marker}:END -->"
     # lambda avoids backslash/group-reference interpretation in the replacement
     return pattern.sub(lambda _m: rendered, text)
 
@@ -190,7 +179,7 @@ def render_sponsors_md(data: dict) -> str:
         "",
     ]
     any_listed = False
-    for tier in (*TOP_TIERS, *BOTTOM_TIERS):
+    for tier in TIERS:
         entries = data.get(tier, [])
         if not entries:
             continue
@@ -229,13 +218,12 @@ def main(argv: list[str] | None = None) -> int:
         print(f"error: {exc}", file=sys.stderr)
         return 1
 
-    top, bottom = render_top(data), render_bottom(data)
+    block = render_sponsors(data)
     drifted: list[str] = []
 
     for readme in sorted(REPO_ROOT.glob("README*.md")):
         original = readme.read_text(encoding="utf-8")
-        updated = _replace_block(original, "TOP", top)
-        updated = _replace_block(updated, "BOTTOM", bottom)
+        updated = _replace_block(original, "SPONSORS", block)
         if updated != original:
             drifted.append(readme.name)
             if args.write:


### PR DESCRIPTION
You didn't like the two-zone sponsor layout, so I checked what comparable projects actually do.

## Research

| Project | Stars | Sponsors at | Sections |
|---|---|---|---|
| **FastAPI** (Python) | ~80K | **8%** — near top | **1** |
| Vite | ~68K | 92% — bottom | **1** |
| TypeORM | ~34K | 88% — bottom | **1** |
| Rollup | ~25K | 85% — bottom | **1** |

**None of them splits sponsors across the page.** All use one `## Sponsors` section with tiers as `###` subheadings — hierarchy from order + logo size, which is how FastAPI prices Gold above Silver too.

## Change

```
BEFORE                              AFTER
## 💛 Sponsors                      ## 💛 Sponsors
  [Atlas Cloud]                       ### Launch Partner
                                        [Atlas Cloud 200px]
...400 lines...                       ### Silver Sponsors
                                        [RapidProxy 140px]
   [RapidProxy]  ← orphaned
## 🌐 Ecosystem                     (nothing near Ecosystem)
```

- Generator renders all tiers into one block, highest first
- Markers collapse: `SPONSORS:TOP`/`SPONSORS:BOTTOM` → one `SPONSORS:START/END`
- All 12 READMEs migrated
- Tier table reworded from "top vs bottom" to **order and size** — describing what the layout actually delivers

## Verified

All 12 READMEs have exactly one marker pair and the Silver subheading; zero `TOP`/`BOTTOM` remnants; `--check` clean; ruff clean; UTM/affiliate guard still behaves correctly after the refactor.

Supersedes #447 (closed).

**Side note:** FastAPI's sponsor links are full of `utm_source`/`ref` params — independent confirmation that the link policy loosened in #445 matches ecosystem norms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)