### PR TITLE
fix(enhance): accept --enhance-level on skill-seekers-enhance

### DIFF
--- a/src/skill_seekers/cli/arguments/enhance.py
+++ b/src/skill_seekers/cli/arguments/enhance.py
@@ -64,6 +64,23 @@ ENHANCE_ARGUMENTS: dict[str, dict[str, Any]] = {
             "help": "Preview what would be enhanced without calling AI",
         },
     },
+    # Accepted for parity with the scrapers, which forward this flag verbatim
+    # (doc_scraper.py, video_scraper.py). This command only enhances SKILL.md,
+    # so any level above 0 behaves identically; 0 skips enhancement entirely.
+    "enhance_level": {
+        "flags": ("--enhance-level",),
+        "kwargs": {
+            "type": int,
+            "choices": [0, 1, 2, 3],
+            "default": 1,
+            "help": (
+                "AI enhancement level: 0=skip enhancement, 1-3=enhance SKILL.md "
+                "(this command only enhances SKILL.md, so 1, 2 and 3 are equivalent here; "
+                "the higher levels are honoured by the scrapers that generate the other files)"
+            ),
+            "metavar": "LEVEL",
+        },
+    },
     # Agent options — LOCAL mode only
     "agent": {
         "flags": ("--agent",),

--- a/src/skill_seekers/cli/enhance_command.py
+++ b/src/skill_seekers/cli/enhance_command.py
@@ -259,6 +259,12 @@ Examples:
         print(f"❌ Error: Not a directory: {skill_dir}")
         return 1
 
+    # Level 0 explicitly disables enhancement. The scrapers forward this flag
+    # verbatim, so honour it here rather than making callers filter it out.
+    if getattr(args, "enhance_level", 1) == 0:
+        print("⏭  Enhancement skipped (--enhance-level 0)")
+        return 0
+
     mode, target = _pick_mode(args)
 
     # Dry run — just show what would happen

--- a/tests/test_enhance_command.py
+++ b/tests/test_enhance_command.py
@@ -549,3 +549,78 @@ class TestConfigManagerDefaultAgent:
         # Re-instantiate to verify persistence
         mgr2 = ConfigManager()
         assert mgr2.get_default_agent() == "openai"
+
+
+# ---------------------------------------------------------------------------
+# --enhance-level forwarding
+#
+# doc_scraper.py and video_scraper.py shell out to `skill-seekers-enhance` and
+# forward --enhance-level verbatim. The flag was never declared on this command,
+# so every scraper-triggered enhancement died with
+# "unrecognized arguments: --enhance-level" and the skill shipped unenhanced.
+# ---------------------------------------------------------------------------
+
+
+class TestEnhanceLevelFlag:
+    def test_flag_is_declared(self):
+        """--enhance-level must parse; the scrapers always send it."""
+        import argparse
+
+        from skill_seekers.cli.arguments.enhance import add_enhance_arguments
+
+        parser = argparse.ArgumentParser()
+        add_enhance_arguments(parser)
+        args = parser.parse_args(["output/react", "--enhance-level", "2"])
+        assert args.enhance_level == 2
+
+    def test_defaults_to_enhancing(self):
+        """Omitting the flag must not disable enhancement."""
+        import argparse
+
+        from skill_seekers.cli.arguments.enhance import add_enhance_arguments
+
+        parser = argparse.ArgumentParser()
+        add_enhance_arguments(parser)
+        args = parser.parse_args(["output/react"])
+        assert args.enhance_level > 0
+
+    @pytest.mark.parametrize("level", ["0", "1", "2", "3"])
+    def test_all_documented_levels_accepted(self, level):
+        import argparse
+
+        from skill_seekers.cli.arguments.enhance import add_enhance_arguments
+
+        parser = argparse.ArgumentParser()
+        add_enhance_arguments(parser)
+        args = parser.parse_args(["output/react", "--enhance-level", level])
+        assert args.enhance_level == int(level)
+
+    def test_level_zero_skips_without_calling_ai(self, tmp_path, monkeypatch):
+        """Level 0 means disabled — it must not reach mode selection."""
+        import skill_seekers.cli.enhance_command as ec
+
+        skill_dir = _make_skill_dir(tmp_path)
+
+        def _boom(*_args, **_kwargs):
+            raise AssertionError("_pick_mode called despite --enhance-level 0")
+
+        monkeypatch.setattr(ec, "_pick_mode", _boom)
+
+        sys_argv_backup = sys.argv.copy()
+        sys.argv = ["enhance_command.py", str(skill_dir), "--enhance-level", "0"]
+        try:
+            assert ec.main() == 0
+        finally:
+            sys.argv = sys_argv_backup
+
+    def test_nonzero_level_still_reaches_dry_run(self, tmp_path):
+        """Levels 1-3 must not short-circuit; this command only writes SKILL.md."""
+        skill_dir = _make_skill_dir(tmp_path)
+        sys_argv_backup = sys.argv.copy()
+        sys.argv = ["enhance_command.py", str(skill_dir), "--enhance-level", "3", "--dry-run"]
+        try:
+            from skill_seekers.cli.enhance_command import main
+
+            assert main() == 0
+        finally:
+            sys.argv = sys_argv_backup


### PR DESCRIPTION
## The bug

`skill-seekers-enhance` never accepted `--enhance-level`, but both scrapers forward it verbatim:

- `src/skill_seekers/cli/doc_scraper.py:2379`
- `src/skill_seekers/cli/video_scraper.py:1218`

```python
enhance_cmd = ["skill-seekers-enhance", f"output/{config['name']}/"]
enhance_cmd.extend(["--enhance-level", str(args.enhance_level)])
```

So every scraper-triggered enhancement dies at argparse:

```
$ skill-seekers create https://developer.clickup.com/reference
...
skill-seekers-enhance: error: unrecognized arguments: --enhance-level 2
⚠ Enhancement failed, but skill was still built
```

The failure is quiet: the skill still ships, just **unenhanced**. `skill-seekers create <url>` silently produces a raw SKILL.md rather than the AI-enhanced one the docs describe, and the only signal is a warning line most users read as "one optional step was skipped."

Reproduced on `development` against the ClickUp API docs (172 endpoints scraped). Running `skill-seekers-enhance output/clickup-api/` by hand — without the flag — worked fine, which is what pinned it to argument parsing rather than the enhancement path.

The same string is also printed as the manual-retry suggestion in `doc_scraper.py`'s `FileNotFoundError` fallback, so a user who copy-pastes it hits the identical error.

## The fix

Declare the flag in `src/skill_seekers/cli/arguments/enhance.py`, whose docstring already designates it as the place enhance arguments are defined:

> This module defines ALL arguments for the enhance command in ONE place.

Fixing the receiver rather than the two callers fixes both call sites, the retry hint, and any future caller at once — and keeps `enhance_command.py`, `enhance_skill_local.py` and `parsers/enhance_parser.py` in sync automatically, since all three build their parser from this dict.

Behaviour:
- **`--enhance-level 0`** short-circuits in `enhance_command.main()` before mode selection, prints `⏭  Enhancement skipped (--enhance-level 0)`, and returns 0 without touching an API key or spawning a local agent.
- **`1`–`3`** are equivalent for this command, which only enhances `SKILL.md`; the higher levels are honoured by the scrapers that generate the other artefacts. The help text says so rather than implying a difference that isn't there.
- Default is `1`, matching the scrapers' own default, so direct invocations are unchanged.

## Tests

Adds `TestEnhanceLevelFlag` to `tests/test_enhance_command.py` — 8 tests covering flag declaration, the default, all four documented levels (parametrized), the level-0 short-circuit (monkeypatching `_pick_mode` to raise, proving no AI path is reached), and non-zero pass-through to dry-run.

Bracketed: all 8 fail on `development` without the fix, all 8 pass with it. Full `test_enhance_command.py` — 49 tests — passes. `ruff check` and `ruff format --check` are clean on all three files.

Full suite: 3,928 passed, 276 skipped. The 12 failures on my machine reproduce unchanged on a clean `development` checkout (verified by stashing this branch's three files), so none are introduced here.
