### PR TITLE
fix(openapi): generate grammatical skill descriptions

### DIFF
--- a/src/skill_seekers/cli/openapi_scraper.py
+++ b/src/skill_seekers/cli/openapi_scraper.py
@@ -69,24 +69,32 @@ def infer_description_from_spec(info: dict | None = None, name: str = "") -> str
         name: Skill name for fallback
 
     Returns:
-        Description string suitable for "Use when..." format
+        Concise API summary with a grammatical "Use when..." trigger.
     """
-    if info:
-        # Try the spec description first
-        desc = info.get("description", "")
-        if desc and len(desc) > 20:
-            # Take first sentence or first 150 chars
-            first_sentence = desc.split(". ")[0]
-            if len(first_sentence) > 150:
-                first_sentence = first_sentence[:147] + "..."
-            return f"Use when working with {first_sentence.lower()}"
+    title = str((info or {}).get("title") or name).strip().rstrip(".")
+    if title:
+        api_name = (
+            title
+            if title.casefold() == "api" or title.casefold().endswith(" api")
+            else f"{title} API"
+        )
+        trigger = f"Use when working with the {api_name}."
+    else:
+        trigger = "Use when working with this API."
 
-        # Fall back to title
-        title = info.get("title", "")
-        if title and len(title) > 5:
-            return f"Use when working with the {title} API"
+    desc = str((info or {}).get("description") or "")
+    normalized = " ".join(desc.split())
+    if len(normalized) <= 20:
+        return trigger
 
-    return f"Use when working with the {name} API" if name else "Use when working with this API"
+    first_sentence = re.split(r"(?<=[.!?])\s+", normalized, maxsplit=1)[0]
+    if len(first_sentence) > 150:
+        first_sentence = first_sentence[:147].rstrip() + "..."
+    if first_sentence.casefold().startswith("use when "):
+        return first_sentence
+    if not first_sentence.endswith((".", "!", "?")):
+        first_sentence += "."
+    return f"{first_sentence} {trigger}"
 
 
 class OpenAPIToSkillConverter(SkillConverter):

--- a/tests/test_openapi_description.py
+++ b/tests/test_openapi_description.py
@@ -1,0 +1,82 @@
+"""Regression tests for OpenAPI skill trigger descriptions."""
+
+from skill_seekers.cli.openapi_scraper import OpenAPIToSkillConverter, infer_description_from_spec
+
+
+def test_declarative_xquik_summary_stays_grammatical() -> None:
+    """Keep a complete API summary separate from its trigger sentence."""
+    info = {
+        "title": "Xquik API",
+        "description": ("Xquik is an independent third-party service. Not affiliated with X Corp."),
+    }
+
+    assert infer_description_from_spec(info) == (
+        "Xquik is an independent third-party service. Use when working with the Xquik API."
+    )
+
+
+def test_existing_use_when_description_is_not_prefixed_twice() -> None:
+    """Preserve source metadata that already supplies a trigger."""
+    info = {
+        "title": "Example API",
+        "description": "Use when searching public posts by keyword.",
+    }
+
+    assert infer_description_from_spec(info) == "Use when searching public posts by keyword."
+
+
+def test_api_suffix_is_not_duplicated() -> None:
+    """Avoid output such as 'Example API API' in title fallbacks."""
+    assert infer_description_from_spec({"title": "Example API"}) == (
+        "Use when working with the Example API."
+    )
+
+
+def test_description_uses_only_first_sentence() -> None:
+    """Keep generated frontmatter concise when the source has several sentences."""
+    info = {
+        "title": "Example",
+        "description": "Search public records! This sentence should not appear.",
+    }
+
+    assert infer_description_from_spec(info) == (
+        "Search public records! Use when working with the Example API."
+    )
+
+
+def test_generated_xquik_skill_has_valid_frontmatter(tmp_path) -> None:
+    """Protect the full OpenAPI extraction and skill-generation path."""
+    spec_path = tmp_path / "xquik-openapi.yaml"
+    spec_path.write_text(
+        """\
+openapi: 3.1.0
+info:
+  title: Xquik API
+  version: "1.0"
+  description: Xquik is an independent third-party service. Not affiliated with X Corp.
+paths:
+  /x/tweets/search:
+    get:
+      summary: Search public posts
+      responses:
+        "200":
+          description: Search results
+""",
+        encoding="utf-8",
+    )
+    output_dir = tmp_path / "xquik-api"
+    converter = OpenAPIToSkillConverter(
+        {
+            "name": "xquik-api",
+            "spec_path": str(spec_path),
+            "output_dir": str(output_dir),
+        }
+    )
+
+    assert converter.run() == 0
+    skill = (output_dir / "SKILL.md").read_text(encoding="utf-8")
+    assert (
+        "description: Xquik is an independent third-party service. "
+        "Use when working with the Xquik API."
+    ) in skill
+    assert "Use when working with xquik is" not in skill


### PR DESCRIPTION
# Pull Request

## 📋 Description

OpenAPI descriptions are often complete declarative sentences. The converter previously placed each sentence after `Use when working with`, producing invalid triggers such as:

```yaml
description: Use when working with xquik is an independent third-party service
```

This change:

- Keeps a declarative summary as its own sentence.
- Adds a separate title-based `Use when` trigger.
- Preserves descriptions that already start with `Use when`.
- Avoids title fallbacks such as `Example API API`.
- Splits the first sentence on `.`, `!`, or `?` and keeps the existing 150-character bound.
- Tests the complete extraction and skill-generation path with a minimal Xquik OpenAPI 3.1 contract.

The full public Xquik contract now generates:

```yaml
description: Xquik is an independent third-party service. Use when working with the Xquik API.
```

## 🔗 Related Issues

Closes #460

## 🎯 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement
- [x] 🧪 Test update

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Documentation updated (the function contract changed; no CLI or user workflow changed)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing relevant unit tests pass locally
- [x] No dependent change is required

## 🧪 Testing

**Test Configuration:**

- Python version: 3.11.15
- OS: macOS
- Dependencies installed: editable core package, pytest, pytest-asyncio, pytest-xdist, Ruff 0.15.8, MyPy

Commands and results:

- `pytest tests/test_openapi_description.py -q`: 5 passed
- `pytest tests/test_openapi_description.py tests/test_data_file_dir_regressions.py -q`: 9 passed, 2 skipped
- Fast parallel suite: 3,824 passed, 149 skipped
- `ruff check src/ tests/`: passed
- `ruff format --check src/ tests/`: 443 files already formatted
- `mypy src/skill_seekers/cli/openapi_scraper.py`: no issues
- Full Xquik OpenAPI 3.1 generation: 128 endpoints and 104 schemas generated successfully

One unrelated local test, `TestVenv::test_create_venv_in_tempdir`, aborts inside the nested Python `ensurepip` process. It fails unchanged when run alone. The fast-suite result above excludes that environment-specific test.

## 📸 Screenshots (if applicable)

Not applicable.

## 📝 Additional Notes

This does not add a preset to the core repository. Maintainer feedback on #413 placed presets in `skill-seekers-configs`; the existing Xquik registry PR remains there. This pull request repairs the core OpenAPI generation path instead.
