### PR TITLE
chore: open the 3.10.0 dev cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_Development version: 3.10.0.dev0_
+
 ### Added
 - **RapidProxy joins as our first Silver sponsor** — logo in the README sponsor grid across all 12 languages and on the website sponsors page, captioned "Sponsor — Silver" per rule 2. Sponsor entries gain an optional `since` field and a `logo_svg` vector companion.
 - **Readability metrics in the quality checker** (#228, PR #441 by @bferanmi806-sketch) — `skill-seekers quality` now reports Flesch Reading Ease, Flesch-Kincaid Grade Level, average sentence length, and average paragraph length for SKILL.md prose, plus aggregated notes for over-long sentences and paragraphs. YAML frontmatter, fenced code, and inline code are excluded, and no new dependency is added. Scores use English-language formulas and may be inaccurate for other languages.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "skill-seekers"
-version = "3.9.1"
+version = "3.10.0.dev0"
 description = "Convert documentation websites, GitHub repositories, and PDFs into Claude AI skills. International support with Chinese (简体中文) documentation."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/skill_seekers/_version.py
+++ b/src/skill_seekers/_version.py
@@ -28,7 +28,7 @@ def get_version() -> str:
     """
     if tomllib is None:
         # Fallback if TOML library not available
-        return "3.9.1"  # Hardcoded fallback
+        return "3.10.0.dev0"  # Hardcoded fallback
 
     try:
         # Get path to pyproject.toml (3 levels up from this file)
@@ -37,7 +37,7 @@ def get_version() -> str:
 
         if not pyproject_path.exists():
             # Fallback for installed package
-            return "3.9.1"  # Hardcoded fallback
+            return "3.10.0.dev0"  # Hardcoded fallback
 
         with open(pyproject_path, "rb") as f:
             pyproject_data = tomllib.load(f)
@@ -46,7 +46,7 @@ def get_version() -> str:
 
     except Exception:
         # Fallback if anything goes wrong
-        return "3.9.1"  # Hardcoded fallback
+        return "3.10.0.dev0"  # Hardcoded fallback
 
 
 __version__ = get_version()


### PR DESCRIPTION
`development` still carried the released **3.9.1**, so in-progress builds were stamped as the shipped version.

## Why 3.10.0, not 3.9.2

`quality_checker.py` gained **~147 lines of new user-facing functionality** — the readability metrics from #441. That's backwards-compatible new behaviour, which is a **MINOR** bump under semver.

Everything else since v3.9.1 (link policy, RapidProxy, the single-section refactor) is docs/tooling, but the readability feature alone justifies the minor.

## Changes

- `pyproject.toml` + `_version.py` fallbacks: `3.9.1` → `3.10.0.dev0`
- CHANGELOG notes the development version under `[Unreleased]`

`plugin.json` stays at the released 3.9.1 and gets bumped at release time, matching the previous cycle.

Verified: pyproject and `skill_seekers.__version__` agree at `3.10.0.dev0`, and the version-tracking tests (38 passed) still pass — they read the source of truth rather than a literal, so a bump can't break them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)